### PR TITLE
fix: 長文ナレッジ記事が真っ白で表示されない問題を修正

### DIFF
--- a/src/layouts/KnowledgeLayout.astro
+++ b/src/layouts/KnowledgeLayout.astro
@@ -90,7 +90,7 @@ const jsonLd = JSON.stringify({
         }
       </header>
 
-      <div class="knowledge-prose animate-on-scroll">
+      <div class="knowledge-prose">
         <slot />
       </div>
 


### PR DESCRIPTION
## 問題
長文記事（embedding-vector-search等）にアクセスすると、本文が真っ白で表示されない。
- 該当記事例: https://shogoworks.com/knowledge/context-engineering/embedding-vector-search/
- 影響範囲: HTMLサイズが47KB以上の長文記事（少なくとも5本以上）

## 原因
\`KnowledgeLayout.astro\` の \`<div class=\"knowledge-prose animate-on-scroll\">\` が原因。

\`.animate-on-scroll\` は初期状態で \`opacity: 0\` であり、IntersectionObserver の \`{ threshold: 0.1 }\` で要素の10%が見えたら \`.is-visible\` クラスを付与してフェードインする実装。

しかし、本文ラッパー要素がビューポートより**10倍以上**大きい場合、要素全体に対するviewportの可視率が10%を超えられず、threshold判定が永遠に成立しない → \`opacity: 0\` のままになってしまう。

## 修正
本文ラッパーから \`animate-on-scroll\` を削除し、本文は即時表示する。
ヘッダー（タイトル・タグ等）のフェードインは引き続き有効。

## Test plan
- [x] \`npm run build\` ビルド成功
- [ ] デプロイ後、長文記事（embedding-vector-search, context-window-management等）が正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)