### PR TITLE
fix: サービスページ最初の項目にフェードインモーションを復活

### DIFF
--- a/src/components/sections/ServiceDetail.astro
+++ b/src/components/sections/ServiceDetail.astro
@@ -27,7 +27,7 @@ const iconSvgs: Record<string, string> = {
   ]}
 >
   <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-    <div class:list={[index !== 0 && "animate-on-scroll"]}>
+    <div class:list={[index === 0 ? "animate-fade-in-up" : "animate-on-scroll"]}>
       <!-- ヘッダー -->
       <div class="flex items-center gap-4 mb-6">
         <div class="w-14 h-14 rounded-2xl bg-teal-50 flex items-center justify-center shrink-0">


### PR DESCRIPTION
## 問題
PR #53 でサービスページ最初の項目を即時表示にした際、フェードイン演出が失われた。

## 修正
既存の \`.animate-fade-in-up\` CSSクラス（@keyframes fade-in-up）を適用。

\`\`\`diff
- <div class:list={[index !== 0 && \"animate-on-scroll\"]}>
+ <div class:list={[index === 0 ? \"animate-fade-in-up\" : \"animate-on-scroll\"]}>
\`\`\`

### 動作の違い
| クラス | 発火方法 | 用途 |
|---|---|---|
| \`animate-on-scroll\` | IntersectionObserver | スクロールで viewport に入った時 |
| \`animate-fade-in-up\` | CSS @keyframes 自動再生 | ページロード直後に即時発火 |

最初の項目はビューポート初期表示位置にあるため、IntersectionObserver を待たずに自動再生型のアニメーションで即時ふわっと表示される。

## Test plan
- [x] \`npm run build\` ビルド成功
- [ ] デプロイ後、スマホで /services を開いた際、最初のサービスがふわっとフェードインすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)