### PR TITLE
feat: トップページServicesセクションのリンク追加

### DIFF
--- a/src/components/sections/Services.astro
+++ b/src/components/sections/Services.astro
@@ -3,6 +3,8 @@ import { services } from "@/data";
 import SectionHeader from "@/components/ui/SectionHeader.astro";
 
 const iconSvgs: Record<string, string> = {
+  wrench:
+    '<svg class="w-6 h-6 text-teal-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>',
   code: '<svg class="w-6 h-6 text-teal-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>',
   bot: '<svg class="w-6 h-6 text-teal-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/><path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/></svg>',
   "graduation-cap":
@@ -17,10 +19,11 @@ const iconSvgs: Record<string, string> = {
       subtitle="Webアプリ開発からAI導入支援、セミナー開催まで。ビジネスの成長をテクノロジーで支援します。"
     />
 
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
       {services.map((service, index) => (
-        <div
-          class={`bg-white/80 ring-1 ring-gray-950/5 shadow-sm rounded-3xl p-6 transition-all duration-300 group animate-on-scroll stagger-${index + 1}`}
+        <a
+          href={`/services#${service.id}`}
+          class={`bg-white/80 ring-1 ring-gray-950/5 shadow-sm rounded-3xl p-6 transition-all duration-300 group animate-on-scroll stagger-${index + 1} hover:ring-teal-500/20 hover:shadow-md`}
         >
           <div class="w-12 h-12 rounded-xl bg-teal-50 flex items-center justify-center mb-5 group-hover:bg-teal-100 transition-colors">
             <Fragment set:html={iconSvgs[service.icon] || ""} />
@@ -28,10 +31,16 @@ const iconSvgs: Record<string, string> = {
           <h3 class="text-lg font-semibold text-foreground mb-3">
             {service.title}
           </h3>
-          <p class="text-sm text-muted-foreground leading-relaxed">
+          <p class="text-sm text-muted-foreground leading-relaxed mb-4">
             {service.description}
           </p>
-        </div>
+          <span class="text-sm font-medium text-teal-600 group-hover:text-teal-700 transition-colors inline-flex items-center gap-1">
+            詳しく見る
+            <svg class="w-4 h-4 group-hover:translate-x-0.5 transition-transform" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M5 12h14M12 5l7 7-7 7" />
+            </svg>
+          </span>
+        </a>
       ))}
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Servicesカードを `<a>` タグに変更し `/services#カテゴリid` へリンク
- 「詳しく見る →」テキスト+ホバーアニメーション追加
- グリッドを3カラム→4カラムに変更（4カテゴリ対応）
- wrenchアイコンSVGを追加

Closes #4

## Test plan
- [x] `npx astro check` — 型エラー0件
- [x] `npx astro build` — ビルド成功
- [ ] 各カードクリックで `/services#id` に遷移すること
- [ ] ホバー時のアニメーションが動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)