### PR TITLE
fix: サービスページ初期表示で最初の項目が見えない問題を修正

### DIFF
--- a/src/components/sections/ServiceDetail.astro
+++ b/src/components/sections/ServiceDetail.astro
@@ -19,9 +19,15 @@ const iconSvgs: Record<string, string> = {
 };
 ---
 
-<section id={service.id} class={`py-16 ${index % 2 === 1 ? "bg-gray-50/50" : ""}`}>
+<section
+  id={service.id}
+  class:list={[
+    index === 0 ? "pt-6 pb-16" : "py-16",
+    index % 2 === 1 && "bg-gray-50/50",
+  ]}
+>
   <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-    <div class="animate-on-scroll">
+    <div class:list={[index !== 0 && "animate-on-scroll"]}>
       <!-- ヘッダー -->
       <div class="flex items-center gap-4 mb-6">
         <div class="w-14 h-14 rounded-2xl bg-teal-50 flex items-center justify-center shrink-0">

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -39,7 +39,7 @@ const { title, description, ogType } = Astro.props;
             }
           });
         },
-        { threshold: 0.1, rootMargin: "-50px" }
+        { threshold: 0, rootMargin: "0px 0px -10% 0px" }
       );
 
       document.querySelectorAll(".animate-on-scroll").forEach((el) => {

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -6,7 +6,7 @@ import { services } from "@/data";
 ---
 
 <BaseLayout title="Services | shogoworks" description="提供サービス一覧 - 自動化ツール開発、AI伴走支援、企業向け研修、Web開発">
-  <section class="pt-20 pb-8">
+  <section class="pt-20 pb-4">
     <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
       <SectionHeader
         title="Services"


### PR DESCRIPTION
## 問題
スマホサイズで /services を開いたとき、最初のサービス項目「自動化・効率化ツール開発」がスクロールしないと表示されない。

## 原因
複合要因:

1. **IntersectionObserverのthresholdが厳しすぎる**
   - `BaseLayout.astro` で `threshold: 0.1` (要素の10%が可視で発動)
   - viewportより大きい要素や、初期に一部しか入らない要素では発動条件を満たせない
   - 以前のKnowledgeLayout長文記事の真っ白問題と同根

2. **最初のServiceDetailまでの余白が大きい**
   - `services.astro` のヒーロー部 `pt-20 pb-8` + `ServiceDetail` の `py-16` で、モバイル画面高さを超えて最初の項目が画面外

## 修正
### 1. `BaseLayout.astro` の IntersectionObserver
```diff
- { threshold: 0.1, rootMargin: "-50px" }
+ { threshold: 0, rootMargin: "0px 0px -10% 0px" }
```
- `threshold: 0` → 要素が1pxでも可視領域に入れば発火
- `rootMargin: -10% (下端)` → 下から入ってくる要素は下端10%手前でトリガー
- 初期可視領域にある要素は即座にis-visibleが付く

### 2. `services.astro` のヒーロー下部padding短縮
- `pb-8` → `pb-4`

### 3. `ServiceDetail` の最初の項目(index===0)を即時表示
- `animate-on-scroll` を外す（フェードイン不要、即時表示）
- セクション上部padding `py-16` → `pt-6 pb-16`（ヒーローとの距離を詰める）

## 影響範囲
- BaseLayout の IntersectionObserver 変更は全サイトに影響
- ただし `threshold: 0` は「可視になれば発火」の自然な挙動で、既存の動作を壊さない
- むしろ以前発動しなかった要素が正しくフェードインするようになる

## Test plan
- [x] `npm test` 50/50 passed
- [x] `npm run build` ビルド成功
- [ ] デプロイ後、スマホサイズで /services を開き、最初の項目が即時表示されることを確認
- [ ] 他のページ（/knowledge、/ など）のフェードイン挙動に問題がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)