### PR TITLE
feat: ナレッジ詳細ページの閲覧体験を改善（外部リンク別タブ・前後ナビ・サイドバー）

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -3,9 +3,21 @@ import react from "@astrojs/react";
 import mdx from "@astrojs/mdx";
 import tailwindcss from "@tailwindcss/vite";
 import cloudflare from "@astrojs/cloudflare";
+import rehypeExternalLinks from "rehype-external-links";
+
 export default defineConfig({
   adapter: cloudflare(),
-  integrations: [react(), mdx()],
+  integrations: [
+    react(),
+    mdx({
+      rehypePlugins: [
+        [
+          rehypeExternalLinks,
+          { target: "_blank", rel: ["noopener", "noreferrer"] },
+        ],
+      ],
+    }),
+  ],
   vite: {
     plugins: [tailwindcss()],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "lucide-react": "^1.7.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "rehype-external-links": "^3.0.0",
         "resend": "^6.10.0",
         "tailwind-merge": "^3.2.0",
         "tailwindcss": "^4.1.4",
@@ -4477,6 +4478,18 @@
         "url": "https://github.com/sponsors/brc-dd"
       }
     },
+    "node_modules/is-absolute-url": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
+      "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
@@ -6534,6 +6547,24 @@
         "rehype-parse": "^9.0.0",
         "rehype-stringify": "^10.0.0",
         "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-external-links": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
+      "integrity": "sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "is-absolute-url": "^4.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lucide-react": "^1.7.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "rehype-external-links": "^3.0.0",
     "resend": "^6.10.0",
     "tailwind-merge": "^3.2.0",
     "tailwindcss": "^4.1.4",

--- a/src/components/knowledge/ArticleSidebar.astro
+++ b/src/components/knowledge/ArticleSidebar.astro
@@ -1,0 +1,49 @@
+---
+import type { KnowledgeCategory } from "@/types";
+
+interface SidebarArticle {
+  slug: string;
+  title: string;
+}
+
+interface Props {
+  articles: SidebarArticle[];
+  currentSlug: string;
+  categoryLabel: string;
+  categorySlug: KnowledgeCategory;
+}
+
+const { articles, currentSlug, categoryLabel, categorySlug } = Astro.props;
+---
+
+<nav class="text-sm" aria-label={`${categoryLabel} の記事一覧`}>
+  <a
+    href={`/knowledge/${categorySlug}`}
+    class="block text-xs font-semibold uppercase tracking-wider text-muted-foreground hover:text-teal-600 transition-colors mb-3"
+  >
+    {categoryLabel}
+  </a>
+  <ol class="space-y-1 border-l border-border">
+    {
+      articles.map((article) => {
+        const isCurrent = article.slug === currentSlug;
+        return (
+          <li>
+            <a
+              href={`/knowledge/${categorySlug}/${article.slug}`}
+              class:list={[
+                "block px-3 py-1.5 -ml-px border-l transition-colors leading-snug",
+                isCurrent
+                  ? "border-teal-500 text-teal-600 font-semibold bg-teal-50/50"
+                  : "border-transparent text-muted-foreground hover:text-foreground hover:border-muted-foreground/40",
+              ]}
+              aria-current={isCurrent ? "page" : undefined}
+            >
+              {article.title}
+            </a>
+          </li>
+        );
+      })
+    }
+  </ol>
+</nav>

--- a/src/layouts/KnowledgeLayout.astro
+++ b/src/layouts/KnowledgeLayout.astro
@@ -2,8 +2,19 @@
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import Breadcrumb from "@/components/knowledge/Breadcrumb.astro";
 import Badge from "@/components/ui/Badge.astro";
+import ArticleSidebar from "@/components/knowledge/ArticleSidebar.astro";
 import { categories } from "@/data/knowledge";
 import type { KnowledgeCategory } from "@/types";
+
+interface SidebarArticle {
+  slug: string;
+  title: string;
+}
+
+interface AdjacentArticle {
+  slug: string;
+  title: string;
+}
 
 interface Props {
   title: string;
@@ -13,10 +24,25 @@ interface Props {
   createdAt: Date;
   updatedAt?: Date;
   author: string;
+  currentSlug: string;
+  sidebarArticles: SidebarArticle[];
+  previous: AdjacentArticle | null;
+  next: AdjacentArticle | null;
 }
 
-const { title, description, category, tags, createdAt, updatedAt, author } =
-  Astro.props;
+const {
+  title,
+  description,
+  category,
+  tags,
+  createdAt,
+  updatedAt,
+  author,
+  currentSlug,
+  sidebarArticles,
+  previous,
+  next,
+} = Astro.props;
 
 const categoryMeta = categories.find((c) => c.slug === category);
 const categoryLabel = categoryMeta?.label ?? category;
@@ -52,7 +78,7 @@ const jsonLd = JSON.stringify({
     <script type="application/ld+json" set:html={jsonLd} />
   </Fragment>
   <article class="py-20 px-4">
-    <div class="max-w-3xl mx-auto">
+    <div class="max-w-6xl mx-auto">
       <Breadcrumb
         items={[
           { label: "Knowledge Base", href: "/knowledge" },
@@ -61,47 +87,102 @@ const jsonLd = JSON.stringify({
         ]}
       />
 
-      <header class="mb-10 animate-on-scroll">
-        <div class="flex items-center gap-2 flex-wrap mb-4">
-          <Badge variant="teal">{categoryLabel}</Badge>
-          <span class="text-sm text-muted-foreground">
-            {formattedCreatedAt}
-          </span>
-          {
-            formattedUpdatedAt && formattedUpdatedAt !== formattedCreatedAt && (
-              <span class="text-sm text-muted-foreground">
-                (更新: {formattedUpdatedAt})
-              </span>
-            )
-          }
-        </div>
-        <h1 class="text-3xl md:text-4xl font-bold text-foreground mb-4">
-          {title}
-        </h1>
-        <p class="text-muted-foreground text-lg">{description}</p>
-        {
-          tags.length > 0 && (
-            <div class="flex gap-1.5 flex-wrap mt-4">
-              {tags.map((tag) => (
-                <Badge variant="default">{tag}</Badge>
-              ))}
-            </div>
-          )
-        }
-      </header>
-
-      <div class="knowledge-prose">
-        <slot />
-      </div>
-
-      <footer class="mt-16 pt-8 border-t border-border">
-        <a
-          href={`/knowledge/${category}`}
-          class="text-teal-600 hover:text-teal-700 transition-colors inline-flex items-center gap-1"
+      <div class="lg:flex lg:gap-10 lg:items-start">
+        <aside
+          class="hidden lg:block lg:w-64 lg:flex-shrink-0 lg:sticky lg:top-24 lg:max-h-[calc(100vh-7rem)] lg:overflow-y-auto"
         >
-          ← {categoryLabel} の記事一覧に戻る
-        </a>
-      </footer>
+          <ArticleSidebar
+            articles={sidebarArticles}
+            currentSlug={currentSlug}
+            categoryLabel={categoryLabel}
+            categorySlug={category}
+          />
+        </aside>
+
+        <div class="flex-1 min-w-0 max-w-3xl">
+          <header class="mb-10">
+            <div class="flex items-center gap-2 flex-wrap mb-4">
+              <Badge variant="teal">{categoryLabel}</Badge>
+              <span class="text-sm text-muted-foreground">
+                {formattedCreatedAt}
+              </span>
+              {
+                formattedUpdatedAt && formattedUpdatedAt !== formattedCreatedAt && (
+                  <span class="text-sm text-muted-foreground">
+                    (更新: {formattedUpdatedAt})
+                  </span>
+                )
+              }
+            </div>
+            <h1 class="text-3xl md:text-4xl font-bold text-foreground mb-4">
+              {title}
+            </h1>
+            <p class="text-muted-foreground text-lg">{description}</p>
+            {
+              tags.length > 0 && (
+                <div class="flex gap-1.5 flex-wrap mt-4">
+                  {tags.map((tag) => (
+                    <Badge variant="default">{tag}</Badge>
+                  ))}
+                </div>
+              )
+            }
+          </header>
+
+          <div class="knowledge-prose">
+            <slot />
+          </div>
+
+          <nav
+            class="mt-16 pt-8 border-t border-border grid grid-cols-1 sm:grid-cols-2 gap-4"
+            aria-label="記事ナビゲーション"
+          >
+            {
+              previous ? (
+                <a
+                  href={`/knowledge/${category}/${previous.slug}`}
+                  class="group block p-4 rounded-2xl border border-border hover:border-teal-500/60 hover:bg-teal-50/30 transition-colors"
+                >
+                  <span class="block text-xs text-muted-foreground mb-1">
+                    ← 前の記事
+                  </span>
+                  <span class="block font-semibold text-foreground group-hover:text-teal-600 transition-colors line-clamp-2">
+                    {previous.title}
+                  </span>
+                </a>
+              ) : (
+                <div />
+              )
+            }
+            {
+              next ? (
+                <a
+                  href={`/knowledge/${category}/${next.slug}`}
+                  class="group block p-4 rounded-2xl border border-border hover:border-teal-500/60 hover:bg-teal-50/30 transition-colors text-right sm:text-right"
+                >
+                  <span class="block text-xs text-muted-foreground mb-1">
+                    次の記事 →
+                  </span>
+                  <span class="block font-semibold text-foreground group-hover:text-teal-600 transition-colors line-clamp-2">
+                    {next.title}
+                  </span>
+                </a>
+              ) : (
+                <div />
+              )
+            }
+          </nav>
+
+          <footer class="mt-8">
+            <a
+              href={`/knowledge/${category}`}
+              class="text-teal-600 hover:text-teal-700 transition-colors inline-flex items-center gap-1"
+            >
+              ← {categoryLabel} の記事一覧に戻る
+            </a>
+          </footer>
+        </div>
+      </div>
     </div>
   </article>
 </BaseLayout>

--- a/src/pages/knowledge/[category]/[slug].astro
+++ b/src/pages/knowledge/[category]/[slug].astro
@@ -3,7 +3,11 @@ import type { GetStaticPaths, InferGetStaticPropsType } from "astro";
 import { getCollection, render } from "astro:content";
 import KnowledgeLayout from "@/layouts/KnowledgeLayout.astro";
 import { categories } from "@/data/knowledge";
-import { getPublishedArticles } from "@/utils/knowledge";
+import {
+  getPublishedArticles,
+  getArticlesByCategory,
+  getAdjacentArticles,
+} from "@/utils/knowledge";
 import type { KnowledgeCategory } from "@/types";
 
 export const getStaticPaths = (async () => {
@@ -16,19 +20,47 @@ export const getStaticPaths = (async () => {
     .filter((entry) => validCategories.has(entry.data.category as KnowledgeCategory))
     .map((entry) => {
       const slug = entry.id.split("/").pop() as string;
+      const category = entry.data.category as KnowledgeCategory;
+      const sameCategoryArticles = getArticlesByCategory(allEntries, category);
+      const sidebarArticles = sameCategoryArticles.map((e) => ({
+        slug: e.id.split("/").pop() as string,
+        title: e.data.title,
+      }));
+      const { previous, next } = getAdjacentArticles(
+        allEntries,
+        entry.id,
+        category,
+      );
       return {
         params: {
-          category: entry.data.category,
+          category,
           slug,
         },
-        props: { entry },
+        props: {
+          entry,
+          currentSlug: slug,
+          sidebarArticles,
+          previous: previous
+            ? {
+                slug: previous.id.split("/").pop() as string,
+                title: previous.data.title,
+              }
+            : null,
+          next: next
+            ? {
+                slug: next.id.split("/").pop() as string,
+                title: next.data.title,
+              }
+            : null,
+        },
       };
     });
 }) satisfies GetStaticPaths;
 
 type Props = InferGetStaticPropsType<typeof getStaticPaths>;
 
-const { entry } = Astro.props as Props;
+const { entry, currentSlug, sidebarArticles, previous, next } =
+  Astro.props as Props;
 const { Content } = await render(entry);
 ---
 
@@ -40,6 +72,10 @@ const { Content } = await render(entry);
   createdAt={entry.data.createdAt}
   updatedAt={entry.data.updatedAt}
   author={entry.data.author}
+  currentSlug={currentSlug}
+  sidebarArticles={sidebarArticles}
+  previous={previous}
+  next={next}
 >
   <Content />
 </KnowledgeLayout>

--- a/src/utils/knowledge.ts
+++ b/src/utils/knowledge.ts
@@ -135,6 +135,21 @@ export function getArticlesByCategory<T extends KnowledgeEntry>(
   );
 }
 
+/** 同カテゴリ内で前後の記事を返す（sortOrder順） */
+export function getAdjacentArticles<T extends KnowledgeEntry>(
+  entries: T[],
+  currentId: string,
+  category: KnowledgeCategory,
+): { previous: T | null; next: T | null } {
+  const list = getArticlesByCategory(entries, category);
+  const idx = list.findIndex((e) => e.id === currentId);
+  if (idx === -1) return { previous: null, next: null };
+  return {
+    previous: idx > 0 ? list[idx - 1] : null,
+    next: idx < list.length - 1 ? list[idx + 1] : null,
+  };
+}
+
 export function getCategoryArticleCount<T extends KnowledgeEntry>(
   entries: T[],
 ): Record<KnowledgeCategory, number> {

--- a/tests/utils/knowledge.test.ts
+++ b/tests/utils/knowledge.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   getPublishedArticles,
   getArticlesByCategory,
+  getAdjacentArticles,
   getCategoryArticleCount,
   getRelatedArticles,
   mergeArticles,
@@ -178,6 +179,48 @@ describe("getArticlesByCategory", () => {
   it("該当カテゴリの記事がない場合、空配列を返すこと", () => {
     const result = getArticlesByCategory(mockEntries, "career");
     expect(result).toEqual([]);
+  });
+});
+
+describe("getAdjacentArticles", () => {
+  it("中間の記事の前後を返すこと", () => {
+    const result = getAdjacentArticles(
+      mockEntries,
+      "ai-tools/cursor-tips",
+      "ai-tools",
+    );
+    expect(result.previous?.id).toBe("ai-tools/claude-code");
+    expect(result.next).toBeNull();
+  });
+
+  it("先頭記事はpreviousがnullになること", () => {
+    const result = getAdjacentArticles(
+      mockEntries,
+      "ai-tools/claude-code",
+      "ai-tools",
+    );
+    expect(result.previous).toBeNull();
+    expect(result.next?.id).toBe("ai-tools/cursor-tips");
+  });
+
+  it("該当記事がない場合、両方nullになること", () => {
+    const result = getAdjacentArticles(
+      mockEntries,
+      "non-existent",
+      "ai-tools",
+    );
+    expect(result.previous).toBeNull();
+    expect(result.next).toBeNull();
+  });
+
+  it("draft記事は対象から除外されること", () => {
+    const result = getAdjacentArticles(
+      mockEntries,
+      "ai-tools/cursor-tips",
+      "ai-tools",
+    );
+    // draft-articleは含まれないのでnextはnull
+    expect(result.next).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
ナレッジ記事詳細ページに3つのUX改善を追加しました。

### 1. 記事本文の外部リンクを別タブで開く
- `rehype-external-links` プラグインを導入
- ビルド時に全外部リンク（`http://`/`https://`）に `target="_blank" rel="noopener noreferrer"` を自動付与
- 内部リンク（`/knowledge/...`）は同タブのまま

### 2. 前の記事 / 次の記事ナビゲーション
- 同カテゴリ内 `sortOrder` 順で前後の記事に直接遷移できるカード型UIをフッターに追加
- 新規ユーティリティ `getAdjacentArticles(entries, currentId, category)` を `src/utils/knowledge.ts` に追加
- レスポンシブ対応（モバイルは縦並び、SM以上は横並び）

### 3. 左サイドバー（同カテゴリ記事一覧）
- 新規コンポーネント `src/components/knowledge/ArticleSidebar.astro`
- `sortOrder` 順で同カテゴリ全記事を縦並び表示
- 現在記事をハイライト（teal色 + 太字 + `aria-current="page"`）
- `lg` 以上で表示（sticky position）、未満では非表示
- レイアウトは `max-w-6xl` の2カラム構成、コンテンツ部は `max-w-3xl` を維持

## Test plan
- [x] `npm test` 44/44 passed（新規 `getAdjacentArticles` テスト4件追加）
- [x] `npm run build` ビルド成功
- [x] 生成HTMLで外部リンクに `target="_blank" rel="noopener noreferrer"` が付与されることを確認
- [x] サイドバーで現在記事に `aria-current="page"` が付与されることを確認
- [x] 前/次の記事ナビゲーションが正しく出力されることを確認
- [ ] デプロイ後、各カテゴリで詳細ページのUXを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)