### PR TITLE
feat: アナリティクス導入（GA4 + Microsoft Clarity）

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -43,3 +43,27 @@ const ogImageUrl = new URL(ogImage, siteConfig.url);
 <meta name="twitter:title" content={title} />
 <meta name="twitter:description" content={description} />
 <meta name="twitter:image" content={ogImageUrl} />
+
+<!-- Google Analytics 4 -->
+{import.meta.env.PUBLIC_GA4_ID && (
+  <>
+    <script is:inline async src={`https://www.googletagmanager.com/gtag/js?id=${import.meta.env.PUBLIC_GA4_ID}`}></script>
+    <script is:inline define:vars={{ gaId: import.meta.env.PUBLIC_GA4_ID }}>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', gaId);
+    </script>
+  </>
+)}
+
+<!-- Microsoft Clarity -->
+{import.meta.env.PUBLIC_CLARITY_ID && (
+  <script is:inline define:vars={{ clarityId: import.meta.env.PUBLIC_CLARITY_ID }}>
+    (function(c,l,a,r,i,t,y){
+      c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+      t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+      y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", clarityId);
+  </script>
+)}


### PR DESCRIPTION
## Summary
- Head.astro に GA4 と Microsoft Clarity のトラッキングスクリプトを追加
- 環境変数（`PUBLIC_GA4_ID`, `PUBLIC_CLARITY_ID`）で測定IDを管理
- 環境変数未設定時はスクリプトを出力しない（graceful degradation）

Closes #5

## Test plan
- [x] `npx astro check` — 型エラー0件
- [x] `npx astro build` — ビルド成功
- [ ] 環境変数設定時にスクリプトがHTMLに含まれること
- [ ] 環境変数未設定時にスクリプトが出力されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)