### PR TITLE
fix: AIニュース一覧の見出し文言から「教材化」表現を除去

### DIFF
--- a/src/pages/ai-news/index.astro
+++ b/src/pages/ai-news/index.astro
@@ -13,13 +13,13 @@ const counts = getAiNewsToolCount(entries);
 
 <BaseLayout
   title="AI News | shogoworks"
-  description="AIツールの公式アップデートを、Knowledge化する前の公開ログとして整理しています"
+  description="主要AIツールの公式アップデート情報を随時発信しています"
 >
   <section class="py-20 px-4">
     <div class="max-w-5xl mx-auto">
       <SectionHeader
         title="AI News"
-        subtitle="AIツールの公式アップデートを、教材化前の公開ログとして整理しています"
+        subtitle="主要AIツールの公式アップデート情報を随時発信しています"
       />
 
       <div class="mb-8 animate-on-scroll">


### PR DESCRIPTION
## Summary
- `/ai-news` のサブタイトルと meta description が「教材化前の公開ログ」「Knowledge化する前の公開ログ」となっており、内部運用の概念が外に漏れていた
- 教材化の管理は `ai-news-notes`（非公開コレクション）側に集約済みのため、公開面では「教材化」を打ち出さない方針に変更
- 文言を `主要AIツールの公式アップデート情報を随時発信しています` に統一（subtitle と meta description）

## 変更ファイル
- `src/pages/ai-news/index.astro`

## Test plan
- [ ] `npm run check` がパスする（実行済み: 0 errors / 0 warnings）
- [ ] `npm run build` 成功
- [ ] `/ai-news` の見出し下サブタイトルが新しい文言になっていること
- [ ] HTML の `<meta name="description">` も新しい文言になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)