### PR TITLE
feat: 2026-05-08〜09のAIニュース追補3件（GPT-5.5-Cyber / Codex v0.130.0 / Workspace Studio日本語）

### DIFF
--- a/src/content/ai-news/chatgpt-openai/codex-v0-130-0.mdx
+++ b/src/content/ai-news/chatgpt-openai/codex-v0-130-0.mdx
@@ -1,0 +1,55 @@
+---
+title: "OpenAI Codex v0.130.0でリモート操作・プラグイン詳細にbundled hooks表示・AWS console-login認証に対応"
+tool: "chatgpt-openai"
+toolLabel: "ChatGPT / OpenAI"
+date: 2026-05-09
+sourceUrl: "https://github.com/openai/codex/releases/tag/rust-v0.130.0"
+summary: "OpenAI Codex の v0.130.0 が 2026-05-08 23:09 UTC（5/9 08:09 JST）に公開。`codex remote-control` でヘッドレス・リモート操作可能なアプリサーバーを起動できるエントリポイント、プラグイン詳細での bundled hooks 表示、AWS console-login 経由の Bedrock 認証、large thread のページング、画像参照の multi-environment 対応など、運用機能の拡張が中心。"
+impact: "Codex を CI / リモート実行・プラグイン経由運用しているチームに直接効く。Bedrock を AWS SSO 経由で使っている組織は認証フローが整い、プラグイン共有を組織内で回す運用がやりやすくなる。Hooks 機能自体は v0.124.0 で Stable 化済みだが、プラグインとの組み合わせで可視化が一段進んだ。"
+tags: ["openai-codex", "remote-control", "hooks", "plugins", "bedrock", "release-note"]
+status: "candidate"
+relatedKnowledge:
+  - "/knowledge/ai-tools/codex/cli-features"
+  - "/knowledge/ai-tools/codex/agent-skills"
+draft: false
+---
+
+## 要約
+
+OpenAI Codex の v0.130.0 が公開されました。リモート操作のための新しいエントリポイント、プラグイン経由の hooks 可視化、AWS console-login での Bedrock 認証など、運用や統合の足回りに効くアップデートが多めです。
+
+なお Codex の Hooks 機能そのものは v0.124.0（2026-04-22）で Stable 化済みです。今回の v0.130.0 で追加されたのは「プラグイン詳細でバンドルされた hooks を表示する」「プラグイン共有時にリンクメタデータと発見可能性のコントロールを公開する」という、可視化・共有運用側の拡張です。
+
+## 何が変わったか
+
+新機能
+
+- `codex remote-control` を追加。ヘッドレスでリモート操作可能なアプリサーバーを起動するシンプルなエントリポイント
+- プラグイン詳細にバンドルされた hooks を表示。プラグイン共有時にリンクメタデータと発見可能性コントロールを公開
+- アプリサーバークライアントで大規模スレッドをページング可能（unloaded / summary / full のターン項目ビュー）
+- Bedrock 認証で `aws login` プロファイルの AWS console-login 資格情報を利用可能
+- `view_image` がマルチ環境セッションでも選択された環境経由でファイル解決
+
+主なバグ修正
+
+- ライブのアプリサーバースレッドが再起動なしで設定変更を反映
+- apply-patch の partial failure を含めてターン diff が正しい状態を保つ
+- スレッド要約・リネーム・resume・fork パスを `ThreadStore` 経由で改善（ローカル rollout パスがないスレッドにも対応）
+- リモートコンパクションが v2 ストリーム向けに `response.processed` を発行、API キー利用の compact 要求では `service_tier` を送らない
+- Windows サンドボックスでサンドボックスユーザーがデスクトップランタイムバイナリキャッシュへアクセス可能に
+- `codex exec` 起動バナーから古い "research preview" 表記を削除
+
+## 業務インパクト
+
+`codex remote-control` の追加で、Codex を「ローカル CLI を立ち上げて使う」用途から、「リモートからヘッドレスで叩くサーバー」用途へ寄せやすくなりました。CI からの実行、社内ツールへの統合、別マシンからの操作などが整理しやすくなる方向です。
+
+プラグイン詳細で bundled hooks が表示されるようになった点は、組織内でプラグインを共有して運用しているチームに効きます。これまでプラグインに含まれた hooks は、入れてみるまで何が動くか把握しづらい部分がありましたが、共有時点で可視化されるので、レビューしてから配布する運用が組みやすくなります。
+
+Bedrock の AWS console-login 認証対応は、AWS SSO（IAM Identity Center）の `aws login` プロファイルで普段運用している組織が、Codex の Bedrock 連携を素直に使えるようになる変更です。これまで Bedrock を使うために専用の API キー運用に寄せていたチームは、認証フローを SSO に統合し直せます。
+
+## 教材化メモ
+
+- Codex の運用・統合教材に「`codex remote-control` を CI から叩くパターン」を追加
+- Codex × Bedrock × AWS SSO の認証統合の章
+- Codex Hooks 教材（既存 v0.124.0 ベース）に「プラグイン経由で hooks を共有・配布する運用」を追補
+- Claude Code との比較教材で、hooks の設定方式（Codex は `config.toml` インライン、Claude Code は `settings.json` + `.claude/hooks/`）の違いを整理

--- a/src/content/ai-news/chatgpt-openai/gpt-5-5-cyber-trusted-access.mdx
+++ b/src/content/ai-news/chatgpt-openai/gpt-5-5-cyber-trusted-access.mdx
@@ -1,0 +1,40 @@
+---
+title: "OpenAIがGPT-5.5-Cyberを限定プレビュー、Trusted Access for Cyberで承認組織だけが使える"
+tool: "chatgpt-openai"
+toolLabel: "ChatGPT / OpenAI"
+date: 2026-05-08
+sourceUrl: "https://openai.com/index/gpt-5-5-with-trusted-access-for-cyber/"
+summary: "OpenAI はサイバーセキュリティ業務向けに調整した GPT-5.5-Cyber を限定プレビューで公開。能力は GPT-5.5 と同等で、認可されたレッドチームやペネトレーションテスト、脆弱性検証など「公開モデルが断る種類の高リスク作業」を扱える許容幅にチューニングされている。アクセスは Trusted Access for Cyber プログラムの最高ティアに承認された組織と防衛者に限定される。"
+impact: "セキュリティベンダー・赤チーム・SOC・CSIRT は、これまで公開モデルでは断られていたワークロードを LLM に任せられる選択肢ができた。逆に「公開モデルで全部やる」発想だったチームは、この層と公開層で扱う仕事の線引きを設計し直す必要がある。"
+tags: ["openai", "gpt-5-5", "security", "limited-preview", "release-note"]
+status: "candidate"
+relatedKnowledge:
+  - "/knowledge/ai-tools/chatgpt-openai/models"
+  - "/knowledge/ai-tools/chatgpt-openai/safety-policy"
+draft: false
+---
+
+## 要約
+
+OpenAI が 2026-05-08 に GPT-5.5-Cyber の限定プレビュー提供を発表しました。サイバーセキュリティ業務向けにセーフガードを再調整した GPT-5.5 派生モデルで、Trusted Access for Cyber プログラムの最高ティアに承認された組織だけがアクセスできます。
+
+## 何が変わったか
+
+- 正式名称は GPT-5.5-Cyber。能力面はベースの GPT-5.5 と同等で、サイバー業務向けに「許容範囲」を広げたバリエーションという位置付け
+- 認可されたレッドチーム、ペネトレーションテスト、脆弱性検証、攻撃シナリオ分析など、公開モデルが断る種類の高リスクワークフローを扱える
+- アクセスは Trusted Access for Cyber プログラムの最高ティア承認組織・防衛者に限定
+- 個人アカウントで利用する場合、2026-06-01 以降は Advanced Account Security の有効化が必須
+
+## 業務インパクト
+
+セキュリティ事業者にとって、これまで「公開モデルでは断られて成立しなかったタスク」を LLM 側に寄せられる選択肢ができました。レッドチーム演習のシナリオ生成、脆弱性 PoC の補助、ログから攻撃手法を逆算する分析などが現実的な対象です。
+
+ただし「能力が劇的に上がるモデル」ではなく「許容範囲を広げるモデル」である点が重要です。GPT-5.5 と同等の推論能力で、検閲側の挙動が業務向けに緩んでいる、という構成です。能力アップを期待して入れると評価がズレます。
+
+導入する側は、Trusted Access for Cyber の承認プロセスと、利用範囲を明示する内部ポリシーの整備がまず先になります。CSIRT / SOC / レッドチームを抱えている組織は、ワークフローのどこを GPT-5.5-Cyber に寄せ、どこを公開モデル・社内モデルに残すかを線引きするタイミングです。
+
+## 教材化メモ
+
+- 「LLM の許容範囲とポリシー設計」教材で、能力ではなくセーフガード側を調整するアプローチの実例として扱う
+- セキュリティ業務向け LLM 比較（GPT-5.5-Cyber / Claude / オープンモデル）の章
+- Trusted Access for Cyber の承認プロセスと、組織側で必要な利用ポリシー整備の流れ

--- a/src/content/ai-news/gemini/workspace-studio-multilingual.mdx
+++ b/src/content/ai-news/gemini/workspace-studio-multilingual.mdx
@@ -1,0 +1,41 @@
+---
+title: "Google Workspace Studioが日本語を含む7言語に対応、UIはアカウント言語で自動切替"
+tool: "gemini"
+toolLabel: "Gemini / Google Workspace"
+date: 2026-05-08
+sourceUrl: "https://workspaceupdates.googleblog.com/2026/05/google-workspace-studio-available-in-more-languages.html"
+summary: "Google Workspace Studio（studio.workspace.google.com）が英語に加えてフランス語・ドイツ語・イタリア語・日本語・韓国語・ポルトガル語・スペイン語の7言語に対応した。Google アカウントの言語設定に応じて UI が自動で切り替わり、管理者操作は不要。展開は 2026-05-07 開始で Rapid / Scheduled Release ともに 1〜3 日でロールアウトされ、5/8〜5/9 の窓内に多くの組織で利用可能になった。"
+impact: "日本のチームが Workspace Studio を業務利用する際の言語的な障壁が下がる。これまで英語UIで止まっていたエージェント/オートメーション設計を、日本語ベースで運用部門に引き渡しやすくなる。"
+tags: ["gemini", "workspace-studio", "japanese", "i18n", "release-note"]
+status: "candidate"
+relatedKnowledge:
+  - "/knowledge/ai-tools/gemini/workspace-studio"
+draft: false
+---
+
+## 要約
+
+Google Workspace Studio が、英語に加えて 7 言語に対応しました。日本語が含まれているため、日本のチームが Workspace Studio を業務利用するときの言語的な障壁が一段下がります。
+
+公式の発表ポストは 2026-05-07 ですが、展開は Rapid / Scheduled Release ともに 1〜3 日でのロールアウトで、5/8 から 5/9 にかけて多くの組織の UI が日本語化された形になります。同日（5/8）の Workspace Updates Weekly Recap にもまとめられています。
+
+## 何が変わったか
+
+- Workspace Studio（studio.workspace.google.com）の UI が以下7言語に対応
+  - フランス語 / ドイツ語 / イタリア語 / 日本語 / 韓国語 / ポルトガル語 / スペイン語
+- UI 言語は Google アカウントの言語設定に応じて自動切替。管理者操作は不要
+- 対象エディション: Business Starter / Standard / Plus、Enterprise Standard / Plus、Education Fundamentals / Standard / Plus / Teaching and Learning
+
+## 業務インパクト
+
+Workspace Studio は、Workspace 内のエージェントワークフローを組み立てる入り口として位置付けが強くなっているプロダクトです。これまで UI が英語固定だったため、設計は IT / 情報システム側で済ませても、運用部門・現場ユーザーへの引き渡しでつまずく場面がありました。
+
+UI が日本語化されたことで、現場ユーザーが Workspace Studio 上で自分の業務に近いエージェントを観察したり、簡単な調整をしたりできる範囲が広がります。エージェントの設計と運用を切り分けて、設計だけ専門部門が担当する体制も組みやすくなります。
+
+なお同じ週の Workspace Updates では、管理コンソールの「AI 制御センター」、Google Docs の Gemini 持続的カスタム指示、Meet の AI 録画同意設定などもまとまって入っています。Workspace AI のガバナンス・エディタ・会議の各レイヤーが同時に整っているタイミングなので、組み合わせで全社展開を見直す価値があります。
+
+## 教材化メモ
+
+- Workspace Studio 入門教材を日本語スクリーンショットで作り直す
+- 「設計は専門部門 / 運用は現場部門」というロール分担の章で、UI 多言語化を実例として扱う
+- Workspace AI 全体（AI 制御センター・Docs Gemini・Meet 同意・Workspace Studio）を「同時期に整った1セット」として束ねた解説記事


### PR DESCRIPTION
## Summary

PR #113 の窓内（2026-05-08 10:00〜2026-05-09 14:00 JST）リサーチで漏れていた3件を、一次情報で裏取りして追補した。

- **GPT-5.5-Cyber 限定プレビュー** — OpenAI 公式ブログ `Scaling Trusted Access for Cyber with GPT-5.5`（2026-05-08）。Trusted Access for Cyber プログラムの最高ティア承認組織のみが利用可能なサイバーセキュリティ業務向けの GPT-5.5 派生モデル。能力は同等で、認可された赤チーム / ペネトレ / 脆弱性検証など公開モデルが断る種類のワークフローを許容範囲とした
- **OpenAI Codex v0.130.0** — `openai/codex` の GitHub Releases（2026-05-08T23:09Z = 5/9 08:09 JST、窓内）。`codex remote-control` 新規追加、プラグイン詳細での bundled hooks 表示、Bedrock の AWS console-login 認証対応、large thread のページング、`view_image` のマルチ環境対応など。Hooks 自体は v0.124.0 で Stable 化済みだが、プラグイン経由の可視化が一段進んだ
- **Workspace Studio 多言語対応（日本語含む）** — workspaceupdates.googleblog.com（2026-05-07 発表、ロールアウトは 5/8〜5/10 で窓内）。フランス語・ドイツ語・イタリア語・**日本語**・韓国語・ポルトガル語・スペイン語の 7 言語対応、UI はアカウント言語で自動切替、管理者操作不要

## 対象ファイル

- `src/content/ai-news/chatgpt-openai/gpt-5-5-cyber-trusted-access.mdx`
- `src/content/ai-news/chatgpt-openai/codex-v0-130-0.mdx`
- `src/content/ai-news/gemini/workspace-studio-multilingual.mdx`

## 補足：ユーザー認識との差分メモ

「Claude Code から Codex への簡単移行」については、OpenAI 公式は逆方向（`openai/codex-plugin-cc`：Claude Code 内から Codex を呼び出すプラグイン、2026-03-30 発表）のみ提供しており、Claude Code → Codex の移行ツールはサードパーティ製（`claude2codex` / `ccode-to-codex` / `cc2codex` など）が担当している状態。窓内には新規発表なし。

## Test plan

- [ ] `npm run check`（astro check）で frontmatter Zod スキーマ違反が出ないこと
- [ ] `npm run dev` で /ai-news/chatgpt-openai および /ai-news/gemini に新規3記事が表示されること
- [ ] 既存記事へのリグレッションがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)