### PR TITLE
fix: AIニュースの「教材化候補」バッジを非表示にする

### DIFF
--- a/src/components/ai-news/StatusBadge.astro
+++ b/src/components/ai-news/StatusBadge.astro
@@ -8,7 +8,11 @@ interface Props {
 }
 
 const { status } = Astro.props;
-const meta = getAiNewsStatusMeta(status);
+
+const hiddenStatuses: AiNewsStatus[] = ["candidate"];
+const isHidden = hiddenStatuses.includes(status);
+
+const meta = isHidden ? null : getAiNewsStatusMeta(status);
 
 const variants: Record<AiNewsStatus, "default" | "blue" | "emerald"> = {
   captured: "default",
@@ -17,4 +21,4 @@ const variants: Record<AiNewsStatus, "default" | "blue" | "emerald"> = {
 };
 ---
 
-<Badge variant={variants[status]}>{meta.label}</Badge>
+{meta && <Badge variant={variants[status]}>{meta.label}</Badge>}


### PR DESCRIPTION
## Summary
- AIニュース一覧・詳細・カード表示で `candidate`（教材化候補）ステータスのバッジを描画しないようにした
- 教材化候補の管理はニュース公開面ではなく `ai-news-notes`（非公開コレクション）側のメモで行う運用に切り替えたため、外向けの体裁から外す
- `captured`（収集済み） / `promoted`（Knowledge反映済み）は従来通り表示
- 既存17本＋今後追加する記事の frontmatter は変更せず、`StatusBadge` 側で非表示制御することで一括対応

## 変更ファイル
- `src/components/ai-news/StatusBadge.astro`

## Test plan
- [ ] `npm run check` がパスする（実行済み: 0 errors / 0 warnings）
- [ ] `npx vitest run tests/utils/aiNews.test.ts` がパスする（実行済み: 6 passed）
- [ ] `npm run build` 成功
- [ ] `/ai-news` 一覧、`/ai-news/[tool]`、`/ai-news/[tool]/[slug]` のいずれにも「教材化候補」バッジが表示されないこと
- [ ] 他ステータス（`captured` / `promoted`）の記事があれば、そちらは引き続きバッジが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)