### PR TITLE
feat: GAS基本ベストプラクティスとClasp+Claude Code連携ガイドを追加

### DIFF
--- a/src/content/knowledge/ai-tools/gas-clasp-claude-code-workflow.mdx
+++ b/src/content/knowledge/ai-tools/gas-clasp-claude-code-workflow.mdx
@@ -1,0 +1,291 @@
+---
+title: "GAS × clasp × Claude Code でローカル開発体験を最高にする"
+description: "Google Apps Script を script.google.com で書く辛さから卒業し、clasp でローカル化、TypeScript 化、Claude Code との連携で AI 補助開発に持ち込むまでの実践ワークフローを解説します。"
+category: "ai-tools"
+tags: ["claude-code", "google-apps-script", "gas", "clasp", "typescript", "ai-coding", "workflow"]
+sortOrder: 1
+createdAt: 2026-04-13
+author: "田中省伍"
+---
+
+Google Apps Script（以下 GAS）は、スプレッドシートやGmail、Drive を自動化するうえで圧倒的に便利な存在です。一方で、標準のエディタ（script.google.com）で長く書き続けるのは正直つらい。補完は弱いし、Git に乗らないし、レビューもできない。何より AI コーディングの文脈にまったく乗れません。
+
+この記事では、私が普段使いしている「**clasp でローカル化 → TypeScript 化 → Claude Code で AI 補助開発**」というワークフローを、導入手順とハマりどころまで含めて解説します。移行コストは一度きり、得られる生産性の向上は継続的。GAS を日常的に書く人ほど、見返りは大きいはずです。
+
+## script.google.com で書く辛さ
+
+まずは「なぜわざわざローカル化するのか」を棚卸ししておきます。私が Web エディタで消耗していたポイントはだいたい次の通りです。
+
+- **補完が弱い**: 型情報が乏しく、`SpreadsheetApp.getActive...` と打ったときのサジェストが物足りない。どの戻り値にどんなメソッドが生えているか、毎回ドキュメントを開く羽目になる。
+- **差分が取れない**: 変更履歴はあるが、Git のような粒度で diff を追えない。誰が何をなぜ変えたかも曖昧。
+- **テストが書けない**: ユニットテストを回す仕組みがない。動かしてみるまで壊れているかわからない。
+- **Git 管理できない**: バックアップは Google 任せ。ブランチ運用もできないので、破壊的変更が怖い。
+- **レビューできない**: PR ベースのコードレビュー文化に乗せられない。ペアで見るときも画面共有頼み。
+- **スニペット管理が地獄**: 再利用したいコードが散らばり、結局スプレッドシートにメモしてコピペするという原始生活になる。
+
+一言でいうと、**script.google.com で書いている限り、2020年代後半の開発体験にアクセスできない**。ここを越える鍵が clasp です。
+
+## clasp とは
+
+[clasp](https://github.com/google/clasp)（Command Line Apps Script Projects）は、Google 公式の GAS 用 CLI ツールです。GAS プロジェクトをローカルファイルとして扱い、push / pull で script.google.com と同期できます。
+
+主要なコマンドは次のとおり。
+
+| コマンド | 役割 |
+| --- | --- |
+| `clasp login` | Google アカウントで認証する |
+| `clasp clone <scriptId>` | 既存プロジェクトをローカルに取得する |
+| `clasp create` | 新規プロジェクトを作成する |
+| `clasp push` | ローカルの変更をリモートへ反映する |
+| `clasp pull` | リモートの変更をローカルへ取り込む |
+| `clasp deploy` | 新しいバージョンをデプロイする |
+| `clasp run` | ローカルから関数を直接実行する |
+
+要は「GAS プロジェクトを Git リポジトリのように扱えるようにする」ツールです。`clone → 編集 → push` という Git ライクなメンタルモデルで動くので、一度覚えれば迷うことはありません。
+
+## 導入手順
+
+### インストールと認証
+
+Node.js 20 以上が必要です（2026 年時点の要件）。
+
+```bash
+npm install -g @google/clasp
+clasp login
+```
+
+`clasp login` すると ブラウザが立ち上がって OAuth 認証に進みます。認証情報はホームディレクトリの `~/.clasprc.json` に保存されます。
+
+その後、[Apps Script API の設定ページ](https://script.google.com/home/usersettings)で API を有効化しておきます。ここを忘れると後で `User has not enabled the Apps Script API` で詰まります。
+
+### 既存プロジェクトの clone
+
+既存の GAS プロジェクトをローカル化するには、script.google.com の「プロジェクトの設定」から `Script ID` をコピーして次を実行します。
+
+```bash
+mkdir my-gas-project && cd my-gas-project
+clasp clone <scriptId>
+```
+
+新規作成なら次のとおり。
+
+```bash
+clasp create --title "My GAS Project" --type standalone --rootDir ./src
+```
+
+`--type` には `standalone` / `sheets` / `docs` / `slides` / `forms` / `webapp` / `api` などが指定できます。
+
+### `.clasp.json` と `appsscript.json` の役割
+
+- **`.clasp.json`**: プロジェクトローカルの設定ファイル。`scriptId` や `rootDir` を持つ。**認証情報ではないが、`scriptId` を晒したくなければ `.gitignore` に入れる運用もあり**。
+- **`appsscript.json`**: GAS プロジェクトのマニフェスト。タイムゾーン、ランタイム（`V8` 一択）、有効にするサービス、OAuth スコープなどを定義する。こちらはリポジトリに含めてよい。
+
+```json
+{
+  "timeZone": "Asia/Tokyo",
+  "dependencies": {
+    "enabledAdvancedServices": []
+  },
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8"
+}
+```
+
+## clasp で得られる4つのメリット
+
+### (a) Git 管理
+
+ローカル化すれば当然 Git に載ります。ブランチを切って、PR を出して、CI を回して、main にマージする。普通のソフトウェア開発と同じフローに GAS を乗せられるのは、一度味わうと戻れません。履歴が追えるので「先週動いてたのに誰が壊した？」が 5 秒で判明します。
+
+### (b) IDE 補完
+
+VS Code や Cursor 上で書けば、構造解析と補完が段違いです。`@types/google-apps-script` を入れれば、`SpreadsheetApp` 配下のメソッドに完全な型が効きます。`getRange()` の戻り値が `Range` であり、さらに `.getValues()` すると `any[][]` が返る、みたいな情報が即座に手に入ります。
+
+### (c) TypeScript 対応
+
+型を入れたまま書けるのが大きい。GAS は実行時の型エラーが地味に痛く、「スプレッドシートの値が空欄だと null」「数値に見えて string」といった罠を型で事前に潰せるのは精神衛生上かなり良いです。
+
+### (d) チーム開発・レビュー
+
+PR ベースで GAS コードをレビューできます。`clasp push` は main マージ後の GitHub Actions で自動化すれば、「リポジトリが single source of truth」が徹底されます。**Web エディタで直接編集するルートを封じる**ことが、ドリフトを防ぐコツです。
+
+## TypeScript セットアップ
+
+現行の clasp 3.x は TypeScript の自動トランスパイルをサポートしていません。つまり「clasp に `.ts` を投げれば勝手に `.gs` に変換してくれる」という旧 2.x の挙動は無くなっており、**自分でビルドしてから push する**構成が標準です。
+
+最低限の構成は次のとおり。
+
+```bash
+npm init -y
+npm install --save-dev typescript @types/google-apps-script
+```
+
+`tsconfig.json` はこんな雰囲気です。
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "none",
+    "lib": ["ES2020"],
+    "types": ["google-apps-script"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true
+  },
+  "include": ["src/**/*.ts"]
+}
+```
+
+`.clasp.json` 側は `rootDir` をビルド後の `dist` に向けます。
+
+```json
+{
+  "scriptId": "xxxxxxxxxxxxxxxxxxxxxxxxx",
+  "rootDir": "./dist"
+}
+```
+
+ビルドと push を npm scripts にまとめておくと楽です。
+
+```json
+{
+  "scripts": {
+    "build": "tsc",
+    "push": "npm run build && clasp push",
+    "deploy": "npm run build && clasp push && clasp deploy"
+  }
+}
+```
+
+bundler を噛ませたい場合は `esbuild` や `rollup-plugin-gas` を使って 1 ファイルに束ねる構成もあります。ただし GAS はトップレベル関数しか UI からトリガーできないので、**エントリポイントの関数はグローバルに公開される形**にする必要があります。この辺は bundler 設定のハマりどころです。
+
+## Claude Code との連携で何が変わるか
+
+ここからが本題です。ローカル化が済めば、GAS プロジェクトは Claude Code にとって普通の TypeScript リポジトリに見えます。つまり、Claude Code の強みがほぼそのまま適用できる。
+
+### 1. CLAUDE.md に GAS 固有のルールを刻む
+
+プロジェクトルートに `CLAUDE.md` を置いて、GAS 特有の制約を明文化します。これは [ハーネスエンジニアリング](/knowledge/ai-tools/claude-code-introduction/) の基本動作と同じで、AI に毎回同じ注意書きを渡す手間を省く仕組みです。
+
+```markdown
+# プロジェクト規約
+- ランタイムは GAS V8。Node.js の API（fs, path, process）は使用不可
+- 外部 HTTP は UrlFetchApp を使う（axios / fetch は動かない）
+- 非同期は使わない。GAS は同期実行モデル
+- エラーは try/catch で拾い、Logger.log でスタックを残す
+- エントリポイント関数は src/main.ts にまとめる
+- push 前に npm run build を通すこと
+```
+
+これを置いておくだけで、Claude Code が「`await fetch(...)` を書いてきてしまう」事故がほぼ消えます。GAS と Node.js の差分は AI がハマりがちなポイントなので、ここを先回りで教え込むのが効きます。
+
+### 2. スプレッドシート操作の定型コードを自動生成
+
+「シート A の B 列から C 列を読み取り、重複を除いてシート B に書き出して」みたいな雑な依頼で、型付きコードが即座に出てきます。`SpreadsheetApp.getActiveSpreadsheet().getSheetByName(...)` の戻り値が `Sheet | null` であることを踏まえた null チェック付きコードが返ってくるのは、型情報が載っているからこそです。
+
+### 3. 既存スクリプトのリファクタリング・型付け
+
+`.gs` からローカル化した直後のコードは `var` まみれで関数も巨大、というのがよくあるパターンです。Claude Code に「`src/legacy.ts` を関数単位に分割し、型を付けて」と頼むと、TDD 的に小さく分解してくれます。私は毎回 `noImplicitAny` を ON にしてから依頼して、未解決の型を順に潰していくアプローチを取っています。
+
+### 4. テストコード生成
+
+GAS そのものは `SpreadsheetApp` などのグローバルが依存注入できず、厳密なユニットテストが難しい領域です。そこで **ビジネスロジックを純関数に切り出す → その純関数だけを vitest でテストする**、という設計を Claude Code に指示します。
+
+```typescript
+// src/lib/dedupe.ts  ← 純関数。vitest で単体テスト可能
+export const dedupeByKey = <T, K>(rows: T[], key: (row: T) => K): T[] => {
+  const seen = new Set<K>();
+  return rows.filter((row) => {
+    const k = key(row);
+    if (seen.has(k)) return false;
+    seen.add(k);
+    return true;
+  });
+};
+
+// src/main.ts  ← GAS の入り口。ここは薄く保つ
+const runDedupe = (): void => {
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("source");
+  if (!sheet) throw new Error("source シートが見つかりません");
+  const values = sheet.getDataRange().getValues();
+  const unique = dedupeByKey(values, (row) => row[0]);
+  // ... 書き出し処理
+};
+```
+
+この「**GAS 境界を薄く、ロジックを純関数に**」というパターンを `CLAUDE.md` に書いておくと、以降のコード生成がすべてこの形に揃います。
+
+### 5. エラーハンドリング・ロギング統一
+
+`logger.ts` のような共通ロガーを作り、`Logger.log` を直接呼ばないルールを敷きます。Claude Code に「全関数を logger 経由に書き換え、呼び出し時点でのコンテキスト（関数名・引数サマリ）を残して」と頼むと、一括で揃います。ここも AI 補助が効く典型です。
+
+## 実践ワークフロー
+
+1 日の流れはだいたいこうなります。
+
+```bash
+# 1. リモートの最新を取り込む（他の開発者が触った可能性に備える）
+clasp pull
+
+# 2. 機能ブランチを切る
+git checkout -b feat/dedupe-sheet
+
+# 3. Claude Code を起動して編集
+claude
+
+# 4. ビルドしてローカルで型チェック
+npm run build
+
+# 5. 動作確認のために push
+clasp push
+
+# 6. script.google.com から関数を実行、または clasp run で実行
+clasp run runDedupe
+
+# 7. 問題なければコミット & PR
+git add .
+git commit -m "feat: シート重複除去処理を追加"
+git push origin feat/dedupe-sheet
+
+# 8. PR レビュー → main マージ → GitHub Actions で本番プロジェクトに clasp push
+```
+
+ポイントは **「ローカルが真、リモートは投影先」という運用を崩さないこと**。誰かが Web エディタで直接いじり始めた瞬間、ドリフトが始まって地獄が口を開けます。
+
+## ハマりどころと対策
+
+- **認証失敗 (`invalid_grant`)**: `~/.clasprc.json` を削除して `clasp login` をやり直す。複数アカウントを切り替えたい場合は `clasp login --creds` でサービスアカウント的な運用もできる。
+- **`User has not enabled the Apps Script API`**: [User Settings](https://script.google.com/home/usersettings) で API を ON にする。組織アカウントだと管理者ブロックされているケースがあるので注意。
+- **`push` しても反映されない**: `.claspignore` で除外されている可能性。clasp 2.2.0 以降は `rootDir` 外を自動で無視するので、ディレクトリ構成を見直す。
+- **ローカルとリモートのドリフト**: Web エディタでの直接編集を封じる。どうしても必要なら、作業前に必ず `clasp pull` してからローカルに反映する運用を徹底する。
+- **TypeScript と GAS の非互換**: `import` / `export` は GAS ランタイムに存在しない。モジュール解決は bundler か、ファイル単位の分割のみ使用し、`module: "none"` 相当で書く。
+- **`appsscript.json` の手動編集が必要なケース**: OAuth スコープを明示したいとき、ライブラリ依存を追加したいときなど。Web エディタから触らず、ローカルで編集して push するのが原則。
+
+## 個人的にハマったTips
+
+- **クォートの扱い**: GAS エディタからコピペしたコードに「全角ダブルクォート」が混入していることがある。TypeScript 化の際、lint が落ちて気付く。置換で一括修正する前提で動く。
+- **`Logger.log` vs `console.log`**: V8 ランタイムでは `console.log` が使えるが、出力先は Cloud Logging。`Logger.log` は Apps Script のエグゼキューション画面。どちらに出したいか意識しないと「ログが見当たらない」で時間を溶かす。私はプロジェクトごとにどちらを使うか `CLAUDE.md` で固定しています。
+- **`clasp run` の制約**: 事前にプロジェクトを GCP プロジェクトに紐付け、OAuth スコープを `appsscript.json` で宣言しておかないと動かない。個人開発では「`push` して script.google.com から実行」のほうが結果的に早い場面も多い。
+- **`clasp push --force`**: リモートの差分を容赦なく上書きする。CI から叩くときは必須だが、ローカルで安易に打つとリモートの手作業変更が消える。**GitHub Actions 用のコマンド**と割り切る。
+
+## まとめ
+
+clasp と Claude Code を組み合わせることで、GAS は「片手間で書く雑なスクリプト」から「ちゃんと型が効く・テストできる・レビューできる」環境に一気に格上げできます。セットアップ当日はいろいろ詰まるかもしれませんが、**一度整えた設定とワークフローは別プロジェクトにも流用できる**ので、投資対効果は極めて高い領域です。
+
+- 補完と型が効く
+- Git に乗る
+- AI がプロジェクト文脈を理解した状態で編集に参加できる
+- チームで PR ベースのレビューができる
+
+これだけ揃えば、GAS は普通に「モダンな TypeScript プロジェクト」として扱えます。社内ツールやスプレッドシート自動化を書き続けるなら、今から clasp 化する価値は十分にあります。
+
+## 参考リンク
+
+- [google/clasp (GitHub)](https://github.com/google/clasp)
+- [Use the command-line interface with clasp | Google for Developers](https://developers.google.com/apps-script/guides/clasp)
+- [TypeScript | Apps Script](https://developers.google.com/apps-script/guides/typescript)
+- [Claude Code Docs](https://docs.claude.com/en/docs/claude-code/overview)
+- [@types/google-apps-script](https://www.npmjs.com/package/@types/google-apps-script)

--- a/src/content/knowledge/web-development/gas-best-practices.mdx
+++ b/src/content/knowledge/web-development/gas-best-practices.mdx
@@ -1,0 +1,341 @@
+---
+title: "Google Apps Script 実践ガイド — デプロイ・バージョン管理・ハマりどころ"
+description: "GASの基本操作からデプロイ方式の違い、HEAD vs バージョン付きデプロイのハマりどころ、クオータ制限の回避テクニック、権限スコープのベストプラクティスまで、実務でつまずく要点を体系的に解説します。"
+category: "web-development"
+tags: ["google-apps-script", "gas", "deployment", "best-practices", "google-workspace", "javascript"]
+sortOrder: 0
+createdAt: 2026-04-13
+author: "田中省伍"
+---
+
+## GASとは何か
+
+Google Apps Script（以下 GAS）は、Googleが提供する**サーバーレスのスクリプト実行環境**です。Google Workspace（Sheets・Docs・Gmail・Calendar・Driveなど）の自動化や、軽量なWebアプリ・APIの構築に使われます。最大の特徴は以下の4点です。
+
+- **無料で始められる**: Googleアカウントさえあれば、サーバーのプロビジョニングも課金設定も不要です
+- **Google Workspaceとの密結合**: SpreadsheetやGmailに対して、SDKの初期化なしで直接APIを叩けます
+- **V8ランタイム**: 2020年から標準化された V8 ベースのランタイムでモダンJavaScript（ES2015+、アロー関数、`let`/`const`、分割代入、`class`、テンプレートリテラルなど）が利用可能です。旧 Rhino ランタイムは 2025年2月に非推奨化され、2026年1月31日以降は実行されなくなりました
+- **トリガーによる自動実行**: 時刻ベース・イベントベースのトリガーで定期実行やユーザー操作への応答を実装できます
+
+サーバーを持たずにちょっとした業務自動化を組むには今でも最有力の選択肢ですが、実務で使うとデプロイ周りやクオータ制限で独特のハマりどころがあります。本記事ではそこを中心に整理します。
+
+## 基本操作
+
+### script.google.com とスタンドアロン/コンテナバインド
+
+GAS プロジェクトには2種類あります。
+
+- **スタンドアロン**: `script.google.com` から直接作成するプロジェクト。単体のWebアプリや定期バッチに向く
+- **コンテナバインド**: Spreadsheet や Doc の「拡張機能 → Apps Script」から作るプロジェクト。親ドキュメントに紐付き、`SpreadsheetApp.getActiveSpreadsheet()` のようなアクティブコンテキストが取れる
+
+### appsscript.json（マニフェスト）
+
+プロジェクトの設定を宣言するJSONファイルです。エディタ上では歯車アイコンから「`appsscript.json` マニフェストファイルをエディタで表示する」を有効にすると編集できます。
+
+```json
+{
+  "timeZone": "Asia/Tokyo",
+  "dependencies": {
+    "enabledAdvancedServices": []
+  },
+  "exceptionLogging": "STACKDRIVER",
+  "runtime": "V8",
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/spreadsheets.currentonly",
+    "https://www.googleapis.com/auth/script.external_request"
+  ],
+  "webapp": {
+    "access": "MYSELF",
+    "executeAs": "USER_DEPLOYING"
+  }
+}
+```
+
+`runtime` は明示的に `"V8"` にしておくと事故が起きません。`oauthScopes` は後述するセキュリティの要です。
+
+### トリガーの種類
+
+| 種類 | 用途 | 例 |
+|---|---|---|
+| シンプルトリガー | 関数名で自動認識される。権限が限られる | `onOpen()`, `onEdit()`, `doGet()`, `doPost()` |
+| インストーラブルトリガー | コードまたはUIから明示的に登録。フル権限で動く | Gmail送信や外部APIを伴う `onEdit` 処理 |
+| 時刻ベーストリガー | cron相当。分・時間・日・週単位で設定 | 毎朝9時に集計バッチ |
+| イベントベーストリガー | Form送信、Calendar更新など | フォーム送信時にSlackへ通知 |
+
+**注意**: シンプルトリガーは権限が制限されており、Gmail送信やUrlFetchなど認可が必要な処理は実行できません。認可が要る処理はインストーラブルトリガーを使ってください。
+
+## デプロイ方式の使い分け
+
+GASのデプロイタイプは大きく4種類あり、用途によって使い分けます。
+
+| デプロイタイプ | 用途 | アクセス方法 | 典型シナリオ |
+|---|---|---|---|
+| **Web アプリ** | HTTPエンドポイントとして公開 | URL（`/exec`）| フォーム受付、Slack Webhook受信、社内ダッシュボード |
+| **API 実行可能** | Apps Script API 経由で関数を呼ぶ | OAuth認証したクライアント | 外部システムからのRPC呼び出し |
+| **アドオン** | Workspace各アプリの拡張 | Workspace Marketplace | Sheetsのカスタムサイドバー |
+| **ライブラリ** | 他のGASプロジェクトから `import` | スクリプトID経由で参照 | 共通ユーティリティの配布 |
+
+一般的な業務自動化では「時刻ベーストリガー + スタンドアロン」か「Web アプリ + `doPost`」のどちらかで9割がた事足ります。アドオンはMarketplace公開やOAuth審査など手間が多いので、本当に必要な時だけ選びましょう。
+
+## バージョン管理の罠（最重要）
+
+ここがGAS最大のハマりどころです。「コードを直したのに、本番のWebアプリに反映されない」という現象は、ほぼ全員が一度は踏みます。
+
+### 前提: バージョンとデプロイは別概念
+
+まず用語を整理します。
+
+- **バージョン（version）**: スクリプトの**静的なスナップショット**。一度作ると変更不可（immutable）。Gitで言えばタグに近い
+- **デプロイ（deployment）**: 特定のバージョン（または HEAD）を指すエンドポイント。ユーザーがアクセスするURLは「デプロイ」に紐付く
+
+つまり「コードを保存する」「バージョンを発行する」「デプロイを更新する」は**それぞれ別の操作**です。
+
+### HEAD デプロイとバージョン付きデプロイ
+
+| 種類 | 反映タイミング | 用途 |
+|---|---|---|
+| **HEAD デプロイ（`/dev` URL）** | 保存した瞬間に最新コードへ同期 | 開発者自身のテスト専用 |
+| **バージョン付きデプロイ（`/exec` URL）** | デプロイを更新するまで固定 | 本番公開用 |
+
+公式ドキュメントでも「HEAD デプロイは公開用途に使うな（Don't use head deployments for public use）」と明言されています。
+
+### よくあるシナリオ: 「修正したのに反映されない」
+
+典型的な詰まり方はこうです。
+
+1. Web アプリを「新しいデプロイ」で発行し、`/exec` で終わるURLを関係者に配布
+2. このとき裏で「バージョン 1」が作られ、デプロイはバージョン 1 を指している
+3. 翌日コードを修正して保存
+4. `/exec` のURLを叩いても、昨日のコードのまま動く ← **ここでハマる**
+
+**理由**: `/exec` のデプロイは「バージョン 1」のスナップショットを指しており、エディタで保存しただけでは更新されません。HEAD デプロイ（`/dev`）なら最新コードを見ていますが、こちらはスクリプト所有者しか実行できません。
+
+### 正しい更新手順
+
+公開用の `/exec` URLを更新する場合の流れです。
+
+1. エディタ右上の「デプロイ」→「**デプロイを管理**」を開く
+2. 対象デプロイの鉛筆アイコンをクリック
+3. 「バージョン」ドロップダウンで「**新バージョン**」を選択
+4. 説明を書いて「デプロイ」を押す
+
+ここで「新しいデプロイ」を選ぶと**URL が別物になる**ので注意してください。既存URLを使い続けたい場合は必ず「デプロイを管理」から既存デプロイを編集します。
+
+### 「新バージョン発行」と「新規デプロイ」の違い
+
+| 操作 | URL | バージョン | 使いどころ |
+|---|---|---|---|
+| 既存デプロイを編集 → 新バージョン | 同じ | 新規作成 | 通常の本番更新 |
+| 新しいデプロイを作成 | 別物 | 新規作成 | ステージング環境を別URLで持ちたい時 |
+
+チームで運用するなら「`Production` と `Staging` の2つのデプロイを維持し、検証済みバージョンを Production に昇格する」という運用がおすすめです。デプロイ管理画面で各デプロイがどのバージョンを指しているか一覧できるので、そこを運用ドキュメントに絡めておくと事故が減ります。
+
+### clasp を使う場合
+
+CLIツールの `clasp` を使えばCI/CDにも組み込めますが、同じ罠があります。
+
+```bash
+# 既存デプロイを更新（URLを維持）
+clasp deploy --deploymentId <既存のデプロイID> --description "v2: バグ修正"
+
+# 新しいデプロイを作成（新URLが発行される）
+clasp deploy --description "staging"
+```
+
+`--deploymentId` を指定しないと毎回新規デプロイが発行される点に注意してください。
+
+## 実行時間とクオータ制限
+
+GASには厳格なクオータがあり、**知らずに書くと本番で突然死にます**。公式の "Quotas for Google Services" をベースに、特に重要なものを押さえます。
+
+### 主要な制限（2026年時点）
+
+| 項目 | Consumer | Workspace |
+|---|---|---|
+| スクリプト実行時間（1回あたり） | 6分 | 6分 |
+| カスタム関数実行時間 | 30秒 | 30秒 |
+| トリガー総実行時間（1日あたり） | 90分 | 6時間 |
+| UrlFetch 呼び出し数（1日あたり） | 20,000 | 100,000 |
+| 同時実行数（ユーザーあたり） | 30 | 30 |
+| プロパティ読み書き（1日あたり） | 50,000 | 500,000 |
+
+特に引っかかりやすいのは**6分のスクリプト実行時間制限**です。スプレッドシートの大量行を処理したり、Drive の全ファイルを走査したりするとすぐ到達します。
+
+### 6分制限の回避: 分割実行 + トリガーチェーン
+
+代表的な対策は、**進捗を `PropertiesService` に保存しながら、時刻ベーストリガーで再開する**パターンです。
+
+```javascript
+const MAX_RUNTIME_MS = 5 * 60 * 1000; // 5分で安全に切り上げ
+
+function processLargeDataset() {
+  const props = PropertiesService.getScriptProperties();
+  const startRow = Number(props.getProperty('lastProcessedRow') || 1);
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheets()[0];
+  const lastRow = sheet.getLastRow();
+  const startTime = Date.now();
+
+  for (let row = startRow; row <= lastRow; row++) {
+    if (Date.now() - startTime > MAX_RUNTIME_MS) {
+      // 残り時間がなくなったら進捗を保存して次回の自分をスケジュール
+      props.setProperty('lastProcessedRow', String(row));
+      scheduleContinuation();
+      return;
+    }
+    try {
+      processRow(sheet, row);
+    } catch (err) {
+      // 握りつぶさず、失敗行を記録して次へ
+      console.error(`row ${row} failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  // 完走したらチェックポイントを消す
+  props.deleteProperty('lastProcessedRow');
+}
+
+function scheduleContinuation() {
+  // 既存の継続トリガーを掃除してから新規登録する
+  ScriptApp.getProjectTriggers()
+    .filter((t) => t.getHandlerFunction() === 'processLargeDataset')
+    .forEach((t) => ScriptApp.deleteTrigger(t));
+
+  ScriptApp.newTrigger('processLargeDataset')
+    .timeBased()
+    .after(60 * 1000)
+    .create();
+}
+```
+
+ポイントは以下です。
+
+- `MAX_RUNTIME_MS` は6分ちょうどではなく**5分程度に余裕を持たせる**。行処理が途中で打ち切られるとデータ不整合になります
+- 再開用のトリガーを登録する前に**古いトリガーを掃除する**。トリガーには上限（スクリプトあたり20個）があり、リークすると詰まります
+- エラーは try/catch で補足し、失敗行を記録して処理を続行する。1行失敗で全体停止させない
+
+### UrlFetch の節約
+
+外部APIを叩く場合、1日あたりの呼び出し数だけでなく**毎リクエストのレイテンシ**がトータルの実行時間を圧迫します。`UrlFetchApp.fetchAll()` でまとめて並列実行するのが基本テクニックです。
+
+## 権限スコープとセキュリティ
+
+GASは便利な反面、**デフォルトで必要以上に広いスコープを要求しがち**です。ここを放置すると、ユーザーに「このスクリプトはGmailを送信・閲覧できます」のような怖い同意画面が出ます。
+
+### 最小スコープの原則
+
+対策は2段構えです。
+
+1. **`appsscript.json` の `oauthScopes` に明示列挙する**: 自動検出に任せず、必要なものだけ手で書く
+2. **現在のドキュメント限定のスコープを使う**: Sheetsバインド型なら `spreadsheets.currentonly`、Docsバインド型なら `documents.currentonly` を選ぶ
+
+Sheetsコンテナバインドで `@OnlyCurrentDoc` を関数コメントに付けると、自動検出時に `spreadsheets` ではなく `spreadsheets.currentonly` へ絞り込まれます。
+
+```javascript
+/**
+ * @OnlyCurrentDoc
+ */
+function onEdit(e) {
+  // このシートだけをいじるならフルスコープは不要
+}
+```
+
+### Web アプリの実行ユーザー設定
+
+`webapp.executeAs` の選択がセキュリティを左右します。
+
+| 値 | 挙動 | リスク |
+|---|---|---|
+| `USER_DEPLOYING` | デプロイした人の権限で動く | アクセスしたユーザーに所有者のデータが見える |
+| `USER_ACCESSING` | アクセスしたユーザーの権限で動く | ユーザーごとに認可フローが走る |
+
+社内ツールで「自分のSpreadsheetを誰でも更新できるようにしたい」のようなケースでは `USER_DEPLOYING` を選びますが、この場合**Webアプリ側で誰がアクセスしているかをきちんと検証**しないと、ただの公開書き込みエンドポイントになります。認証は `Session.getActiveUser().getEmail()` で取れますが、これはドメイン内でしか機能しない点に注意してください。
+
+### シークレットの保管
+
+APIキーや外部サービスのトークンは**絶対にコードにハードコードしない**でください。`PropertiesService.getScriptProperties()` に格納するのが定番です。
+
+```javascript
+function getSlackWebhookUrl() {
+  const url = PropertiesService.getScriptProperties().getProperty('SLACK_WEBHOOK_URL');
+  if (!url) {
+    throw new Error('SLACK_WEBHOOK_URL が未設定です。プロジェクトの設定から登録してください。');
+  }
+  return url;
+}
+```
+
+起動時に未設定を検出してエラーを投げることで、沈黙の失敗を防げます。
+
+### PropertiesService と CacheService の使い分け
+
+どちらも key-value ストアですが、性質が異なります。
+
+| 項目 | PropertiesService | CacheService |
+|---|---|---|
+| 永続性 | 削除するまで保持 | 最大6時間（デフォルト25分） |
+| 用途 | 設定値・認証情報・進捗チェックポイント | APIレスポンスの一時キャッシュ |
+| 読み取り速度 | 標準 | PropertiesService の約10倍高速 |
+| スコープ | Script / User / Document | Script / User / Document |
+
+**使い分けの原則**: 永続的な真実の源は PropertiesService（または外部DB）、それを高速化する一時コピーが CacheService、です。CacheService は勝手に消えるので、消えたら困るデータを置いてはいけません。
+
+## ロギング・デバッグ
+
+GASのログは3種類あり、用途が少しずつ違います。
+
+| API | 保存先 | 保持期間 | 用途 |
+|---|---|---|---|
+| `Logger.log()` | スクリプトエディタのログ | セッション内 | 対話的デバッグ |
+| `console.log()` | Cloud Logging（Stackdriver） | 一定期間保持 | 本番の継続監視 |
+| `console.error()` | Cloud Logging + エラーレポート | 同上 | アラート対象 |
+
+本番運用なら `console.log` / `console.error` を使ってください。エディタの「実行数」画面から Cloud Logging に飛べます。
+
+### エラー通知の自動化
+
+バッチの失敗に気づかないのが一番怖いので、以下のパターンを入れておくと安心です。
+
+```javascript
+function runDailyBatch() {
+  try {
+    doWork();
+  } catch (err) {
+    const message = err instanceof Error ? err.stack ?? err.message : String(err);
+    console.error(message);
+    notifySlack(`[GAS] 日次バッチが失敗しました: ${message}`);
+    throw err; // 実行履歴上も失敗として残すため再スロー
+  }
+}
+```
+
+Apps Script の「トリガー」画面から「失敗時にメール通知」を有効にする方法もありますが、通知頻度を制御しにくいので、Slackなどに直接投げる方が実務的です。
+
+## ベストプラクティスまとめ
+
+実務で効く要点をチェックリストにまとめます。
+
+- [ ] `appsscript.json` の `runtime` を `"V8"` に明示している
+- [ ] `oauthScopes` を手で列挙し、最小権限になっている（`@OnlyCurrentDoc` の活用も検討）
+- [ ] 本番用の `/exec` URLと開発用の `/dev` URLを混同していない
+- [ ] コード修正後、「デプロイを管理 → 既存デプロイ編集 → 新バージョン」で反映している
+- [ ] ステージング用と本番用のデプロイを分けている
+- [ ] 6分を超えうる処理は分割実行 + トリガーチェーンで設計している
+- [ ] 再開用トリガーの掃除を忘れていない（トリガー数上限20）
+- [ ] UrlFetch は `fetchAll()` でバッチ化している
+- [ ] シークレットは `PropertiesService` に入れ、未設定時にエラーを投げる
+- [ ] `console.error` を使い、Cloud Logging で本番エラーを監視している
+- [ ] バッチ失敗を Slack などの通知チャネルに転送している
+- [ ] try/catch でエラーを握りつぶしていない（最低限 `console.error` する）
+
+## 参考リンク
+
+- [Create and manage deployments | Apps Script](https://developers.google.com/apps-script/concepts/deployments)
+- [Versions | Apps Script](https://developers.google.com/apps-script/guides/versions)
+- [Quotas for Google Services | Apps Script](https://developers.google.com/apps-script/guides/services/quotas)
+- [Authorization Scopes | Apps Script](https://developers.google.com/apps-script/concepts/scopes)
+- [Best Practices | Apps Script](https://developers.google.com/apps-script/guides/support/best-practices)
+- [Troubleshooting | Apps Script](https://developers.google.com/apps-script/guides/support/troubleshooting)
+- [Class CacheService | Apps Script](https://developers.google.com/apps-script/reference/cache/cache-service)
+- [Migrate your Apps Script projects to V8 runtime before Jan 31, 2026](https://discuss.google.dev/t/migrate-your-apps-script-projects-to-v8-runtime-before-jan-31-2026/260396)
+- [Google Apps Script Quotas & Workarounds (2026) — FolderPal](https://folderpal.io/articles/google-apps-script-quotas-and-workarounds-2026-breaking-limits-on-drive-automation)
+- [Enhancing Security in Apps Script — DEV Community](https://dev.to/googleworkspace/enhancing-security-in-apps-script-5ii)


### PR DESCRIPTION
## Summary
ナレッジベースに Google Apps Script (GAS) 関連の記事を2本追加しました。

### 記事1: Google Apps Script 実践ガイド — デプロイ・バージョン管理・ハマりどころ
- 配置: \`src/content/knowledge/web-development/gas-best-practices.mdx\`
- カテゴリ: web-development（このカテゴリ初の記事）
- sortOrder: 0
- 内容: GASとは / 基本操作 / デプロイ方式の使い分け / **バージョン管理の罠（最重要セクション）** / クオータ制限の回避 / OAuthスコープ / ロギング / ベストプラクティスまとめ

特に「HEADと番号付きバージョンの違い」「修正したのに本番が反映されない」現象を厚く解説。\`/exec\` vs \`/dev\`、新規デプロイ vs 既存デプロイ更新の差、\`PropertiesService\` チェックポイント+トリガーチェーンによる6分制限回避など実用的な内容を含む。

### 記事2: GAS × clasp × Claude Code でローカル開発体験を最高にする
- 配置: \`src/content/knowledge/ai-tools/gas-clasp-claude-code-workflow.mdx\`
- カテゴリ: ai-tools
- sortOrder: 1（既存の \`claude-code-introduction\` が sortOrder 0）
- 内容: script.google.comの辛さ / clasp導入 / 4つのメリット / TypeScriptセットアップ / **Claude Codeとの連携で何が変わるか** / 実践ワークフロー / ハマりどころ / 個人的Tips

clasp 3.x の TypeScript 自動トランスパイル廃止、Node.js 20以上必須など2026年時点の最新情報を反映。

## リサーチソース
両記事ともウェブリサーチ（公式ドキュメント、最新ブログ、GitHub）で2025-2026年情報を確認の上で執筆。

## Test plan
- [x] \`npm run build\` ビルド成功（0 errors）
- [x] \`/knowledge/web-development/gas-best-practices/\` ページ生成確認
- [x] \`/knowledge/ai-tools/gas-clasp-claude-code-workflow/\` ページ生成確認
- [x] \`/knowledge/tags/gas/\` タグページ自動生成確認
- [ ] デプロイ後、各記事ページの目視確認
- [ ] サイドバーで sortOrder 順に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)