### PR TITLE
fix: ナビゲーションから重複する Contact リンクを削除

### DIFF
--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -7,5 +7,4 @@ export const navItems: NavItem[] = [
   { label: "About", href: "/about" },
   { label: "Portfolio", href: "/portfolio" },
   { label: "Skills", href: "/skills" },
-  { label: "Contact", href: "/contact" },
 ];

--- a/tests/data/navigation.test.ts
+++ b/tests/data/navigation.test.ts
@@ -16,8 +16,12 @@ describe("navigation データ", () => {
     }
   });
 
-  it("7つのナビ項目が定義されていること", () => {
-    expect(navItems).toHaveLength(7);
+  it("6つのナビ項目が定義されていること", () => {
+    expect(navItems).toHaveLength(6);
+  });
+
+  it("Contactリンクは Navbar の常設ボタンに集約するためナビ項目には含めないこと", () => {
+    expect(navItems.find((item) => item.href === "/contact")).toBeUndefined();
   });
 
   it("Knowledgeリンクが含まれていること", () => {


### PR DESCRIPTION
## Summary
- ナビバーに「Contact」と緑色の「お問い合わせ」ボタンが両方表示され、どちらも `/contact` を指していて入り口が二重になっていた
- `src/data/navigation.ts` から `{ label: "Contact", href: "/contact" }` を削除
- 既存の緑の「お問い合わせ」ボタン（`Navbar.astro` の Button）は従来通り残す

## 変更ファイル
- `src/data/navigation.ts`

## Test plan
- [ ] `npm run check` がパスする（実行済み: 0 errors / 0 warnings）
- [ ] `npm run build` 成功
- [ ] PCナビ・モバイルメニューいずれにも「Contact」項目が出ないこと
- [ ] 緑の「お問い合わせ」ボタンが従来通り表示され、`/contact` に遷移できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)