### PR TITLE
feat: タグ検索・フィルタリング + コードブロック可読性改善

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -7,6 +7,12 @@ import rehypeExternalLinks from "rehype-external-links";
 
 export default defineConfig({
   adapter: cloudflare(),
+  markdown: {
+    shikiConfig: {
+      theme: "one-dark-pro",
+      wrap: false,
+    },
+  },
   integrations: [
     react(),
     mdx({

--- a/src/layouts/KnowledgeLayout.astro
+++ b/src/layouts/KnowledgeLayout.astro
@@ -122,7 +122,13 @@ const jsonLd = JSON.stringify({
               tags.length > 0 && (
                 <div class="flex gap-1.5 flex-wrap mt-4">
                   {tags.map((tag) => (
-                    <Badge variant="default">{tag}</Badge>
+                    <a
+                      href={`/knowledge/tags/${encodeURIComponent(tag)}`}
+                      class="hover:opacity-80 transition-opacity"
+                      aria-label={`タグ ${tag} の記事一覧へ`}
+                    >
+                      <Badge variant="default">#{tag}</Badge>
+                    </a>
                   ))}
                 </div>
               )

--- a/src/pages/knowledge/index.astro
+++ b/src/pages/knowledge/index.astro
@@ -28,7 +28,7 @@ function getCategoryLabel(slug: string): string {
         subtitle="AI活用・Web開発・DevOpsなど、実践的な技術ナレッジを発信しています"
       />
 
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-16">
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
         {
           categories.map((category, i) => (
             <div class={`animate-on-scroll stagger-${i + 1}`}>
@@ -39,6 +39,15 @@ function getCategoryLabel(slug: string): string {
             </div>
           ))
         }
+      </div>
+
+      <div class="mb-16 flex justify-end">
+        <a
+          href="/knowledge/tags"
+          class="inline-flex items-center gap-1 text-sm text-teal-600 hover:text-teal-700 transition-colors"
+        >
+          タグから記事を探す →
+        </a>
       </div>
 
       {

--- a/src/pages/knowledge/tags/[tag].astro
+++ b/src/pages/knowledge/tags/[tag].astro
@@ -1,0 +1,75 @@
+---
+import type { GetStaticPaths, InferGetStaticPropsType } from "astro";
+import { getCollection } from "astro:content";
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import SectionHeader from "@/components/ui/SectionHeader.astro";
+import Breadcrumb from "@/components/knowledge/Breadcrumb.astro";
+import ArticleCard from "@/components/knowledge/ArticleCard.astro";
+import { categories } from "@/data/knowledge";
+import { getAllTags, getArticlesByTag } from "@/utils/knowledge";
+import type { KnowledgeCategory } from "@/types";
+
+export const getStaticPaths = (async () => {
+  const allEntries = await getCollection("knowledge");
+  const tags = getAllTags(allEntries);
+  return tags.map(({ tag }) => ({
+    params: { tag },
+    props: { tag },
+  }));
+}) satisfies GetStaticPaths;
+
+type Props = InferGetStaticPropsType<typeof getStaticPaths>;
+
+const { tag } = Astro.props as Props;
+const allEntries = await getCollection("knowledge");
+const articles = getArticlesByTag(allEntries, tag);
+
+function getCategoryLabel(slug: string): string {
+  return categories.find((c) => c.slug === slug)?.label ?? slug;
+}
+---
+
+<BaseLayout
+  title={`#${tag} | Knowledge Base | shogoworks`}
+  description={`タグ「${tag}」が付いたナレッジ記事の一覧 (${articles.length}件)`}
+>
+  <section class="py-20 px-4">
+    <div class="max-w-5xl mx-auto">
+      <Breadcrumb
+        items={[
+          { label: "Knowledge Base", href: "/knowledge" },
+          { label: "タグ", href: "/knowledge/tags" },
+          { label: `#${tag}` },
+        ]}
+      />
+
+      <SectionHeader
+        title={`#${tag}`}
+        subtitle={`${articles.length}件の記事が見つかりました`}
+      />
+
+      {
+        articles.length > 0 ? (
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {articles.map((entry) => {
+              const slug = entry.id.split("/").pop() as string;
+              const category = entry.data.category as KnowledgeCategory;
+              return (
+                <ArticleCard
+                  title={entry.data.title}
+                  description={entry.data.description}
+                  categoryLabel={getCategoryLabel(category)}
+                  tags={entry.data.tags}
+                  createdAt={entry.data.createdAt}
+                  href={`/knowledge/${category}/${slug}`}
+                />
+              );
+            })}
+          </div>
+        ) : (
+          <p class="text-muted-foreground">該当する記事がありません。</p>
+        )
+      }
+    </div>
+  </section>
+</BaseLayout>

--- a/src/pages/knowledge/tags/index.astro
+++ b/src/pages/knowledge/tags/index.astro
@@ -1,0 +1,49 @@
+---
+import { getCollection } from "astro:content";
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import SectionHeader from "@/components/ui/SectionHeader.astro";
+import Breadcrumb from "@/components/knowledge/Breadcrumb.astro";
+import { getAllTags } from "@/utils/knowledge";
+
+const allEntries = await getCollection("knowledge");
+const tags = getAllTags(allEntries);
+---
+
+<BaseLayout
+  title="タグ一覧 | Knowledge Base | shogoworks"
+  description="ナレッジ記事のタグから記事を探せます。"
+>
+  <section class="py-20 px-4">
+    <div class="max-w-5xl mx-auto">
+      <Breadcrumb
+        items={[
+          { label: "Knowledge Base", href: "/knowledge" },
+          { label: "タグ" },
+        ]}
+      />
+
+      <SectionHeader
+        title="タグ一覧"
+        subtitle={`${tags.length} 個のタグから記事を探せます`}
+      />
+
+      {
+        tags.length > 0 ? (
+          <div class="flex flex-wrap gap-2">
+            {tags.map(({ tag, count }) => (
+              <a
+                href={`/knowledge/tags/${encodeURIComponent(tag)}`}
+                class="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-border bg-white hover:border-teal-500/60 hover:bg-teal-50/40 hover:text-teal-700 transition-colors text-sm"
+              >
+                <span class="font-medium text-foreground">#{tag}</span>
+                <span class="text-xs text-muted-foreground">{count}</span>
+              </a>
+            ))}
+          </div>
+        ) : (
+          <p class="text-muted-foreground">タグはまだありません。</p>
+        )
+      }
+    </div>
+  </section>
+</BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -210,6 +210,10 @@ body {
   color: var(--color-muted-foreground);
 }
 
+.knowledge-prose blockquote a {
+  color: var(--color-primary);
+}
+
 .knowledge-prose code {
   font-family: var(--font-mono);
   font-size: 0.875em;
@@ -219,20 +223,34 @@ body {
   color: var(--color-foreground);
 }
 
+.knowledge-prose a code {
+  color: inherit;
+}
+
 .knowledge-prose pre {
   margin: 1.5rem 0;
-  padding: 1rem 1.25rem;
+  padding: 1.25rem 1.5rem;
   border-radius: 0.75rem;
   overflow-x: auto;
   font-size: 0.875rem;
   line-height: 1.7;
+  background: #282c34;
+  border: 1px solid hsl(220 13% 22%);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  color: #abb2bf;
 }
 
 .knowledge-prose pre code {
-  background: none;
+  background: none !important;
   padding: 0;
   border-radius: 0;
   font-size: inherit;
+  color: inherit;
+}
+
+.knowledge-prose pre code .line {
+  display: block;
+  min-height: 1.5em;
 }
 
 .knowledge-prose img {
@@ -259,6 +277,11 @@ body {
 .knowledge-prose th {
   background: var(--color-secondary);
   font-weight: 600;
+}
+
+.knowledge-prose td a,
+.knowledge-prose th a {
+  color: var(--color-primary);
 }
 
 .knowledge-prose hr {

--- a/src/utils/knowledge.ts
+++ b/src/utils/knowledge.ts
@@ -135,6 +135,31 @@ export function getArticlesByCategory<T extends KnowledgeEntry>(
   );
 }
 
+/** 全タグと出現回数を取得する（公開記事のみ、件数降順→タグ名昇順） */
+export function getAllTags<T extends KnowledgeEntry>(
+  entries: T[],
+): Array<{ tag: string; count: number }> {
+  const counts = new Map<string, number>();
+  for (const entry of getPublishedArticles(entries)) {
+    for (const tag of entry.data.tags) {
+      counts.set(tag, (counts.get(tag) ?? 0) + 1);
+    }
+  }
+  return Array.from(counts.entries())
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
+}
+
+/** 指定タグを含む公開記事を返す */
+export function getArticlesByTag<T extends KnowledgeEntry>(
+  entries: T[],
+  tag: string,
+): T[] {
+  return getPublishedArticles(entries).filter((entry) =>
+    entry.data.tags.includes(tag),
+  );
+}
+
 /** 同カテゴリ内で前後の記事を返す（sortOrder順） */
 export function getAdjacentArticles<T extends KnowledgeEntry>(
   entries: T[],

--- a/tests/utils/knowledge.test.ts
+++ b/tests/utils/knowledge.test.ts
@@ -3,6 +3,8 @@ import {
   getPublishedArticles,
   getArticlesByCategory,
   getAdjacentArticles,
+  getAllTags,
+  getArticlesByTag,
   getCategoryArticleCount,
   getRelatedArticles,
   mergeArticles,
@@ -221,6 +223,53 @@ describe("getAdjacentArticles", () => {
     );
     // draft-articleは含まれないのでnextはnull
     expect(result.next).toBeNull();
+  });
+});
+
+describe("getAllTags", () => {
+  it("公開記事に含まれる全タグと出現回数を返すこと", () => {
+    const result = getAllTags(mockEntries);
+    const tags = result.map((t) => t.tag);
+    // ai タグは claude-code(1) + cursor-tips(1) = 2件
+    const aiTag = result.find((t) => t.tag === "ai");
+    expect(aiTag?.count).toBe(2);
+    // draft 記事のタグは含まれない
+    expect(tags).not.toContain("draft");
+  });
+
+  it("件数降順、同件数ならタグ名昇順でソートされること", () => {
+    const result = getAllTags(mockEntries);
+    for (let i = 1; i < result.length; i++) {
+      const prev = result[i - 1];
+      const curr = result[i];
+      if (prev.count === curr.count) {
+        expect(prev.tag.localeCompare(curr.tag)).toBeLessThanOrEqual(0);
+      } else {
+        expect(prev.count).toBeGreaterThan(curr.count);
+      }
+    }
+  });
+
+  it("空配列を渡した場合、空配列を返すこと", () => {
+    expect(getAllTags([])).toEqual([]);
+  });
+});
+
+describe("getArticlesByTag", () => {
+  it("指定タグを含む公開記事のみ返すこと", () => {
+    const result = getArticlesByTag(mockEntries, "ai");
+    expect(result).toHaveLength(2);
+    expect(result.every((e) => e.data.tags.includes("ai"))).toBe(true);
+  });
+
+  it("draft記事を除外すること", () => {
+    const result = getArticlesByTag(mockEntries, "draft");
+    expect(result).toHaveLength(0);
+  });
+
+  it("該当タグの記事がない場合、空配列を返すこと", () => {
+    const result = getArticlesByTag(mockEntries, "non-existent-tag");
+    expect(result).toEqual([]);
   });
 });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
     "jsx": "react-jsx",
     "jsxImportSource": "react"
   },
-  "exclude": ["tests", "scripts", "vitest.config.ts"]
+  "exclude": ["tests", "scripts", "vitest.config.ts", "dist"]
 }


### PR DESCRIPTION
## Summary
2点の改善を1PRにまとめました（コミット2つに分割）。

### コミット1: タグ検索・フィルタリング機能
- 新規ページ `/knowledge/tags` — 全タグ一覧（記事数付きのバッジ形式）
- 新規ページ `/knowledge/tags/{tag}` — タグ別記事一覧
- 詳細ページのタグをクリッカブル化（`#{tag}` 形式で表示、タグページへ遷移）
- knowledge トップに「タグから記事を探す」リンクを追加
- ユーティリティ `getAllTags()` / `getArticlesByTag()` を新規追加（テスト6件）
- ついでに `tsconfig.json` の exclude に \`dist\` を追加（ローカルでの \`astro check\` 安定化）

### コミット2: コードブロックとマークダウン本文の可読性改善
- Shiki テーマを Astro デフォルト（github-dark）から `one-dark-pro` に変更
  - 背景 `#282c34`、文字色のコントラストが改善
- `.knowledge-prose pre` に明示的な背景色・border・shadowを設定
- インラインコード内のリンク色を `inherit` 化（同化を防止）
- テーブル / blockquote 内のリンク色を明示

## なぜ `one-dark-pro` か
- VSCode 標準テーマで読み慣れているユーザーが多い
- 背景 `#282c34` は github-dark (`#0d1117`) より明るく、白基調サイトとの境界が自然
- シンタックストークンの色設計が読みやすい

## Test plan
- [x] \`npm test\` 50/50 passed（新規 \`getAllTags\` 3件 + \`getArticlesByTag\` 3件追加）
- [x] \`npm run build\` ビルド成功
- [x] 生成HTMLでタグページが作成されることを確認（`/knowledge/tags/`, `/knowledge/tags/{tag}/`）
- [x] 生成HTMLに `one-dark-pro` テーマと `#282c34` 背景色が含まれることを確認
- [ ] デプロイ後、各記事のタグクリックでタグページに遷移することを目視確認
- [ ] デプロイ後、コードブロックの可読性を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)