### PR TITLE
feat: ナビゲーションにServicesを追加

### DIFF
--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -1,6 +1,7 @@
 import type { NavItem } from "@/types";
 
 export const navItems: NavItem[] = [
+  { label: "Services", href: "/services" },
   { label: "About", href: "/about" },
   { label: "Portfolio", href: "/portfolio" },
   { label: "Skills", href: "/skills" },

--- a/tests/data/navigation.test.ts
+++ b/tests/data/navigation.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { navItems } from "@/data/navigation";
+
+describe("navigation データ", () => {
+  it("Servicesが先頭に含まれていること", () => {
+    expect(navItems[0]).toEqual({
+      label: "Services",
+      href: "/services",
+    });
+  });
+
+  it("すべてのナビ項目にlabelとhrefが存在すること", () => {
+    for (const item of navItems) {
+      expect(item.label).toBeTruthy();
+      expect(item.href).toMatch(/^\//);
+    }
+  });
+
+  it("5つのナビ項目が定義されていること", () => {
+    expect(navItems).toHaveLength(5);
+  });
+});


### PR DESCRIPTION
## Summary
- ナビゲーションバーの先頭にServicesリンクを追加
- ナビゲーションデータのユニットテスト追加

Closes #3

## Test plan
- [x] `npx vitest run tests/data/navigation.test.ts` — 3テスト全通過
- [ ] ナビゲーションバーにServicesが表示されること
- [ ] モバイルメニューにも反映されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)