### PR TITLE
feat: 2026-05-06のAIニュース3記事を追加

### DIFF
--- a/src/content/ai-news/chatgpt-openai/gpt-5-5-instant.mdx
+++ b/src/content/ai-news/chatgpt-openai/gpt-5-5-instant.mdx
@@ -1,0 +1,36 @@
+---
+title: "GPT-5.5 InstantがChatGPTの新デフォルトモデルに"
+tool: "chatgpt-openai"
+toolLabel: "ChatGPT / OpenAI"
+date: 2026-05-05
+sourceUrl: "https://openai.com/index/gpt-5-5-instant/"
+summary: "OpenAIがGPT-5.5 Instantを発表し、ChatGPTのデフォルトモデルとして展開した。事実性、画像理解、STEM、検索判断、パーソナライズが改善されている。"
+impact: "ChatGPTの普段使い、社内手順、モデル選定、memory sourcesを含むパーソナライズ管理の説明に影響。"
+tags: ["chatgpt", "openai", "gpt-5-5-instant", "personalization", "model-update"]
+status: "candidate"
+relatedKnowledge:
+  - "/knowledge/ai-tools/chatgpt/overview"
+draft: false
+---
+
+## 何が変わったか
+
+OpenAIは2026年5月5日、GPT-5.5 InstantをChatGPTの新しいデフォルトモデルとして発表しました。
+
+GPT-5.3 Instantと比べて、事実性、画像アップロードの読み取り、STEM系の回答、Web検索を使うべき場面の判断、応答の簡潔さが改善されています。Plus / ProのWebユーザー向けには、過去チャット、ファイル、接続済みGmailなどを使ったパーソナライズも強化されています。
+
+同日にSystem Cardも公開され、GPT-5.5 Instantの安全性評価や高リスク領域での扱いが説明されています。
+
+## 影響
+
+ChatGPTを「とりあえずデフォルトで使う」場面の前提が変わります。社内マニュアルや教材でGPT-5.3 Instantを前提にしている箇所は、順次GPT-5.5 Instant前提へ書き換えが必要です。
+
+実務では性能改善以上に、パーソナライズの扱いが重要になります。回答に過去チャットや保存済みメモリが反映される場面が増えるため、古い前提が混ざっていないかをmemory sourcesで参照元から確認する運用もセットで説明したほうが安全です。
+
+## 教材化メモ
+
+Knowledgeへ直接独立記事を作るより、まずはAIニュースとして掲載するのが自然です。
+
+恒久教材へ反映するなら、ChatGPT概要、モデル一覧、料金・トークン、パーソナライズ設定、メモリ確認手順など、既存ページの前提が古くなる箇所だけを最小限更新します。
+
+参考: [GPT-5.5 Instant System Card](https://openai.com/index/gpt-5-5-instant-system-card/)

--- a/src/content/ai-news/claude/finance-agents.mdx
+++ b/src/content/ai-news/claude/finance-agents.mdx
@@ -1,0 +1,32 @@
+---
+title: "Claudeに金融サービス向けエージェントテンプレート"
+tool: "claude"
+toolLabel: "Claude"
+date: 2026-05-05
+sourceUrl: "https://www.anthropic.com/news/finance-agents"
+summary: "Anthropicが金融サービス向けにエージェントテンプレートを公開した。Claude Cowork、Claude Code、Claude Managed Agentsで、Skills、Connectors、Subagentsを組み合わせた業務フローとして利用できる。"
+impact: "金融、経理、リサーチ、KYC、資料作成など、業界特化型エージェントを設計する際の参考例になる。"
+tags: ["claude", "anthropic", "agents", "finance", "skills", "connectors", "subagents"]
+status: "candidate"
+relatedKnowledge:
+  - "/knowledge/ai-tools/claude/agent-skills"
+draft: false
+---
+
+## 何が変わったか
+
+Anthropicは2026年5月5日、金融サービス向けのエージェントテンプレートを公開しました。
+
+これらはClaude CoworkとClaude Codeではpluginとして、Claude Managed Agentsではcookbookとして利用できる構成です。業務手順を定義するSkills、業務データへ接続するConnectors、比較やレビューを担当するSubagentsを組み合わせる形になっています。
+
+## 影響
+
+Pitch builder、Meeting preparer、Earnings reviewer、Month-end closer、KYC screener、Valuation reviewerなど、金融業務に近い反復作業をエージェント化する参考になります。
+
+ただし、汎用的なClaude Agent Skills教材へ長く書き込むより、業界特化エージェントのニュースとして扱うほうが自然です。Knowledge側には「Skills単体ではなく、ConnectorsやSubagentsと組み合わせて業務フローを作る」という設計思想だけを残せば十分です。
+
+## 教材化メモ
+
+金融業務では、AIに完成まで丸投げするより、リサーチ、下書き、比較、レビュー、承認を分けて設計する観点が重要です。
+
+今後Knowledgeへ反映するなら、Claude Agent Skillsの記事に短い補足を入れるか、業界別エージェント設計の記事を別途作る段階で参照します。

--- a/src/content/ai-news/gemini/workspace-ai-control-center-meet-consent.mdx
+++ b/src/content/ai-news/gemini/workspace-ai-control-center-meet-consent.mdx
@@ -1,0 +1,34 @@
+---
+title: "Gemini for WorkspaceにAI control centerとMeet同意管理"
+tool: "gemini"
+toolLabel: "Gemini"
+date: 2026-05-05
+sourceUrl: "https://workspaceupdates.googleblog.com/2026/05/securely-manage-AI-and-agent-access-to-Workspace-data-with-the-AI-control-center.html"
+summary: "Google WorkspaceのAdmin consoleにAI control centerが追加され、AIとエージェントのWorkspaceデータアクセス管理を確認しやすくなった。MeetではGeminiメモ、録画、文字起こしの明示同意管理も追加されている。"
+impact: "Gemini for Workspaceを組織導入する際の管理、監査、同意取得、データアクセス設計に影響。"
+tags: ["gemini", "google-workspace", "admin-console", "ai-governance", "google-meet"]
+status: "candidate"
+relatedKnowledge:
+  - "/knowledge/ai-tools/gemini/workspace-features"
+draft: false
+---
+
+## 何が変わったか
+
+Google WorkspaceのAdmin consoleに、AI control centerが追加されました。管理者が、GeminiやAIエージェントによるWorkspaceデータアクセス、関連設定、利用状況を確認しやすくするための管理画面です。
+
+あわせてGoogle Meetでは、Take Notes with Gemini、録画、文字起こしを開始する前に、参加者の明示的な同意を求める管理設定も追加されています。
+
+## 影響
+
+Gemini for Workspaceの導入は、便利機能の有効化だけでなく、誰がAIを使えるか、どの業務データへアクセスできるか、会議参加者の同意をどう取るかまで含めて設計する必要があります。
+
+特にEnterprise環境では、AI利用状況、分類ラベル、trust rules、data protection rulesなどと組み合わせて確認する導線が重要になります。
+
+## 教材化メモ
+
+Knowledgeへ独立した「管理・ガバナンス入門」を新設するより、まずはAIニュースとして掲載します。
+
+恒久教材へ反映するなら、既存のGemini Workspace機能ページに、管理者が見るべき項目としてAI control centerとMeet同意管理を数行追記する程度が適切です。
+
+参考: [Require explicit consent for Take Notes with Gemini, recordings, and transcripts in Google Meet](https://workspaceupdates.googleblog.com/2026/04/require-explicit-consent-for-take-notes-with-Gemini-recordings-and-transcripts-in-Google-Meet.html)

--- a/src/content/knowledge/ai-tools/claude/agent-skills.mdx
+++ b/src/content/knowledge/ai-tools/claude/agent-skills.mdx
@@ -153,6 +153,19 @@ message = client.beta.messages.create(
 
 ---
 
+## 業務エージェント化の考え方
+
+Skillsは単体でも使えますが、実務ではConnectorsやSubagentsと組み合わせることで、より業務フローに近いエージェントを設計できます。
+
+業務フローへ落とし込むときは、次の設計思想を押さえる方が重要です。
+
+- 反復業務はSkillsに落とし込む
+- 業務データはConnectorsで統制された形で渡す
+- 比較・検証・レビューはSubagentsに分担させる
+- 最終成果物は人間が確認・承認してから使う
+
+---
+
 ## 参考リンク
 
 - [Agent Skills Documentation | Anthropic](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview)


### PR DESCRIPTION
## Summary

- ChatGPT / OpenAI: GPT-5.5 InstantがChatGPTの新デフォルトモデルになった件を速報記事化（`src/content/ai-news/chatgpt-openai/gpt-5-5-instant.mdx`）
- Claude: 金融サービス向けエージェントテンプレート公開を速報記事化（`src/content/ai-news/claude/finance-agents.mdx`）
- Gemini: Workspace Admin consoleのAI control centerとGoogle Meet明示同意管理を速報記事化（`src/content/ai-news/gemini/workspace-ai-control-center-meet-consent.mdx`）
- Knowledge: `claude/agent-skills.mdx` に「業務エージェント化の考え方」節を追記し、Skills/Connectors/Subagentsを組み合わせた業務フロー設計の方針を明文化

`docs/research/daily-ai-updates/2026-05-06.md` に記録された7件のうち、上記3件を記事化。残る4件（GPT-5.5 System Card / ChatGPT ads / Claude Code v2.1.129 / n8n@2.20.0）は本PRのスコープ外。

## Test plan

- [x] `npm run check` がエラー0件で通ること
- [ ] `npm run dev` を起動し、`/ai-news/chatgpt-openai/gpt-5-5-instant`, `/ai-news/claude/finance-agents`, `/ai-news/gemini/workspace-ai-control-center-meet-consent` の3ページが描画されること
- [ ] `/knowledge/ai-tools/claude/agent-skills` の追記節がレンダリングされること
- [ ] AIニュース一覧ページで新記事3件が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)