### PR TITLE
fix: モバイルメニュー表示中のスクロール時表示崩れを修正

### DIFF
--- a/src/components/islands/MobileMenu.tsx
+++ b/src/components/islands/MobileMenu.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 interface NavItem {
   label: string;
@@ -12,6 +12,20 @@ interface Props {
 
 export default function MobileMenu({ navItems, currentPath }: Props) {
   const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const body = document.body;
+    const previousOverflow = body.style.overflow;
+    if (open) {
+      body.style.overflow = "hidden";
+    } else {
+      body.style.overflow = previousOverflow;
+    }
+    return () => {
+      body.style.overflow = previousOverflow;
+    };
+  }, [open]);
 
   return (
     <div className="md:hidden">
@@ -54,7 +68,7 @@ export default function MobileMenu({ navItems, currentPath }: Props) {
           />
 
           {/* Menu panel */}
-          <div className="fixed top-0 right-0 bottom-0 w-72 bg-white/95 backdrop-blur-xl border-l border-gray-200 z-50 shadow-xl">
+          <div className="fixed top-0 right-0 bottom-0 w-72 bg-white/95 backdrop-blur-xl border-l border-gray-200 z-50 shadow-xl overflow-y-auto overscroll-contain">
             <div className="flex justify-end p-4">
               <button
                 onClick={() => setOpen(false)}


### PR DESCRIPTION
## 問題
スマホサイズでハンバーガーメニューを開いた状態でスクロールすると、背景コンテンツが一緒に動いてしまい、ヘッダーの背景色切り替え（スクロール量に応じた `bg-transparent` → `bg-white/95`）と競合して見た目が崩れる。

## 原因
- `MobileMenu` コンポーネントでメニュー開放中に body のスクロールをロックしていなかった
- 裏のコンテンツがスクロールすることで、`Navbar` のスクロールイベントが発火し、ヘッダー背景が切り替わってメニュー上部と競合
- メニューパネル自体にも `overflow-y-auto` が無く、項目が多い場合の縦スクロール時にスクロールチェーンが発生する可能性

## 修正
1. `useEffect` でメニュー開放中は `document.body.style.overflow = "hidden"` を適用
2. メニュー閉じる時に元の overflow 値に復元（cleanup関数でも念のため復元）
3. メニューパネルに `overflow-y-auto overscroll-contain` を追加
   - `overscroll-contain` で親要素へのスクロール伝播を防止

## Test plan
- [x] `npm test` 50/50 passed
- [x] `npm run build` ビルド成功
- [ ] デプロイ後、スマホサイズでメニューを開いてスクロール試行し、表示崩れがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)