### PR TITLE
fix: CIのNode.jsバージョンを22に更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - run: npm ci


### PR DESCRIPTION
## Summary
- GitHub Actions CIのNode.jsバージョンを20→22に更新
- Astro 6が `>=22.12.0` を要求しているための対応

Closes #12

## Test plan
- [ ] CIが正常に通ること（astro check + astro build）

🤖 Generated with [Claude Code](https://claude.com/claude-code)