### PR TITLE
fix: モバイルメニューの表示崩れ（z-index競合とstacking context）を修正

### DIFF
--- a/src/components/islands/MobileMenu.tsx
+++ b/src/components/islands/MobileMenu.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 
 interface NavItem {
   label: string;
@@ -12,20 +13,25 @@ interface Props {
 
 export default function MobileMenu({ navItems, currentPath }: Props) {
   const [open, setOpen] = useState(false);
+  const [mounted, setMounted] = useState(false);
 
+  // hydration 完了後にポータルを有効化（SSR時のmismatchを防止）
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // メニュー開放中は body のスクロールをロック
   useEffect(() => {
     if (typeof document === "undefined") return;
-    const body = document.body;
-    const previousOverflow = body.style.overflow;
     if (open) {
-      body.style.overflow = "hidden";
-    } else {
-      body.style.overflow = previousOverflow;
+      document.body.style.overflow = "hidden";
     }
     return () => {
-      body.style.overflow = previousOverflow;
+      document.body.style.overflow = "";
     };
   }, [open]);
+
+  const closeMenu = () => setOpen(false);
 
   return (
     <div className="md:hidden">
@@ -59,66 +65,69 @@ export default function MobileMenu({ navItems, currentPath }: Props) {
         </svg>
       </button>
 
-      {open && (
-        <>
-          {/* Backdrop */}
-          <div
-            className="fixed inset-0 bg-black/20 backdrop-blur-sm z-40"
-            onClick={() => setOpen(false)}
-          />
+      {mounted &&
+        open &&
+        createPortal(
+          <>
+            {/* Backdrop */}
+            <div
+              className="fixed inset-0 bg-black/20 backdrop-blur-sm z-[60]"
+              onClick={closeMenu}
+            />
 
-          {/* Menu panel */}
-          <div className="fixed top-0 right-0 bottom-0 w-72 bg-white/95 backdrop-blur-xl border-l border-gray-200 z-50 shadow-xl overflow-y-auto overscroll-contain">
-            <div className="flex justify-end p-4">
-              <button
-                onClick={() => setOpen(false)}
-                className="p-2 text-foreground hover:bg-gray-100 rounded-md transition-colors"
-                aria-label="メニューを閉じる"
-              >
-                <svg
-                  className="w-5 h-5"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
+            {/* Menu panel */}
+            <div className="fixed top-0 right-0 bottom-0 w-72 bg-white border-l border-gray-200 z-[70] shadow-xl overflow-y-auto overscroll-contain">
+              <div className="flex justify-end p-4">
+                <button
+                  onClick={closeMenu}
+                  className="p-2 text-foreground hover:bg-gray-100 rounded-md transition-colors"
+                  aria-label="メニューを閉じる"
                 >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
-              </button>
-            </div>
-
-            <div className="flex flex-col gap-1 px-4">
-              {navItems.map((item) => (
-                <a
-                  key={item.href}
-                  href={item.href}
-                  onClick={() => setOpen(false)}
-                  className={`px-4 py-3 text-sm rounded-lg transition-colors ${
-                    currentPath === item.href
-                      ? "text-foreground font-medium bg-gray-50"
-                      : "text-muted-foreground hover:text-foreground hover:bg-gray-100"
-                  }`}
-                >
-                  {item.label}
-                </a>
-              ))}
-              <div className="mt-4">
-                <a
-                  href="/contact"
-                  onClick={() => setOpen(false)}
-                  className="block w-full text-center bg-gradient-to-r from-teal-500 to-emerald-500 hover:from-teal-600 hover:to-emerald-600 text-white rounded-lg px-4 py-2.5 text-sm font-medium transition-all"
-                >
-                  お問い合わせ
-                </a>
+                  <svg
+                    className="w-5 h-5"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M6 18L18 6M6 6l12 12"
+                    />
+                  </svg>
+                </button>
               </div>
+
+              <nav className="flex flex-col gap-1 px-4 pb-8">
+                {navItems.map((item) => (
+                  <a
+                    key={item.href}
+                    href={item.href}
+                    onClick={closeMenu}
+                    className={`px-4 py-3 text-sm rounded-lg transition-colors ${
+                      currentPath === item.href
+                        ? "text-foreground font-medium bg-gray-50"
+                        : "text-muted-foreground hover:text-foreground hover:bg-gray-100"
+                    }`}
+                  >
+                    {item.label}
+                  </a>
+                ))}
+                <div className="mt-4">
+                  <a
+                    href="/contact"
+                    onClick={closeMenu}
+                    className="block w-full text-center bg-gradient-to-r from-teal-500 to-emerald-500 hover:from-teal-600 hover:to-emerald-600 text-white rounded-lg px-4 py-2.5 text-sm font-medium transition-all"
+                  >
+                    お問い合わせ
+                  </a>
+                </div>
+              </nav>
             </div>
-          </div>
-        </>
-      )}
+          </>,
+          document.body,
+        )}
     </div>
   );
 }


### PR DESCRIPTION
## 問題
スマホで右上のハンバーガーメニューをクリックした際、タイミングによっては
- メニュー項目が全く表示されない
- ヘッダーバーの中だけ白い背景が見える
- 一部だけ表示されてスクロールできる

という挙動が発生する。

## 原因
1. **stacking context 競合**
   - メニューパネルが Navbar (`#main-header` z-50 fixed) の内部に fixed で描画されていた
   - ヘッダーは独自の stacking context を作るため、メニューパネルはヘッダー内部の階層に閉じ込められる
   - スクロール時にヘッダー背景が `bg-white/95 backdrop-blur-md` に切り替わり、メニューパネルと視覚的に競合

2. **半透明背景 + backdrop-blur の重ね**
   - メニューパネル: `bg-white/95 backdrop-blur-xl`
   - ヘッダー: `bg-white/95 backdrop-blur-md`
   - 重なると描画が不安定になる（特にiOS Safari）

3. **body scroll lock の race condition**
   - `previousOverflow` をクロージャで保存していたため、連続クリックで意図しない値に戻る可能性

## 修正
### 1. createPortalでbody直下に描画
```tsx
{mounted && open && createPortal(
  <>
    <div className="fixed inset-0 ... z-[60]" />
    <div className="fixed top-0 right-0 bottom-0 ... z-[70]" />
  </>,
  document.body,
)}
```
- Navbar の stacking context から完全に独立
- ヘッダーの z-50 より上に明示的に配置 (z-[60]/z-[70])

### 2. mounted state で hydration mismatch回避
最初のSSR描画では portal を出さず、useEffect で `mounted=true` になってから有効化。

### 3. メニューパネル背景を不透明に
- `bg-white/95 backdrop-blur-xl` → `bg-white`
- 描画の不安定さを排除し、ヘッダーと重なっても視認性を確保

### 4. body scroll lock を簡潔化
```tsx
useEffect(() => {
  if (open) document.body.style.overflow = "hidden";
  return () => { document.body.style.overflow = ""; };
}, [open]);
```
previousOverflow のクロージャ参照を削除し、cleanup で必ず空文字列に戻す。

### 5. セマンティック改善
メニュー項目のラッパーを `<div>` → `<nav>` に変更。

## Test plan
- [x] `npm test` 50/50 passed
- [x] `npm run build` ビルド成功
- [ ] デプロイ後、スマホでハンバーガーメニュー連打して常に正しく表示されることを確認
- [ ] スクロール後にメニューを開いても正常表示されることを確認
- [ ] メニュー閉じた後に背景スクロールが復活することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)