### PR TITLE
fix: embedding-vector-search 本番表示問題の調査用再ビルド

### DIFF
--- a/src/content/knowledge/context-engineering/embedding-vector-search.mdx
+++ b/src/content/knowledge/context-engineering/embedding-vector-search.mdx
@@ -253,3 +253,4 @@ async def search_with_rerank(
 - [RAG in 2026: Why Vector Embeddings Are No Longer Enough — Prism Labs](https://www.prismlabs.uk/blog/rag-beyond-vector-embeddings-2026)
 - [From RAG to Context: A 2025 Year-end Review — RAGFlow](https://ragflow.io/blog/rag-review-2025-from-rag-to-context)
 - [Vector Databases Guide: RAG Applications 2025 — DEV Community](https://dev.to/klement_gunndu_e16216829c/vector-databases-guide-rag-applications-2025-55oj)
+


### PR DESCRIPTION
## 問題
https://shogoworks.com/knowledge/context-engineering/embedding-vector-search/ が本番で本文欠落（HTML 7.8KB、本文不在）。

## 調査結果
- ローカルビルド (\`dist/\`): 47KB、本文完全に存在 ✓
- 本番デプロイ: 7.8KB、knowledge-prose div の中身が空 ✗
- 同じディレクトリの \`rag-architecture\` 等は正常表示
- PR #48 (animate-on-scroll削除) はマージ・デプロイ済み

## 仮説
Cloudflare Workers Builds の特定ファイルキャッシュが古い壊れた状態を保持している可能性。

## このPRの目的
\`embedding-vector-search.mdx\` に末尾改行を1行追加し、Cloudflare の再ビルドをトリガーする。
これで直れば一過性のビルドキャッシュ問題と判定できる。
直らなければ、内容に依存した本番固有の問題であり、別途絞り込みが必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)