### PR TITLE
chore: DependabotでTypeScriptメジャーアップデートを除外

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "chore"
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- `@astrojs/check@0.9.8` が `peer typescript@"^5.0.0"` を要求しており、TypeScript 6.x は現時点で非対応
- Dependabot設定で `typescript` のメジャーアップデートPR生成を抑止する
- `@astrojs/check` が TS6 対応後に設定を解除してアップグレードする

## 関連
- Closes に該当なし（#37 はクローズ済み）

## Test plan
- [ ] Dependabotが今後 TypeScript 6.x のPRを生成しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)