### PR TITLE
feat: 2026-05-08〜09のAIニュース速報4件と教材化メモ2件を追加

### DIFF
--- a/src/content/ai-news-notes/claude-code/claude-code-v2-1-136.mdx
+++ b/src/content/ai-news-notes/claude-code/claude-code-v2-1-136.mdx
@@ -1,0 +1,25 @@
+---
+title: "Claude Code v2.1.136 / 137 教材化メモ"
+noteFor: "claude-code/claude-code-v2-1-136"
+date: 2026-05-09
+tags: ["claude-code", "mcp", "oauth", "auto-mode", "windows"]
+---
+
+Claude Code 教材の「実務運用・トラブルシューティング」と「Enterprise 運用設計」へ反映する。
+
+優先反映先:
+
+- `/knowledge/ai-tools/claude-code/daily-operations`
+- `/knowledge/ai-tools/claude-code/mcp`
+- `/knowledge/ai-tools/claude-code/auto-mode`
+
+教材化ポイント:
+
+- `/clear` 実行が `.mcp.json` ・プラグイン・claude.ai コネクタ MCP に与える影響と、v2.1.136 以前 / 以降の挙動差
+- 複数 MCP サーバーを同時に動かす場合の OAuth リフレッシュ競合パターン（チェックリスト化）
+- `settings.autoMode.hard_deny` の使い所：分類器の出力を信用しきれない業務（本番 DB / 決済 API / 顧客データ）の絶対ブロックルール例
+- redacted thinking ブロックが API 400 に化けるケースの再現条件と、Anthropic SDK 側の thinking ブロック仕様への接続
+- Windows + VSCode 利用者向けの「v2.1.136 をスキップして v2.1.137 へ直接更新する」運用ノート
+- WSL2 で Windows クリップボード画像 paste が PowerShell フォールバックを通る理屈（クロスバウンダリの仕組みを軽く解説）
+
+単独記事にするなら「Claude Code 自動モードを Enterprise で安全に動かす設計」を `hard_deny` 起点で書ける。

--- a/src/content/ai-news-notes/gemini/workspace-weekly-recap-2026-05-08.mdx
+++ b/src/content/ai-news-notes/gemini/workspace-weekly-recap-2026-05-08.mdx
@@ -1,0 +1,29 @@
+---
+title: "Google Workspace 2026-05-08 週次まとめ 教材化メモ"
+noteFor: "gemini/workspace-weekly-recap-2026-05-08"
+date: 2026-05-08
+tags: ["gemini", "workspace", "admin-console", "governance"]
+---
+
+Workspace 教材の「組織管理者向けガバナンス」と「Gemini × Docs/Meet」の章へ反映する。
+
+優先反映先:
+
+- `/knowledge/ai-tools/gemini/workspace-admin`
+- `/knowledge/ai-tools/gemini/google-docs`
+- `/knowledge/ai-tools/gemini/google-meet`
+
+教材化ポイント:
+
+- 「AI 制御センター」を、Workspace AI ガバナンス教材の起点（入口）として再構成
+- ポリシーで「Workspace データへのエージェントアクセス」をどう絞るかの段階別チェックリスト
+- Meet の録画 / 文字起こし / Gemini 利用時の「明示同意要求」を、社内ルール × UI 設定の整合事例として扱う
+- Docs の Gemini カスタム指示（持続適用）を、ChatGPT のシステムプロンプト・Claude の Style と比較
+- CSE × Drive API バルクインポート GA を、エンタープライズの「セキュアなデータ持ち込み」教材で扱う
+- Workspace Studio の言語拡張・Meet 開始ステップ拡張は、エージェントワークフロー教材の補助情報として扱う
+
+単独記事の候補:
+
+- 「Workspace AI 制御センターで何が設定できるのか」
+- 「Google Meet の AI 録画と同意設計」
+- 「Google Docs Gemini カスタム指示と他社システムプロンプトの違い」

--- a/src/content/ai-news/claude-code/claude-code-v2-1-136.mdx
+++ b/src/content/ai-news/claude-code/claude-code-v2-1-136.mdx
@@ -1,0 +1,60 @@
+---
+title: "Claude Code v2.1.136 / 137はMCP・OAuth・思考ブロックまわりの大型修正"
+tool: "claude-code"
+toolLabel: "Claude Code"
+date: 2026-05-09
+sourceUrl: "https://github.com/anthropics/claude-code/releases/tag/v2.1.136"
+summary: "Claude Code v2.1.136 では、`/clear` で MCP 設定が消える、複数 MCP 同時リフレッシュで OAuth トークンが落ちる、redacted thinking 後に 400 が出る、といった運用直撃のバグをまとめて修正。あわせて自動モード分類器の絶対ブロックを設定する `hard_deny` を追加。直後に出た v2.1.137 は Windows × VSCode 拡張のリグレッション修正。"
+impact: "MCP を使うチームと、Windows + VSCode で Claude Code を運用しているチームは、即時更新の価値がある。Enterprise 運用者は `hard_deny` で自動モードのガード設計を見直せる。"
+tags: ["claude-code", "mcp", "oauth", "extended-thinking", "windows", "release-note"]
+status: "candidate"
+relatedKnowledge:
+  - "/knowledge/ai-tools/claude-code/daily-operations"
+  - "/knowledge/ai-tools/claude-code/mcp"
+  - "/knowledge/ai-tools/claude-code/auto-mode"
+draft: false
+---
+
+## 要約
+
+Claude Code v2.1.136 が 2026-05-09 03:39 JST に公開され、その約5時間半後の 09:11 JST に v2.1.137 がパッチとして出ました。
+
+v2.1.136 は新機能2点（`hard_deny` と OTel feedback survey）に加えて、MCP・OAuth・拡張思考・WSL2・パス・UI など、運用で直撃する種類のバグをまとめて潰した大型リリースです。v2.1.137 は Windows × VSCode で 2.1.136 が起動しなくなったリグレッションのみを直すパッチです。
+
+## 何が変わったか
+
+新機能 / 設定追加（v2.1.136）
+
+- `settings.autoMode.hard_deny` で自動モード分類器の判断を上書きする「絶対ブロックルール」を定義可能
+- `CLAUDE_CODE_ENABLE_FEEDBACK_SURVEY_FOR_OTEL` で OTel セッション品質調査をエンタープライズで再有効化
+
+主要バグ修正（v2.1.136）
+
+- `/clear` の後に `.mcp.json` ・プラグイン・claude.ai コネクタの MCP サーバー定義がサイレント消失する問題
+- 複数 MCP サーバーを同時にリフレッシュしたときに OAuth トークンが失われる問題
+- 拡張思考（extended thinking）でツール呼び出し後に redacted thinking ブロックが続くと API 400 になる問題
+- プロジェクトパスにアンダースコアを含む場合に `--resume` / `--continue` がセッションを発見できない問題
+- WSL2 で Windows クリップボードからの画像 paste が動かない問題（PowerShell フォールバック経由で対応）
+- `@` ファイルピッカーが100件超のディレクトリや新規作成ファイルを検出できない問題
+- スラッシュコマンドダイアログのフッターヒント・スペーシング・矢印キースタイルを標準化
+
+v2.1.137 のパッチ
+
+- Windows で VSCode 拡張機能が `activate` に失敗する問題を修正
+
+## 業務インパクト
+
+このリリースの中身は、Claude Code を「単発で触る」用途では気づきにくく、「日常運用」しているチームほど効くタイプです。
+
+特に大きいのは MCP 周辺。`.mcp.json` やプラグインで MCP を組んでいる環境で `/clear` を実行すると、入れていたサーバー定義が黙って外れていた、というのが直っています。複数サーバーで OAuth リフレッシュが衝突するとトークンが消える件と合わせて、これまで「MCP がたまに動かなくなる」と感じていたチームには明確な体感差が出るはずです。
+
+`hard_deny` は、自動モードを Enterprise で本格運用する場合のガードレール設計が一段引き締まります。auto-classifier の判断より優先する「絶対ブロックルール」を持てるので、業務的に絶対通したくない操作（本番 DB への破壊系、特定 API の呼び出しなど）を分類器のミスから守れます。
+
+Windows + VSCode 環境を使っているチームは、v2.1.136 を入れるとそもそも拡張が起動しないので、v2.1.137 まで一気に上げる前提です。
+
+## 教材化視点
+
+- 「Claude Code が壊れた時の見る場所」教材に、`/clear` × MCP の落とし穴ケースを追加
+- `hard_deny` と既存 deny ルールの違いを auto-mode 教材で整理
+- redacted thinking と 400 エラーの関係は Anthropic SDK の thinking ブロック解説と接続
+- WSL2 / Windows / VSCode の組み合わせのトラブル切り分けガイド

--- a/src/content/ai-news/gemini/workspace-weekly-recap-2026-05-08.mdx
+++ b/src/content/ai-news/gemini/workspace-weekly-recap-2026-05-08.mdx
@@ -1,0 +1,51 @@
+---
+title: "Google Workspace 5月8日週次まとめ：管理コンソールにAI制御センター、Docs Geminiが持続カスタム指示、Meet録画に同意設定"
+tool: "gemini"
+toolLabel: "Gemini / Google Workspace"
+date: 2026-05-08
+sourceUrl: "https://workspaceupdates.googleblog.com/2026/05/weekly-recap-05-08-2026.html"
+summary: "Google Workspace Updates の週次リキャップ（2026-05-08）に9件のアップデートがまとまった。組織での AI 運用に直結するのは、管理コンソールの「AI 制御センター」追加、Google Docs の Gemini への持続的カスタム指示、Google Meet の録画 / 文字起こし / Gemini 利用時の参加者同意設定の3点。"
+impact: "Workspace を全社で使う組織の管理者は、AI ガバナンス設定の一段強化として「AI 制御センター」と「Meet 同意設定」を入口にレビューする価値がある。"
+tags: ["gemini", "workspace", "admin-console", "google-docs", "google-meet", "release-note"]
+status: "candidate"
+relatedKnowledge:
+  - "/knowledge/ai-tools/gemini/workspace-admin"
+  - "/knowledge/ai-tools/gemini/google-docs"
+  - "/knowledge/ai-tools/gemini/google-meet"
+draft: false
+---
+
+## 要約
+
+Google Workspace Updates の週次まとめ（2026-05-08 公開）で、AI 関連を中心に9件のアップデートが一気にロールアップされました。組織で Workspace AI を運用している側から見ると、特に効くのは管理コンソール側の機能と、Docs / Meet の Gemini 連携の挙動変更です。
+
+## 何が変わったか
+
+管理者・セキュリティ系
+
+- 管理コンソールに「AI 制御センター」が追加。生成 AI / エージェントの Workspace データアクセスを管理者がポリシーで制御
+- クライアント側暗号化（CSE）を使った Drive API バルクインポートが GA
+- Google Meet で録画 / 文字起こし / Gemini 利用時に参加者の明示同意を要求できる管理者設定
+
+エディタ / 会議 / コラボ系
+
+- Google Docs で Gemini への「カスタム指示」が会話間で持続適用される
+- Chrome の「スキル」機能でよく使うプロンプトを保存しワンクリック実行
+- Workspace Studio の Meet 開始ステップが拡張
+- 定員超過の Meet に新規参加者を自動でライブストリームへリダイレクト
+- Workspace Studio が7言語に拡張
+- Gmail「Help me write」がユーザーの文体・コンテキストを反映して強化
+
+## 業務インパクト
+
+「AI 制御センター」は、組織で生成 AI を扱うときの「入口の一本化」が前進しました。これまで Workspace の AI 関連設定は機能ごとに散らばっていましたが、エージェントを含めて Workspace データへどこまでアクセスさせるかをポリシーとして集約できる方向です。コンプライアンス・情報システム部門のレビュー対象になります。
+
+Meet の同意設定は、生成 AI 録画ポリシーを正面から議論したい組織にとって、技術的な裏付けになる機能です。録画・文字起こし・Gemini 利用時に「明示同意を要求」を設定できるので、社内ルールと UI 動作を整合させやすくなります。
+
+Docs の Gemini カスタム指示が「持続」になった点は、ChatGPT / Claude のシステムプロンプト相当が Google Docs にも入ってきた、と捉えると比較しやすい変化です。文書編集のルール（用語・トーン・テンプレート）を会話のたびに伝え直す必要がなくなります。
+
+## 教材化メモ
+
+- 「組織で生成 AI を扱う管理者の設定」教材で「AI 制御センター」を主軸に再構成
+- 「生成 AI 録画と同意」教材に Meet の同意設定を実装事例として追加
+- ChatGPT / Claude のシステムプロンプトと Docs Gemini のカスタム指示を比較する章

--- a/src/content/ai-news/github-copilot/copilot-cloud-agent-secrets.mdx
+++ b/src/content/ai-news/github-copilot/copilot-cloud-agent-secrets.mdx
@@ -1,0 +1,39 @@
+---
+title: "GitHub Copilot Cloud Agentに組織レベルのSecrets / Variables専用セクションが新設"
+tool: "github-copilot"
+toolLabel: "GitHub Copilot"
+date: 2026-05-08
+sourceUrl: "https://github.blog/changelog/2026-05-08-more-flexible-secrets-and-variables-for-copilot-cloud-agent"
+summary: "GitHub Copilot Cloud Agent 向けに、Actions とは独立した組織レベル Secrets / Variables セクションが追加された。複数リポジトリへの共有設定が可能になり、Actions のシークレット運用と切り離して権限スコープを設計できる。"
+impact: "Copilot Cloud Agent を全社展開しているチームは、Actions のシークレットと混在していた権限分離をやり直せる。組織の AI ガバナンス設計に直結する。"
+tags: ["github-copilot", "cloud-agent", "secrets", "enterprise", "release-note"]
+status: "candidate"
+relatedKnowledge:
+  - "/knowledge/ai-tools/github-copilot/cloud-agent"
+  - "/knowledge/ai-tools/github-copilot/enterprise-policy"
+draft: false
+---
+
+## 要約
+
+GitHub Copilot の Cloud Agent 向けに、組織レベルの Secrets / Variables を管理する専用セクションが追加されました。これまで Actions のシークレット領域と区別が曖昧だった部分が、Cloud Agent 専用として明示的に切り出されています。
+
+## 何が変わったか
+
+- 組織設定の Copilot 領域に Cloud Agent 専用 Secrets / Variables セクションが追加
+- 複数リポジトリにまたがって共有する設定が可能
+- Actions の Secrets / Variables と独立した権限管理
+
+## 業務インパクト
+
+これまで Cloud Agent から API キーや外部サービス資格情報を扱う場合、運用上は Actions のシークレットを流用するか、リポ単位で個別管理するかの選択になりがちでした。Actions と Cloud Agent では「いつ・どのコンテキストで・誰の権限で」動くかが違うので、本来は分けて管理した方が安全です。
+
+今回の更新で組織レベルの Cloud Agent 専用シークレット領域ができたことで、たとえば「Cloud Agent からは本番 API を叩けるが、Actions ワークフローからはステージング API しか叩けない」といった、エージェント向けの権限スコープ設計を独立して組めるようになります。
+
+Enterprise で AI エージェントを横断利用するチームは、この分離を前提にしたガバナンス設計を組むタイミングです。
+
+## 教材化メモ
+
+- Copilot Cloud Agent 運用教材に「Actions と Cloud Agent のシークレット分離設計」の章を追加
+- Enterprise の権限スコープ最小化の章で実例として扱える
+- AI エージェント全般の「秘密情報の扱い方」教材で、組織レベル × エージェント専用の二段構成を紹介

--- a/src/content/ai-news/github-copilot/grok-code-fast-1-eol.mdx
+++ b/src/content/ai-news/github-copilot/grok-code-fast-1-eol.mdx
@@ -1,0 +1,41 @@
+---
+title: "GitHub CopilotのGrok Code Fast 1が2026-05-15で廃止、代替はGPT-5 mini / Claude Haiku 4.5"
+tool: "github-copilot"
+toolLabel: "GitHub Copilot"
+date: 2026-05-08
+sourceUrl: "https://github.blog/changelog/2026-05-08-upcoming-deprecation-of-grok-code-fast-1"
+summary: "GitHub Copilot で選択できるモデルの一つだった Grok Code Fast 1 が 2026-05-15 に Chat / Edit / Agent / CLI / Code Review の全機能から廃止される。公式の代替推奨は GPT-5 mini と Claude Haiku 4.5。Enterprise / Organization 管理者は廃止前にポリシー設定で代替モデルを有効化しておく必要がある。"
+impact: "Grok Code Fast 1 を既定で使っていたチームは1週間以内に切り替えが必要。Enterprise ではモデルポリシー側を更新しないとユーザー側でモデルが選べなくなる。"
+tags: ["github-copilot", "model-deprecation", "grok", "enterprise", "release-note"]
+status: "candidate"
+relatedKnowledge:
+  - "/knowledge/ai-tools/github-copilot/models"
+  - "/knowledge/ai-tools/github-copilot/enterprise-policy"
+draft: false
+---
+
+## 要約
+
+GitHub Copilot で利用できるモデルの一つ、Grok Code Fast 1 が 2026-05-15 に全機能から廃止されます。
+
+GitHub 公式の changelog によると、対象は Copilot Chat / Edit / Agent / CLI / Code Review のすべて。代替モデルとしては GPT-5 mini もしくは Claude Haiku 4.5 への移行が推奨されています。
+
+## 何が変わったか
+
+- Grok Code Fast 1 が Copilot 全機能で 2026-05-15 に選択不可になる
+- 公式の代替推奨は GPT-5 mini / Claude Haiku 4.5
+- Enterprise / Organization では、モデルポリシーで代替モデルが有効化されている必要がある
+
+## 業務インパクト
+
+Grok Code Fast 1 を「速度優先」のデフォルトに置いていたチームは、廃止までに切り替えのリードタイムがほとんどありません。今回の changelog は 5/8 公開で、廃止まで実質1週間です。
+
+特に Enterprise / Organization の場合、ユーザーが UI で代替モデルを選ぼうとしても、管理者がポリシーで GPT-5 mini や Claude Haiku 4.5 を許可していなければ「選択肢に出ない」状態になります。管理者側の対応が先行で必要です。
+
+代替候補の比較は、応答速度・コスト・コードレビュー精度のどれを取るかで変わります。GPT-5 mini は OpenAI 系、Claude Haiku 4.5 は Anthropic 系で、Copilot CLI の Rubber Duck（5/7 のリリース）が複数モデル対応を拡張した流れと組み合わせると、モデル横断の運用設計を見直すいい機会になります。
+
+## 教材化メモ
+
+- Copilot のモデル選択戦略の章に「廃止のリードタイムが短い」ケースとして追加
+- Enterprise 管理者向け「モデルポリシー切替プレイブック」の事例
+- 速度系モデルの代替探索（GPT-5 mini / Claude Haiku 4.5 / Gemini Flash 系）の比較教材


### PR DESCRIPTION
## Summary

2026-05-08 10:00〜2026-05-09 14:00 JST の窓で公開された公式アップデートを巡回し、業務インパクトが高い4件を速報記事化、Claude Code と Gemini/Workspace の2件は教材化メモも作成した。

- **Claude Code v2.1.136 / 137**: MCP サーバーが `/clear` で消える致命バグ、複数 MCP 同時リフレッシュ時の OAuth トークン消失、redacted thinking 後の API 400 を修正。`settings.autoMode.hard_deny` を新設。直後の v2.1.137 は Windows × VSCode のリグレッション修正
- **GitHub Copilot — Grok Code Fast 1 廃止予告**: 2026-05-15 に全 Copilot 機能から廃止。代替は GPT-5 mini / Claude Haiku 4.5
- **GitHub Copilot — Cloud Agent Secrets / Variables**: 組織レベルで Cloud Agent 専用のシークレット領域が追加され、Actions と権限を分離設計可能に
- **Google Workspace Weekly Recap (2026-05-08)**: AI 制御センター、Docs Gemini の持続的カスタム指示、Meet の AI 録画同意設定など9件をまとめて反映

## 対象ファイル

- `src/content/ai-news/claude-code/claude-code-v2-1-136.mdx`
- `src/content/ai-news/github-copilot/grok-code-fast-1-eol.mdx`
- `src/content/ai-news/github-copilot/copilot-cloud-agent-secrets.mdx`
- `src/content/ai-news/gemini/workspace-weekly-recap-2026-05-08.mdx`
- `src/content/ai-news-notes/claude-code/claude-code-v2-1-136.mdx`
- `src/content/ai-news-notes/gemini/workspace-weekly-recap-2026-05-08.mdx`

なお `docs/research/daily-ai-updates/2026-05-09.md` および各ツールの `official-updates/*.md`（合計11件）は `.gitignore` 対象のためローカル運用ノートとして残置している。

## 保留・更新なし

- 保留: n8n@1.123.42 / 2.20.6（粒度小・本文取得不安定）、xAI/Grok 2件（公式ページ反映遅延）、OpenAI 5/8 ステータス障害、Anthropic × Akamai $1.8B 報道（公式声明未取得）
- 更新なし: ChatGPT 製品、Claude 公式 Release Notes / News、Genspark、Manus、Meta AI、Runway、ByteDance Seed、Dify

## Test plan

- [ ] `npm run check`（astro check）で frontmatter の Zod スキーマ違反がないこと
- [ ] `npm run dev` で /ai-news 配下に4記事が表示されること
- [ ] 既存 ai-news 記事へのリグレッションがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)