### PR TITLE
feat: ナレッジベースにサブカテゴリ機能を追加

### DIFF
--- a/src/components/knowledge/ArticleSidebar.astro
+++ b/src/components/knowledge/ArticleSidebar.astro
@@ -11,17 +11,34 @@ interface Props {
   currentSlug: string;
   categoryLabel: string;
   categorySlug: KnowledgeCategory;
+  subcategorySlug?: string;
+  subcategoryLabel?: string;
 }
 
-const { articles, currentSlug, categoryLabel, categorySlug } = Astro.props;
+const {
+  articles,
+  currentSlug,
+  categoryLabel,
+  categorySlug,
+  subcategorySlug,
+  subcategoryLabel,
+} = Astro.props;
+
+const headingLabel = subcategoryLabel ?? categoryLabel;
+const headingHref = subcategorySlug
+  ? `/knowledge/${categorySlug}/${subcategorySlug}`
+  : `/knowledge/${categorySlug}`;
+const articleBasePath = subcategorySlug
+  ? `/knowledge/${categorySlug}/${subcategorySlug}`
+  : `/knowledge/${categorySlug}`;
 ---
 
-<nav class="text-sm" aria-label={`${categoryLabel} の記事一覧`}>
+<nav class="text-sm" aria-label={`${headingLabel} の記事一覧`}>
   <a
-    href={`/knowledge/${categorySlug}`}
+    href={headingHref}
     class="block text-xs font-semibold uppercase tracking-wider text-muted-foreground hover:text-teal-600 transition-colors mb-3"
   >
-    {categoryLabel}
+    {headingLabel}
   </a>
   <ol class="space-y-1 border-l border-border">
     {
@@ -30,7 +47,7 @@ const { articles, currentSlug, categoryLabel, categorySlug } = Astro.props;
         return (
           <li>
             <a
-              href={`/knowledge/${categorySlug}/${article.slug}`}
+              href={`${articleBasePath}/${article.slug}`}
               class:list={[
                 "block px-3 py-1.5 -ml-px border-l transition-colors leading-snug",
                 isCurrent

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -15,6 +15,7 @@ const knowledge = defineCollection({
       "context-engineering",
       "harness-engineering",
     ]),
+    subcategory: z.string().optional(),
     tags: z.array(z.string()).default([]),
     sortOrder: z.number().int().default(0),
     createdAt: z.coerce.date(),

--- a/src/data/knowledge.ts
+++ b/src/data/knowledge.ts
@@ -1,4 +1,9 @@
-import type { CategoryMeta, ExternalArticle } from "@/types";
+import type {
+  CategoryMeta,
+  ExternalArticle,
+  KnowledgeCategory,
+  SubcategoryMeta,
+} from "@/types";
 
 export const categories: CategoryMeta[] = [
   {
@@ -49,6 +54,19 @@ export const categories: CategoryMeta[] = [
     icon: "settings",
   },
 ];
+
+export const subcategories: Partial<
+  Record<KnowledgeCategory, SubcategoryMeta[]>
+> = {
+  "ai-tools": [
+    {
+      slug: "agents",
+      label: "AIエージェント",
+      description:
+        "Claude Code、Codex、ChatGPT、Gemini、ClaudeなどのLLMアシスタント・AIエージェントツール",
+    },
+  ],
+};
 
 // 外部プラットフォームに公開した記事
 // 記事を追加する場合はここにエントリを追加する

--- a/src/layouts/KnowledgeLayout.astro
+++ b/src/layouts/KnowledgeLayout.astro
@@ -20,6 +20,8 @@ interface Props {
   title: string;
   description: string;
   category: KnowledgeCategory;
+  subcategorySlug?: string;
+  subcategoryLabel?: string;
   tags: string[];
   createdAt: Date;
   updatedAt?: Date;
@@ -34,6 +36,8 @@ const {
   title,
   description,
   category,
+  subcategorySlug,
+  subcategoryLabel,
   tags,
   createdAt,
   updatedAt,
@@ -46,6 +50,25 @@ const {
 
 const categoryMeta = categories.find((c) => c.slug === category);
 const categoryLabel = categoryMeta?.label ?? category;
+
+const articleBasePath = subcategorySlug
+  ? `/knowledge/${category}/${subcategorySlug}`
+  : `/knowledge/${category}`;
+const backLinkLabel = subcategoryLabel ?? categoryLabel;
+
+const breadcrumbItems = [
+  { label: "Knowledge Base", href: "/knowledge" },
+  { label: categoryLabel, href: `/knowledge/${category}` },
+  ...(subcategorySlug && subcategoryLabel
+    ? [
+        {
+          label: subcategoryLabel,
+          href: `/knowledge/${category}/${subcategorySlug}`,
+        },
+      ]
+    : []),
+  { label: title },
+];
 
 const formattedCreatedAt = createdAt.toLocaleDateString("ja-JP", {
   year: "numeric",
@@ -79,13 +102,7 @@ const jsonLd = JSON.stringify({
   </Fragment>
   <article class="py-20 px-4">
     <div class="max-w-6xl mx-auto">
-      <Breadcrumb
-        items={[
-          { label: "Knowledge Base", href: "/knowledge" },
-          { label: categoryLabel, href: `/knowledge/${category}` },
-          { label: title },
-        ]}
-      />
+      <Breadcrumb items={breadcrumbItems} />
 
       <div class="lg:flex lg:gap-10 lg:items-start">
         <aside
@@ -96,6 +113,8 @@ const jsonLd = JSON.stringify({
             currentSlug={currentSlug}
             categoryLabel={categoryLabel}
             categorySlug={category}
+            subcategorySlug={subcategorySlug}
+            subcategoryLabel={subcategoryLabel}
           />
         </aside>
 
@@ -146,7 +165,7 @@ const jsonLd = JSON.stringify({
             {
               previous ? (
                 <a
-                  href={`/knowledge/${category}/${previous.slug}`}
+                  href={`${articleBasePath}/${previous.slug}`}
                   class="group block p-4 rounded-2xl border border-border hover:border-teal-500/60 hover:bg-teal-50/30 transition-colors"
                 >
                   <span class="block text-xs text-muted-foreground mb-1">
@@ -163,7 +182,7 @@ const jsonLd = JSON.stringify({
             {
               next ? (
                 <a
-                  href={`/knowledge/${category}/${next.slug}`}
+                  href={`${articleBasePath}/${next.slug}`}
                   class="group block p-4 rounded-2xl border border-border hover:border-teal-500/60 hover:bg-teal-50/30 transition-colors text-right sm:text-right"
                 >
                   <span class="block text-xs text-muted-foreground mb-1">
@@ -181,10 +200,10 @@ const jsonLd = JSON.stringify({
 
           <footer class="mt-8">
             <a
-              href={`/knowledge/${category}`}
+              href={articleBasePath}
               class="text-teal-600 hover:text-teal-700 transition-colors inline-flex items-center gap-1"
             >
-              ← {categoryLabel} の記事一覧に戻る
+              ← {backLinkLabel} の記事一覧に戻る
             </a>
           </footer>
         </div>

--- a/src/pages/knowledge/[category]/[subcategory]/[slug].astro
+++ b/src/pages/knowledge/[category]/[subcategory]/[slug].astro
@@ -2,7 +2,7 @@
 import type { GetStaticPaths, InferGetStaticPropsType } from "astro";
 import { getCollection, render } from "astro:content";
 import KnowledgeLayout from "@/layouts/KnowledgeLayout.astro";
-import { categories } from "@/data/knowledge";
+import { categories, subcategories } from "@/data/knowledge";
 import {
   getPublishedArticles,
   getArticlesByCategoryAndSubcategory,
@@ -20,16 +20,18 @@ export const getStaticPaths = (async () => {
     .filter(
       (entry) =>
         validCategories.has(entry.data.category as KnowledgeCategory) &&
-        entry.data.subcategory === undefined,
+        entry.data.subcategory !== undefined,
     )
     .map((entry) => {
       const slug = entry.id.split("/").pop() as string;
       const category = entry.data.category as KnowledgeCategory;
-      const sameCategoryArticles = getArticlesByCategoryAndSubcategory(
+      const subcategory = entry.data.subcategory as string;
+      const sameSubArticles = getArticlesByCategoryAndSubcategory(
         allEntries,
         category,
+        subcategory,
       );
-      const sidebarArticles = sameCategoryArticles.map((e) => ({
+      const sidebarArticles = sameSubArticles.map((e) => ({
         slug: e.id.split("/").pop() as string,
         title: e.data.title,
       }));
@@ -37,15 +39,22 @@ export const getStaticPaths = (async () => {
         allEntries,
         entry.id,
         category,
+        subcategory,
+      );
+      const subcategoryMeta = (subcategories[category] ?? []).find(
+        (s) => s.slug === subcategory,
       );
       return {
         params: {
           category,
+          subcategory,
           slug,
         },
         props: {
           entry,
           currentSlug: slug,
+          subcategorySlug: subcategory,
+          subcategoryLabel: subcategoryMeta?.label ?? subcategory,
           sidebarArticles,
           previous: previous
             ? {
@@ -66,8 +75,15 @@ export const getStaticPaths = (async () => {
 
 type Props = InferGetStaticPropsType<typeof getStaticPaths>;
 
-const { entry, currentSlug, sidebarArticles, previous, next } =
-  Astro.props as Props;
+const {
+  entry,
+  currentSlug,
+  subcategorySlug,
+  subcategoryLabel,
+  sidebarArticles,
+  previous,
+  next,
+} = Astro.props as Props;
 const { Content } = await render(entry);
 ---
 
@@ -75,6 +91,8 @@ const { Content } = await render(entry);
   title={entry.data.title}
   description={entry.data.description}
   category={entry.data.category as KnowledgeCategory}
+  subcategorySlug={subcategorySlug}
+  subcategoryLabel={subcategoryLabel}
   tags={entry.data.tags}
   createdAt={entry.data.createdAt}
   updatedAt={entry.data.updatedAt}

--- a/src/pages/knowledge/[category]/[subcategory]/index.astro
+++ b/src/pages/knowledge/[category]/[subcategory]/index.astro
@@ -1,0 +1,100 @@
+---
+import type { GetStaticPaths } from "astro";
+import { getCollection } from "astro:content";
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import SectionHeader from "@/components/ui/SectionHeader.astro";
+import Breadcrumb from "@/components/knowledge/Breadcrumb.astro";
+import ArticleCard from "@/components/knowledge/ArticleCard.astro";
+import { categories, subcategories } from "@/data/knowledge";
+import {
+  getArticlesByCategoryAndSubcategory,
+  toUnifiedFromInternal,
+} from "@/utils/knowledge";
+import type { CategoryMeta, SubcategoryMeta } from "@/types";
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const paths: Array<{
+    params: { category: string; subcategory: string };
+    props: { category: CategoryMeta; subcategory: SubcategoryMeta };
+  }> = [];
+  for (const cat of categories) {
+    const subs = subcategories[cat.slug] ?? [];
+    for (const sub of subs) {
+      paths.push({
+        params: { category: cat.slug, subcategory: sub.slug },
+        props: { category: cat, subcategory: sub },
+      });
+    }
+  }
+  return paths;
+};
+
+interface Props {
+  category: CategoryMeta;
+  subcategory: SubcategoryMeta;
+}
+
+const { category, subcategory } = Astro.props;
+const allEntries = await getCollection("knowledge");
+const entries = getArticlesByCategoryAndSubcategory(
+  allEntries,
+  category.slug,
+  subcategory.slug,
+);
+const articles = entries.map(toUnifiedFromInternal);
+---
+
+<BaseLayout
+  title={`${subcategory.label} | ${category.label} | Knowledge Base | shogoworks`}
+  description={subcategory.description}
+>
+  <section class="py-20 px-4">
+    <div class="max-w-5xl mx-auto">
+      <Breadcrumb
+        items={[
+          { label: "Knowledge Base", href: "/knowledge" },
+          { label: category.label, href: `/knowledge/${category.slug}` },
+          { label: subcategory.label },
+        ]}
+      />
+
+      <SectionHeader
+        title={subcategory.label}
+        subtitle={subcategory.description}
+      />
+
+      {
+        articles.length > 0 ? (
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {articles.map((article, i) => (
+              <div class={`animate-on-scroll stagger-${(i % 5) + 1}`}>
+                <ArticleCard
+                  title={article.title}
+                  description={article.description}
+                  categoryLabel={subcategory.label}
+                  tags={article.tags}
+                  createdAt={article.createdAt}
+                  href={article.href}
+                  isExternal={article.isExternal}
+                  platform={article.platform}
+                />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div class="text-center py-16 animate-on-scroll">
+            <p class="text-muted-foreground text-lg">
+              このサブカテゴリにはまだ記事がありません。
+            </p>
+            <a
+              href={`/knowledge/${category.slug}`}
+              class="inline-block mt-4 text-teal-600 hover:text-teal-700 transition-colors"
+            >
+              ← {category.label} に戻る
+            </a>
+          </div>
+        )
+      }
+    </div>
+  </section>
+</BaseLayout>

--- a/src/pages/knowledge/[category]/index.astro
+++ b/src/pages/knowledge/[category]/index.astro
@@ -6,7 +6,10 @@ import SectionHeader from "@/components/ui/SectionHeader.astro";
 import Breadcrumb from "@/components/knowledge/Breadcrumb.astro";
 import ArticleCard from "@/components/knowledge/ArticleCard.astro";
 import { categories, externalArticles } from "@/data/knowledge";
-import { mergeArticlesByCategory } from "@/utils/knowledge";
+import {
+  mergeArticlesByCategory,
+  getSubcategories,
+} from "@/utils/knowledge";
 import type { CategoryMeta } from "@/types";
 
 export const getStaticPaths: GetStaticPaths = async () => {
@@ -22,11 +25,16 @@ interface Props {
 
 const { category } = Astro.props;
 const allEntries = await getCollection("knowledge");
-const articles = mergeArticlesByCategory(
+const allCategoryArticles = mergeArticlesByCategory(
   externalArticles,
   allEntries,
   category.slug,
 );
+// カテゴリ直下の記事のみを表示（サブカテゴリ内の記事はサブカテゴリページで扱う）
+const articles = allCategoryArticles.filter(
+  (a) => a.subcategory === undefined,
+);
+const subcategoryList = getSubcategories(category.slug);
 ---
 
 <BaseLayout
@@ -43,6 +51,31 @@ const articles = mergeArticlesByCategory(
       />
 
       <SectionHeader title={category.label} subtitle={category.description} />
+
+      {
+        subcategoryList.length > 0 && (
+          <div class="mb-12">
+            <h2 class="text-lg font-semibold text-foreground mb-4">
+              サブカテゴリ
+            </h2>
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {subcategoryList.map((sub) => (
+                <a
+                  href={`/knowledge/${category.slug}/${sub.slug}`}
+                  class="block p-5 rounded-2xl border border-border hover:border-teal-500/60 hover:bg-teal-50/30 transition-colors"
+                >
+                  <h3 class="font-semibold text-foreground mb-1">
+                    {sub.label}
+                  </h3>
+                  <p class="text-sm text-muted-foreground line-clamp-2">
+                    {sub.description}
+                  </p>
+                </a>
+              ))}
+            </div>
+          </div>
+        )
+      }
 
       {
         articles.length > 0 ? (
@@ -62,7 +95,7 @@ const articles = mergeArticlesByCategory(
               </div>
             ))}
           </div>
-        ) : (
+        ) : subcategoryList.length === 0 ? (
           <div class="text-center py-16 animate-on-scroll">
             <p class="text-muted-foreground text-lg">
               このカテゴリにはまだ記事がありません。
@@ -74,7 +107,7 @@ const articles = mergeArticlesByCategory(
               ← Knowledge Base に戻る
             </a>
           </div>
-        )
+        ) : null
       }
     </div>
   </section>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -101,6 +101,12 @@ export interface CategoryMeta {
   icon: string;
 }
 
+export interface SubcategoryMeta {
+  slug: string;
+  label: string;
+  description: string;
+}
+
 export type ArticlePlatform = "zenn" | "qiita" | "note";
 
 export interface ExternalArticle {

--- a/src/utils/knowledge.ts
+++ b/src/utils/knowledge.ts
@@ -1,5 +1,10 @@
-import type { KnowledgeCategory, ExternalArticle, ArticlePlatform } from "@/types";
-import { categories } from "@/data/knowledge";
+import type {
+  KnowledgeCategory,
+  ExternalArticle,
+  ArticlePlatform,
+  SubcategoryMeta,
+} from "@/types";
+import { categories, subcategories } from "@/data/knowledge";
 
 interface KnowledgeEntry {
   id: string;
@@ -7,6 +12,7 @@ interface KnowledgeEntry {
     title: string;
     description: string;
     category: string;
+    subcategory?: string;
     tags: string[];
     sortOrder: number;
     createdAt: Date;
@@ -23,6 +29,7 @@ export interface UnifiedArticle {
   title: string;
   description: string;
   category: KnowledgeCategory;
+  subcategory?: string;
   tags: string[];
   sortOrder: number;
   createdAt: Date;
@@ -54,16 +61,21 @@ export function toUnifiedFromExternal(
 /** MDX記事をUnifiedArticleに変換 */
 export function toUnifiedFromInternal(entry: KnowledgeEntry): UnifiedArticle {
   const slug = entry.id.split("/").pop() as string;
+  const { category, subcategory } = entry.data;
+  const href = subcategory
+    ? `/knowledge/${category}/${subcategory}/${slug}`
+    : `/knowledge/${category}/${slug}`;
   return {
     id: entry.id,
     title: entry.data.title,
     description: entry.data.description,
-    category: entry.data.category as KnowledgeCategory,
+    category: category as KnowledgeCategory,
+    subcategory,
     tags: entry.data.tags,
     sortOrder: entry.data.sortOrder,
     createdAt: entry.data.createdAt,
     source: "internal",
-    href: `/knowledge/${entry.data.category}/${slug}`,
+    href,
     isExternal: false,
   };
 }
@@ -135,6 +147,29 @@ export function getArticlesByCategory<T extends KnowledgeEntry>(
   );
 }
 
+/**
+ * カテゴリ＋サブカテゴリで記事をフィルタする。
+ * subcategory 省略時はカテゴリ直下（subcategory 未指定）の記事のみを返す。
+ */
+export function getArticlesByCategoryAndSubcategory<T extends KnowledgeEntry>(
+  entries: T[],
+  category: KnowledgeCategory,
+  subcategory?: string,
+): T[] {
+  return getArticlesByCategory(entries, category).filter((entry) =>
+    subcategory === undefined
+      ? entry.data.subcategory === undefined
+      : entry.data.subcategory === subcategory,
+  );
+}
+
+/** 指定カテゴリに登録されたサブカテゴリメタ情報を返す */
+export function getSubcategories(
+  category: KnowledgeCategory,
+): SubcategoryMeta[] {
+  return subcategories[category] ?? [];
+}
+
 /** 全タグと出現回数を取得する（公開記事のみ、件数降順→タグ名昇順） */
 export function getAllTags<T extends KnowledgeEntry>(
   entries: T[],
@@ -160,13 +195,21 @@ export function getArticlesByTag<T extends KnowledgeEntry>(
   );
 }
 
-/** 同カテゴリ内で前後の記事を返す（sortOrder順） */
+/**
+ * 同カテゴリ（または同サブカテゴリ）内で前後の記事を返す（sortOrder順）。
+ * subcategory 省略時はカテゴリ直下の記事のみを対象にする。
+ */
 export function getAdjacentArticles<T extends KnowledgeEntry>(
   entries: T[],
   currentId: string,
   category: KnowledgeCategory,
+  subcategory?: string,
 ): { previous: T | null; next: T | null } {
-  const list = getArticlesByCategory(entries, category);
+  const list = getArticlesByCategoryAndSubcategory(
+    entries,
+    category,
+    subcategory,
+  );
   const idx = list.findIndex((e) => e.id === currentId);
   if (idx === -1) return { previous: null, next: null };
   return {

--- a/tests/utils/knowledge.test.ts
+++ b/tests/utils/knowledge.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   getPublishedArticles,
   getArticlesByCategory,
+  getArticlesByCategoryAndSubcategory,
+  getSubcategories,
   getAdjacentArticles,
   getAllTags,
   getArticlesByTag,
@@ -21,6 +23,7 @@ interface MockEntry {
     title: string;
     description: string;
     category: string;
+    subcategory?: string;
     tags: string[];
     sortOrder: number;
     createdAt: Date;
@@ -402,5 +405,180 @@ describe("getUnifiedCategoryCount", () => {
     expect(counts["web-development"]).toBe(2); // 外部1 + 内部1
     expect(counts["devops"]).toBe(0);
     expect(counts["career"]).toBe(0);
+  });
+});
+
+// --- サブカテゴリ機能のテスト ---
+
+const mockEntriesWithSubcategory: MockEntry[] = [
+  {
+    id: "ai-tools/claude-code-intro",
+    data: {
+      title: "Claude Code入門",
+      description: "",
+      category: "ai-tools",
+      tags: ["claude"],
+      sortOrder: 0,
+      createdAt: new Date("2026-04-01"),
+      draft: false,
+      author: "田中省伍",
+    },
+  },
+  {
+    id: "ai-tools/agents/claude-code",
+    data: {
+      title: "Claude Code詳細",
+      description: "",
+      category: "ai-tools",
+      subcategory: "agents",
+      tags: ["claude"],
+      sortOrder: 0,
+      createdAt: new Date("2026-04-10"),
+      draft: false,
+      author: "田中省伍",
+    },
+  },
+  {
+    id: "ai-tools/agents/chatgpt",
+    data: {
+      title: "ChatGPT詳細",
+      description: "",
+      category: "ai-tools",
+      subcategory: "agents",
+      tags: ["chatgpt"],
+      sortOrder: 1,
+      createdAt: new Date("2026-04-11"),
+      draft: false,
+      author: "田中省伍",
+    },
+  },
+  {
+    id: "ai-tools/agents/gemini",
+    data: {
+      title: "Gemini詳細",
+      description: "",
+      category: "ai-tools",
+      subcategory: "agents",
+      tags: ["gemini"],
+      sortOrder: 2,
+      createdAt: new Date("2026-04-12"),
+      draft: true,
+      author: "田中省伍",
+    },
+  },
+  {
+    id: "web-development/astro-basics",
+    data: {
+      title: "Astro基礎",
+      description: "",
+      category: "web-development",
+      tags: ["astro"],
+      sortOrder: 0,
+      createdAt: new Date("2026-04-02"),
+      draft: false,
+      author: "田中省伍",
+    },
+  },
+];
+
+describe("getArticlesByCategoryAndSubcategory", () => {
+  it("正常系: subcategory省略時、カテゴリ直下（subcategory未指定）の記事のみ返すこと", () => {
+    const result = getArticlesByCategoryAndSubcategory(
+      mockEntriesWithSubcategory,
+      "ai-tools",
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("ai-tools/claude-code-intro");
+  });
+
+  it("正常系: subcategory指定時、そのサブカテゴリの公開記事のみ返すこと", () => {
+    const result = getArticlesByCategoryAndSubcategory(
+      mockEntriesWithSubcategory,
+      "ai-tools",
+      "agents",
+    );
+    expect(result).toHaveLength(2);
+    expect(result.every((e) => e.data.subcategory === "agents")).toBe(true);
+    expect(result.every((e) => !e.data.draft)).toBe(true);
+  });
+
+  it("正常系: sortOrder昇順でソートされること", () => {
+    const result = getArticlesByCategoryAndSubcategory(
+      mockEntriesWithSubcategory,
+      "ai-tools",
+      "agents",
+    );
+    expect(result[0].id).toBe("ai-tools/agents/claude-code");
+    expect(result[1].id).toBe("ai-tools/agents/chatgpt");
+  });
+
+  it("異常系: 該当記事がない場合、空配列を返すこと", () => {
+    const result = getArticlesByCategoryAndSubcategory(
+      mockEntriesWithSubcategory,
+      "ai-tools",
+      "non-existent",
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("異常系: 他カテゴリの記事が混ざらないこと", () => {
+    const result = getArticlesByCategoryAndSubcategory(
+      mockEntriesWithSubcategory,
+      "web-development",
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("web-development/astro-basics");
+  });
+});
+
+describe("getSubcategories", () => {
+  it("正常系: ai-tools のとき、agents メタ情報を返すこと", () => {
+    const result = getSubcategories("ai-tools");
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    const agents = result.find((s) => s.slug === "agents");
+    expect(agents).toBeDefined();
+    expect(agents?.label).toBe("AIエージェント");
+  });
+
+  it("正常系: サブカテゴリ未登録カテゴリのとき、空配列を返すこと", () => {
+    const result = getSubcategories("career");
+    expect(result).toEqual([]);
+  });
+});
+
+describe("getAdjacentArticles with subcategory", () => {
+  it("正常系: subcategory指定時、同じサブカテゴリ内で前後を返すこと", () => {
+    const result = getAdjacentArticles(
+      mockEntriesWithSubcategory,
+      "ai-tools/agents/chatgpt",
+      "ai-tools",
+      "agents",
+    );
+    expect(result.previous?.id).toBe("ai-tools/agents/claude-code");
+    expect(result.next).toBeNull();
+  });
+
+  it("正常系: subcategory省略時、カテゴリ直下記事のみで前後を返すこと", () => {
+    const result = getAdjacentArticles(
+      mockEntriesWithSubcategory,
+      "ai-tools/claude-code-intro",
+      "ai-tools",
+    );
+    expect(result.previous).toBeNull();
+    expect(result.next).toBeNull();
+  });
+});
+
+describe("toUnifiedFromInternal with subcategory", () => {
+  it("正常系: subcategoryありの場合、3階層hrefを生成すること", () => {
+    const result = toUnifiedFromInternal(mockEntriesWithSubcategory[1]);
+    expect(result.href).toBe("/knowledge/ai-tools/agents/claude-code");
+    expect(result.subcategory).toBe("agents");
+  });
+
+  it("正常系: subcategoryなしの場合、2階層hrefを生成すること", () => {
+    const result = toUnifiedFromInternal(mockEntriesWithSubcategory[0]);
+    expect(result.href).toBe("/knowledge/ai-tools/claude-code-intro");
+    expect(result.subcategory).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- ナレッジベースに `subcategory`（任意）概念を導入し、カテゴリ直下とサブカテゴリ内の両方に記事を配置できるようにした
- `ai-tools/agents`（AIエージェント）を初期サブカテゴリとして登録
- 既存記事は `subcategory` 未指定のまま動き後方互換を維持

## 変更点
- **スキーマ/型**: `content.config.ts` に `subcategory` 追加、`SubcategoryMeta` 型を新設
- **データ**: `src/data/knowledge.ts` に `subcategories` 定数（`ai-tools: agents` のみ登録）
- **ユーティリティ**: `getArticlesByCategoryAndSubcategory` / `getSubcategories` を新設、`getAdjacentArticles` と `toUnifiedFromInternal` を subcategory 対応
- **ルーティング**: `/knowledge/[category]/[subcategory]/index.astro` と `/[slug].astro` を新規追加。既存 `[category]/[slug].astro` は `subcategory === undefined` の記事のみ生成
- **UI**: `KnowledgeLayout`（パンくず4段）, `ArticleSidebar`（同サブカテゴリ内記事のみ表示）, `[category]/index.astro`（サブカテゴリカードセクション）
- **テスト**: 新規ユーティリティの正常系・異常系テストを追加

## Phase B
`ai-tools/agents/` 配下への5記事追加は別 PR で対応予定。

## Test plan
- [x] `npm run check` — 型エラー0
- [x] `npx vitest run` — 61 tests pass
- [x] `npm run build` — 全ページ生成成功（`/knowledge/ai-tools/agents/` 含む）
- [ ] `npm run preview` で以下を確認:
  - [ ] `/knowledge/ai-tools/` にサブカテゴリカードが表示される
  - [ ] `/knowledge/ai-tools/agents/` が空状態でも正常表示される
  - [ ] 既存 `/knowledge/ai-tools/claude-code-introduction/` のパンくず・前後ナビが壊れていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)