### PR TITLE
feat(knowledge/vercel): 公式ドキュメント差分5記事を追加（Queues & Workflows / Microfrontends / Collaboration / Flags / Pricing）

### DIFF
--- a/src/content/knowledge/web-development/vercel-docs/28-queues-and-workflows.mdx
+++ b/src/content/knowledge/web-development/vercel-docs/28-queues-and-workflows.mdx
@@ -1,0 +1,210 @@
+---
+title: "Queues & Workflows — durable イベントストリームと多段ワークフローを Vercel で完結させる"
+description: "Vercel Queues は durable な append-only ログを軸にした event streaming 基盤であり、push/poll 両モード、fan-out consumers、idempotency キーによる重複排除を提供する。Vercel Workflows はその上に構築された多段オーケストレーション層であり、'use workflow' / 'use step' というディレクティブと Sleep / Hooks を用いて JS/TS/Python で durable application や AI エージェントを記述できる。本章では両者の中核機能、Functions / Fluid Compute との関係、料金構造、AI エージェント基盤としての位置付けまでを 1 章でカバーする。"
+category: "web-development"
+subcategory: "vercel"
+createdAt: 2026-05-10
+sortOrder: 28
+---
+
+## この章の要点
+
+- Vercel Queues は durable event streaming 基盤であり、トピックを永続的な append-only ログとして保持する。メッセージは複数の consumer group に fan-out され、TTL の範囲内であれば後から参加した consumer group が履歴を replay できる構造である。
+- Vercel Workflows は Queues の上に構築された higher-level の SDK であり、`'use workflow'` / `'use step'` という 2 つのディレクティブで通常の async 関数を durable に変換する。JavaScript / TypeScript に加え、`vercel` Python SDK でも同等の API が beta として提供されている。
+- Workflows は Sleep（数分から数か月の停止）と Hooks（外部イベントを待ち受ける human-in-the-loop 用 API）を備え、ステートマシンや YAML を書かずに event sourcing ベースの durable application を構築できる。
+- Functions / Fluid Compute とは独立した課金軸を持つ。Queues は Send / Receive / Delete / Visibility change / Notify の 5 種の operation 単位、Workflows は Steps と Storage（GB-Hour）単位で billing される。両者で起動される Function は従来どおり compute rates が課金される。
+- AI エージェント基盤としての位置付けが強い。公式ドキュメントは Workflows を「JavaScript / TypeScript / Python で durable applications and AI agents を構築する fully managed platform」と定義しており、Claude Managed Agent Guide や stateful Slack bot ガイドが Resources に並ぶ。
+- Workflows ではすべての state transition が event として記録され、デプロイ・クラッシュをまたいで決定的に replay される。観測性はダッシュボードの Observability → Workflows から確認でき、追加コードなしに run 単位で trace できる。
+
+## Vercel Queues / Vercel Workflows とは
+
+Vercel Queues は、サーバーレス向けに設計された durable event streaming システムである。プロデューサーはトピックにメッセージを publish し、独立した consumer group がそれぞれ並列にメッセージを消費する。各トピックは durable な append-only log として動作し、メッセージは TTL（最小 60 秒、最大 7 日、デフォルト 24 時間）が切れるまで保持される。後から参加した consumer group も、まだ expire していない履歴を replay できる構造であり、Kafka 的な fan-out モデルをマネージドかつサーバーレス前提で提供している点が特徴である。
+
+公式ドキュメント上、Queues の典型的なユースケースは次の 6 つに整理されている。重い処理（メール送信、PDF 生成、外部 API 呼び出し）の deferral、トラフィックスパイクの buffering、関数クラッシュやデプロイをまたいだ delivery guarantee、最大 retention までの delay scheduling、idempotency キーによる重複排除、そして同じメッセージを複数の独立したパイプラインで処理する consumer isolation である。これらはいずれも、従来は SQS や Kafka、あるいはサードパーティのワークフロー基盤を組み合わせて実現してきた領域である。
+
+Vercel Workflows は、その Queues を内部で活用しながら durable な多段処理を記述するための higher-level SDK である。公式の表現を借りれば、Workflows は「JavaScript、TypeScript、Python で durable applications と AI agents を構築する fully managed platform」であり、open-source の Workflow SDK（workflow-sdk.dev）と `vercel` Python SDK の上に成り立つ。Vercel Functions が workflow と step のコードを実行し、Vercel Queues がそれらのルートを reliability 付きで enqueue/execute し、managed persistence が state と event log を最適化されたデータベースに格納する、という三層構成になっている。
+
+両者の関係は明確である。Queues は低レベルのプリミティブで、メッセージの発行・消費・ルーティングを直接制御したいときに用いる。Workflows は durable steps、sleep、hooks を備えたより人間工学的な API であり、stateful な多段処理（AI エージェントのプランニング、人間の承認待ち、長時間のリトライなど）を記述する場合に用いる。公式ドキュメントは「stateful multi-step workflows を作るなら Workflows から始めよ」と明示的にガイドしている。
+
+## 何が解説されているか
+
+Queues 側のドキュメントは、Quickstart、Concepts、API reference、SDK Reference、Poll mode、Observability、Pricing and limits の 7 章で構成される。Concepts では durability、retries、visibility timeout、deployment behavior が扱われ、Poll mode では `PollingQueueClient` を使って自前のワーカーから消費する手順が示される。Observability ではキューのスループット、メッセージ age、consumer の性能が dashboard でモニタできる旨が述べられている。
+
+Workflows 側は Concepts、Python、Pricing and Limits を中心に、Workflow SDK の getting started、Slack bot guide、Claude Managed Agent guide が Resources として並ぶ。Concepts では Workflow / Step / Sleep / Hook の 4 つの抽象が、event sourcing の観点から説明されている。すなわち、`'use workflow'` 関数は内部的にルートにコンパイルされ、すべての input / output が event log に記録される。デプロイやクラッシュが発生すると、システムは event log を決定的に replay して停止位置から処理を再開する。`'use step'` 関数は isolated な API ルートにコンパイルされ、ビルトインのリトライを備える。step が実行している間、外側の workflow は資源を消費せずに suspend される。
+
+Queues と Workflows、そして従来の Cron や外部ワークフロー基盤との関係は次のように整理できる。
+
+| 観点 | Vercel Queues | Vercel Workflows |
+| --- | --- | --- |
+| レイヤー | 低レベル primitive（durable log + consumer group） | 高レベル SDK（durable function + step + sleep + hook） |
+| プログラミングモデル | publish / handleCallback or PollingQueueClient | `'use workflow'` / `'use step'` ディレクティブ、または Python の `@wf.workflow` / `@wf.step` |
+| 状態管理 | メッセージ単位（ステートレスな consumer 前提） | event sourcing による run 単位の状態 |
+| 主な用途 | fan-out 配信、重い処理の deferral、spike 吸収 | 多段オーケストレーション、AI エージェント、人間の承認待ち |
+| 課金軸 | API operation（Send/Receive/Delete/Visibility/Notify） | Workflow Steps と Storage（GB-Hour） |
+
+| 観点 | Vercel Cron Jobs | Vercel Queues | Vercel Workflows |
+| --- | --- | --- | --- |
+| トリガー | 時刻ベース | メッセージ ベース | プログラム的に start、Hook、Cron いずれも可 |
+| 配信保証 | best-effort | at-least-once、retry あり | event sourcing による決定的 replay |
+| ステート | なし | メッセージペイロードのみ | run ごとに event log を保持 |
+
+| 観点 | AWS Step Functions | Temporal | Vercel Workflows |
+| --- | --- | --- | --- |
+| 記述形式 | Amazon States Language（JSON / YAML 寄り） | TS/Python/Go の SDK | TS/JS/Python の async 関数＋ディレクティブ |
+| ホスティング | AWS マネージド | self-host or Temporal Cloud | Vercel フルマネージド |
+| Function 課金 | 別途 Lambda 課金 | 別途 worker 課金 | Functions / Fluid Compute と同じ compute rates |
+| AI エージェント | 別途設計が必要 | サポートあり | 公式ガイドで Claude Managed Agent / Slack bot を提示 |
+
+Queues 側のもう一つの重要な観点が retry policy と visibility timeout である。Queues SDK のデフォルトでは、`handleCallback` の visibility timeout は 5 分で、ハンドラ実行中は SDK 側で自動的に lease を再延長する。一方、Queues API そのものは visibility timeout のデフォルトが 60 秒で、自動延長は行わない。SDK 経由で扱う限り意識する必要は少ないが、PollingQueueClient で自前のワーカーを書く場合は、この差を踏まえて延長操作を組み込む必要がある。
+
+公式の retry behavior は「最初の 32 回は configured delay に従い、それを超えると forced backoff に切り替わる」と明記されている。アプリケーション側で `retry` コールバックを返せば、`afterSeconds` で次の試行までの delay を指定したり、`acknowledge: true` を返して poison message を切り離したりできる。
+
+## 使い方
+
+ここでは Queues の Producer / push Consumer、Workflows の TypeScript ワークフロー、そして Python ワークフローの 3 つの実装パターンを示す。いずれも公式 SDK ドキュメントの記法に揃えている。
+
+まず Queues で `orders` トピックに publish する Producer は次のように書ける。`@vercel/queue` から `send` を import するだけで済み、デフォルトクライアントは `VERCEL_REGION` から自動的にリージョンを判定し、未指定なら `iad1` にフォールバックする。
+
+```ts filename="app/api/orders/route.ts"
+import { send } from "@vercel/queue";
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const { messageId } = await send(
+    "orders",
+    { orderId: body.orderId, action: "process" },
+    {
+      idempotencyKey: `order-${body.orderId}`,
+      retentionSeconds: 3600,
+      delaySeconds: 60,
+    },
+  );
+  return Response.json({ messageId });
+}
+```
+
+Consumer は push mode の `handleCallback` を用いる。`vercel.json` の `experimentalTriggers` でルートをトピックに紐付け、ハンドラ内では通常の async 関数として処理を書けばよい。例外を throw すれば自動的に retry され、デフォルトでは 5 回を超えた段階で acknowledge して poison message として切り離している。
+
+```ts filename="app/api/queues/process-order/route.ts"
+import { handleCallback } from "@vercel/queue";
+
+export const POST = handleCallback(
+  async (message, metadata) => {
+    await processOrder(message);
+  },
+  {
+    visibilityTimeoutSeconds: 600,
+    retry: (error, metadata) => {
+      if (metadata.deliveryCount > 5) return { acknowledge: true };
+      const delay = Math.min(300, 2 ** metadata.deliveryCount * 5);
+      return { afterSeconds: delay };
+    },
+  },
+);
+```
+
+Workflows 側は、`'use workflow'` と `'use step'` を使って同等の処理をより宣言的に書ける。次の例は AI ドラフト生成、7 日のスリープ、人間の承認待ちまでを 1 関数で表現したものである。`sleep('7 days')` の間はインフラを一切消費せず、`approvalHook.create` は外部 API から `resume` が呼ばれるまでイベント受信を待ち続ける。
+
+```ts filename="app/workflows/ai-approval.ts"
+import { sleep, defineHook } from "workflow";
+
+const approvalHook = defineHook<{
+  decision: "approved" | "changes";
+  notes?: string;
+}>();
+
+async function generateDraft(topic: string) {
+  "use step";
+  return await aiGenerate({ prompt: `Write a blog post about ${topic}` });
+}
+
+async function publishDraft(draft: string) {
+  "use step";
+  await cms.publish(draft);
+}
+
+export async function aiApprovalWorkflow(topic: string) {
+  "use workflow";
+
+  const draft = await generateDraft(topic);
+  await sleep("7 days");
+
+  const events = approvalHook.create({ token: `draft-${topic}` });
+  for await (const event of events) {
+    if (event.decision === "approved") {
+      await publishDraft(draft);
+      break;
+    }
+  }
+
+  return { topic, status: "done" };
+}
+```
+
+Python SDK でも同じ思想が `@wf.workflow` / `@wf.step` という decorator として提供されている。`workflow.sleep("7 days")` の長時間スリープ、Pydantic と `workflow.BaseHook` を組み合わせた hook 定義まで、JS/TS 版とほぼ 1 対 1 で対応する。なお Python 対応は公式ドキュメント上で beta と明記されており、API は変更される可能性がある。
+
+```python filename="app/workflows/ai_content_workflow.py"
+from vercel import workflow
+from app.workflow import wf
+
+@wf.step
+async def generate_draft(*, topic: str):
+    return await ai_generate(prompt=f"Write a blog post about {topic}")
+
+@wf.step
+async def summarize_draft(*, draft: str):
+    return await ai_summarize(text=draft)
+
+@wf.workflow
+async def ai_content_workflow(*, topic: str):
+    draft = await generate_draft(topic=topic)
+
+    # 7 日間スリープしてフィードバックを集めてから要約に進む
+    await workflow.sleep("7 days")
+
+    summary = await summarize_draft(draft=draft)
+
+    return {"draft": draft, "summary": summary}
+```
+
+Python ワークフローを動かすには、`vercel.json` の `experimentalServices` にエントリポイントとサブスクライブする topic を宣言する必要がある。`__wkf_*` のようなワイルドカードを指定して Workflows ランタイムが内部的に使うトピックをまとめて受信する形が公式の例として示されている。
+
+```json filename="vercel.json"
+{
+  "experimentalServices": {
+    "ai_content_workflow": {
+      "type": "worker",
+      "entrypoint": "app/workflows/ai_content_workflow.py",
+      "topics": ["__wkf_*"]
+    }
+  }
+}
+```
+
+これらのコードは、Functions と Fluid Compute の章で扱った前提（`maxDuration`、Active CPU 課金、Optimized Concurrency）の上にそのまま乗る。Workflows のドキュメントでも「Fluid Compute の利用を推奨する」と明記されており、長時間アイドルになりやすいワークフローの性質と Active CPU 課金の相性が良い設計である。
+
+## 注意点・セキュリティ観点
+
+第 1 に、Queues は at-least-once delivery を前提としている。SDK 経由で `idempotencyKey` を付与すれば重複 publish は弾けるが、consumer 側のビジネスロジックは「同じメッセージが 2 回以上届く可能性」を許容する設計（例：DB に対する upsert、外部副作用の事前チェック）にしておく必要がある。retry は最初の 32 回までは設定どおりの delay で進み、それを超えると forced backoff に切り替わるため、無限ループ的な失敗が long-tail のコストを発生させない構造になっている。
+
+第 2 に、Workflows の state には明確なサイズ上限がある。1 run あたり events 25,000、steps 10,000、payload 50 MB、entity storage 合計 2 GB、replay duration 240 秒、hook token 255 バイト、workflow / step 名 255 バイトといった具体的な数値が公式に明示されている。とくに 2,000 events または 1 GB を超えると replay が遅くなることが docs で明言されており、長尺の処理は child workflow に分割するパターンが推奨されている。AI エージェントのように LLM 出力をそのまま log に残すと events 数が膨らみやすいため、step の粒度設計は意識的に行う必要がある。
+
+第 3 に、課金は Functions / Fluid Compute とは別軸で発生する。Workflows は Hobby プランで Workflow Steps が 50,000、Workflow Storage が 720 GB-Hours まで含まれ、超過分はそれぞれ 100,000 Steps あたり 2.50 ドル、GB-Hour あたり 0.00069 ドルが on-demand rate となる。Storage retention は run 完了後に Hobby で 1 日、Pro で 7 日、Enterprise で 30 日と plan ごとに固定で、配信レート上限も 1,000 runs/sec、Hobby 100,000 req/min、Pro 1,000,000 req/min、Enterprise 5,000,000 req/min と公式に定められている。Queues 側は 4 KiB チャンク単位で課金され、idempotency key 付き Send と max concurrency 付き push 配信は 2x で billing される点に注意が要る。
+
+第 4 に、AI エージェントへ渡す権限境界の設計である。Workflows は Claude Managed Agent や Slack bot のように外部権限と接続するユースケースを公式に推奨しており、Hook 経由で外部からワークフローを resume できる仕組みは強力である一方、`token` をそのまま URL や JSON に露出させると第三者がワークフローを進められてしまうリスクがある。`token` は 255 バイト以内で十分にエントロピーを持たせ、`/api/resume` のようなエンドポイントには認可レイヤーを必ず噛ませること。step が外部 API キーを読む場合は環境変数バリデーションを通し、step ごとに権限を最小化することが望ましい。
+
+第 5 に、observability の整え方である。Workflows ではすべての step、入力、出力、sleep、エラーが自動的に記録され、Vercel ダッシュボードの Observability → Workflows から run ごとに trace できる。追加コードは不要だが、step 名と workflow 名は 255 バイト以内で意味のあるものに揃えておくと、後からの failure 分析や AI エージェントのデバッグが格段に楽になる。Queues 側は dashboard でスループット、message age、consumer のパフォーマンスを確認できるため、push と poll を併用する設計でもボトルネックを掴みやすい。
+
+最後に、Queues と Workflows の双方が Vercel Functions の上で動く以上、関数本体の制限（Maximum bundle size 250 MB、step 単位の最大実行時間は Functions のリミット準拠）はそのまま適用される。長時間スリープを抱えるワークフローでも、step ひとつあたりの実行時間は Functions の `maxDuration` が上限になる点を忘れてはならない。
+
+## 一次ソース（原文）
+
+- Vercel Queues: https://vercel.com/docs/queues
+- Vercel Queues — Pricing and Limits: https://vercel.com/docs/queues/pricing
+- Vercel Queues — SDK Reference: https://vercel.com/docs/queues/sdk
+- Vercel Workflows: https://vercel.com/docs/workflows
+- Vercel Workflows — Concepts: https://vercel.com/docs/workflows/concepts
+- Vercel Workflows — Python: https://vercel.com/docs/workflows/python
+- Vercel Workflows — Pricing and Limits: https://vercel.com/docs/workflows/pricing
+- Workflow SDK 公式サイト: https://workflow-sdk.dev/
+- Vercel Changelog: https://vercel.com/changelog

--- a/src/content/knowledge/web-development/vercel-docs/29-microfrontends.mdx
+++ b/src/content/knowledge/web-development/vercel-docs/29-microfrontends.mdx
@@ -1,0 +1,182 @@
+---
+title: "Microfrontends — 複数フレームワーク横断の本番運用とゾーン分割を Vercel で実現する"
+description: "Vercel Microfrontends の GA（2025 年 10 月 31 日）、ゾーン分割（Microfrontend Zones）・パス連結・共有レイアウト・複数フレームワーク（Next.js / SvelteKit / Vite / その他）の同居運用を解説する。1 日約 10 億リクエストを処理する規模、Cursor を含む 250 以上のチームでの採用事例、`microfrontends.json` の設定、ローカル開発プロキシ、Build & Deploy パイプラインや Preview Deployment との統合、CSP・認証・課金観点までをカバーする。"
+category: "web-development"
+subcategory: "vercel"
+createdAt: 2026-05-10
+sortOrder: 29
+---
+
+## この章の要点
+
+- Vercel Microfrontends は 2025 年 10 月 31 日に一般提供（GA）となった機能であり、単一の大規模アプリケーションを独立デプロイ可能な複数アプリへ分割しつつ、エンドユーザーには 1 つのアプリとして提供するための仕組みである。
+- GA 時点で 1 日およそ 10 億件のマイクロフロントエンド・ルーティングリクエストを処理しており、Cursor、The Weather Company、A+E Global Media を含む 250 以上のチームが本番運用に採用している。
+- 全プランで利用可能であり、Hobby は 50K リクエスト / 月までと 2 プロジェクトが含まれる。Pro / Enterprise では 2 プロジェクトを越える追加プロジェクトが 1 件あたり月 250 ドル、追加リクエストは 100 万件あたり 2 ドルで従量課金される。
+- フレームワーク非依存に設計されており、Next.js（App Router / Pages Router）、SvelteKit、Vite ベースのフレームワーク、その他の任意フレームワークを同一グループ内で同居させられる。Module Federation のようなランタイム合成ではなく、Vercel の Edge / CDN レベルでパスごとに合成（path-based composition）する点が特徴である。
+- Preview Deployment と Production Deployment の両方でゾーン構成が反映され、ブランチ URL・デプロイメント URL ごとに「同一コミットの子アプリ」「ブランチ最新ビルド」「フォールバック環境」と段階的に解決される。これにより、複数チームが独立にリリースしても URL 体験が崩れない設計になっている。
+- ローカル開発では `@vercel/microfrontends` が提供する `microfrontends proxy` と `microfrontends port` を組み合わせ、ローカルで動かすゾーンだけを起動し、他は本番にフォールバックする「単一ゾーン開発」を可能にしている。
+
+## Vercel Microfrontends とは
+
+マイクロフロントエンドとは、単一の Web アプリケーションを「機能単位の小さなアプリ」へ分割し、独立にデプロイ可能にする設計手法である。チームごとに技術選定とリリースサイクルを切り離せるため、組織のスケールに伴う「ビルド時間の肥大化」「単一リポジトリでのリリース調整コスト」「レガシースタックからの段階的移行」の三つの課題を解きやすくなる。一方で、合成方法を誤るとパフォーマンス低下・セキュリティ境界の曖昧化・運用の複雑化を招くため、合成レイヤーをどこに置くかの設計判断が中心命題になる。
+
+Vercel の実装は、合成レイヤーを「Vercel のグローバルネットワーク」に置く方式である。公式ドキュメントが明記しているとおり、Vercel は「ドメインに対するリクエストを受けると、ライブデプロイ内の `microfrontends.json` を読み、そのリクエスト処理の中で適切な子アプリへルーティング先を確定させる」。ここで重要なのは、これがリライト（rewrite）による再リクエストではなく、同一リクエスト内で行われるネットワーク内ルーティングであり、追加のネットワークホップを生まないという点である。結果として、ブラウザから見ると単一ドメインの単一アプリに見えるが、内部的にはパスごとに別プロジェクトのデプロイへ吸い込まれていく構造になる。
+
+この方式は、Module Federation のように「ホストアプリのランタイムが remoteEntry を取得して JS をマージする」モデルとは性質が異なる。Vercel Microfrontends ではフレームワーク同士のランタイム結合は行われず、ページ遷移やパス境界で別プロジェクトに到達する。ホスト側で別フレームワークの JS を直接インポートする必要がないため、Next.js と SvelteKit のように世代もランタイムも異なる組み合わせを同居させやすい。代償として、SPA 的な「同一プロセス内でコンポーネントを差し込む」用途には向かず、適用範囲は「縦割りの機能分割（vertical slice）」が中心となる。
+
+Vercel が公式ブログ「How Vercel adopted microfrontends」（2024 年 10 月 22 日公開、著者 Mark Knichel / Dan Fein / Brian Emerick）で述べているとおり、Vercel 自身もこの方式で自社ダッシュボードを再構成しており、`vercel.com` をマーケティングサイト・ドキュメント・ログイン後ダッシュボードの 3 つの縦割りマイクロフロントエンドへ分解している。同記事は、プレビュービルド時間が 40% 以上短縮され、初期検証では「ビルド時間が半減し得る」結果が得られたこと、LCP と INP の Core Web Vitals 指標で改善が見られたことを報告している。
+
+## 何が解説されているか
+
+公式ドキュメント `vercel.com/docs/microfrontends` 配下は、概念・クイックスタート・設定リファレンス・パスルーティング・ローカル開発・運用管理・ツールバー・トラブルシューティングの 8 領域で構成される。前提知識としては、Vercel プロジェクトを 2 つ以上作成し、それらを「マイクロフロントエンドグループ」として束ねる必要がある。グループ内には必ず 1 つの「Default app（既定アプリ）」を置き、`microfrontends.json` の所有とフォールバック処理を担わせる。
+
+実装上の核は次の 4 つである。第一に、Default app に置かれる `microfrontends.json` がルーティング権限を一元的に持つ。第二に、各子アプリは `@vercel/microfrontends` をインストールし、フレームワークごとのラッパー（Next.js なら `withMicrofrontends`、SvelteKit / Vite なら `experimental/vite` プラグイン）を経由して、自身のアセット URL に「アセットプレフィックス」を付与する。第三に、CDN レイヤーでのパスマッチングは、純粋なパス式（`/docs/:path*`、`/:path(a|b)` など）で記述され、複数セグメントに跨る `*` / `+` は末尾でしか使えないなどの明示的な制約がある。第四に、Preview や Branch URL では「同一コミット → ブランチ最新 → フォールバック環境」という順序で解決される。これにより、複数子アプリのリリースサイクルがズレても URL 体験が壊れにくい。
+
+下表は、Vercel Microfrontends と他の代表的な合成手段の比較である。設計判断時の補助として用いる。
+
+| 観点 | Vercel Microfrontends | Module Federation | iframe 埋め込み | リバースプロキシ自前構成 |
+| --- | --- | --- | --- | --- |
+| 合成レイヤー | Edge / CDN（同一リクエスト内ルーティング） | ブラウザランタイム（remoteEntry のロード） | ブラウザ（独立ドキュメント） | リバースプロキシ層（rewrite / proxy_pass） |
+| フレームワーク混在 | 容易（Next.js / SvelteKit / Vite 等） | 同一バンドラ前提（webpack / Rspack 中心） | 完全自由 | 自由（HTTP レベルで結合） |
+| 追加ネットワークホップ | なし | あり（remoteEntry 取得） | あり（iframe 文書） | プロキシ実装次第 |
+| 認証 / Cookie 共有 | 同一ドメインで自然に共有 | 同一ドメイン前提 | 別オリジン扱いで分離 | 設計による |
+| 観測性・ロールバック | Vercel ダッシュボード / Instant Rollback で統合 | バンドル側で各自実装 | ほぼ独立 | 自前で構築 |
+| 主な弱点 | 縦割り分割向き、横方向のコンポーネント差し込みは不可 | バージョン整合・ランタイム結合の運用負荷 | UX 制約（モーダル・ナビ） | 運用工数と SLO 担保 |
+
+この比較が示すように、Vercel Microfrontends はランタイム結合を捨てる代わりに、ネットワーク層での合成を Vercel に委譲することで、フレームワーク選択の自由度と運用コストの両立を狙っている。設計の方向性としては「巨大 SPA を一つの世界として作る」のではなく、「URL の縦割りで責務を切る」アプローチに最適化されている。
+
+## 使い方
+
+ここでは、`web`（Next.js、Default app）と `docs`（任意フレームワーク、`/docs/*` を担当）の 2 ゾーン構成を例に、最小手順を示す。
+
+最初に、Vercel ダッシュボードまたは CLI でマイクロフロントエンドグループを作成する。CLI の場合は次のとおりである。
+
+```bash filename="terminal"
+vercel microfrontends create-group
+```
+
+対話プロンプトでグループ名と所属プロジェクトを指定し、Default app を選ぶ。グループを作っただけでは挙動は変わらず、Default app に `microfrontends.json` を含むデプロイが本番に反映された時点でルーティングが有効になる。
+
+次に、Default app のリポジトリルートに `microfrontends.json` を置く。最小例は次のとおりである。
+
+```json filename="microfrontends.json"
+{
+  "$schema": "https://openapi.vercel.sh/microfrontends.json",
+  "applications": {
+    "web": {
+      "development": {
+        "fallback": "vercel.com"
+      }
+    },
+    "docs": {
+      "routing": [
+        {
+          "group": "docs",
+          "paths": ["/docs/:path*"]
+        }
+      ]
+    }
+  }
+}
+```
+
+`applications` のキーは Vercel プロジェクト名と一致させる必要がある。プロジェクト名と `package.json` の `name` が一致しない場合は、`packageName` フィールドで明示する。`development.fallback` は、ローカル開発でそのアプリを起動していないときに代替として参照する本番ホストである。
+
+続いて、各子アプリで `@vercel/microfrontends` を導入する。Next.js では `next.config.js` を `withMicrofrontends` でラップするだけで、JS / CSS のアセット URL に自動で `/vc-ap-<application name のハッシュ>` 形式のアセットプレフィックスが付与され、CDN ルーティングと整合する。Next.js の `basePath` との併用は現時点では非サポートである点に注意する。
+
+```ts filename="next.config.ts"
+import { withMicrofrontends } from "@vercel/microfrontends/next/config";
+
+export default withMicrofrontends({
+  reactStrictMode: true,
+});
+```
+
+SvelteKit を子アプリにする場合は、Svelte 設定をラップしたうえで Vite 側にもプラグインを追加する。`@vercel/microfrontends` の `1.0.1` 以上が必要である。
+
+```ts filename="vite.config.ts"
+import { defineConfig } from "vite";
+import { sveltekit } from "@sveltejs/kit/vite";
+import { microfrontends } from "@vercel/microfrontends/experimental/vite";
+
+export default defineConfig({
+  plugins: [sveltekit(), microfrontends()],
+});
+```
+
+Vite ベースのフレームワーク（React Router / Astro 等の Vite を使うケース）でも同じ `experimental/vite` プラグインが利用できる。Vercel ドキュメントは、Vite ネイティブの `base` を併用するより、プラグインが自動付与するアセットプレフィックスを使うことを推奨している。フレームワーク非対応の場合は、JS / CSS / `public/` 配下のアセットすべてを「ユニークなパスプレフィックス（例: `/docs-assets`）」配下に移し、その値を `microfrontends.json` の `paths` に追加する手動運用となる。
+
+`microfrontends.json` のパス式は意図的に保守的で、`/path`、`/:segment`、`/prefix/:path*`、`/prefix/:path+`、`/:path(a|b)`、`/:path((?!a|b).*)`、`/prefix-:path-suffix` をサポートする。重複・競合するルートは禁止であり、`*` や `+` は末尾でのみ使える。これは「同じパスが 2 つの子アプリに割り当たる」状態をビルド時に検出するための制約である。ユニットテストとしては `validateRouting` ヘルパーが提供され、CI でルーティングを担保できる。
+
+ローカル開発では、子アプリを 1 つだけ起動し、他は本番にフォールバックさせる構成が公式の推奨である。各子アプリの `dev` スクリプトで `microfrontends port` を使い、ポートを動的にプロキシと整合させる。
+
+```json filename="package.json"
+{
+  "name": "web",
+  "scripts": {
+    "dev": "next --port $(microfrontends port)",
+    "proxy": "microfrontends proxy microfrontends.json --local-apps web"
+  },
+  "dependencies": {
+    "@vercel/microfrontends": "latest"
+  }
+}
+```
+
+Turborepo を併用する場合は、`turbo run dev --filter=web` を実行するだけで、Web の開発サーバーとローカルプロキシが同時に立ち上がる（`turbo` 2.3.6 以降または 2.4.2 以降が必要）。プロキシは既定で `http://localhost:3024` で受け付け、`/docs/*` のような自分が起動していない子アプリへのリクエストは `microfrontends.json` の `development.fallback` で指定した本番ホストに転送される。
+
+ポリレポ構成の場合、`microfrontends.json` を共有する手段が必要になる。Vercel CLI 44.2.2 以降では `vercel microfrontends pull` で Default app から設定を引き寄せられ、CI では環境変数 `VC_MICROFRONTENDS_CONFIG` にパスを渡すことでも読み込める。これにより、各リポジトリのローカル開発で同一のルーティング表を参照できる。
+
+CI / Preview の運用では、Vercel が「同一コミットで子アプリのデプロイがあればそれに、なければブランチ最新、それもなければフォールバック環境」の順で解決する仕様を活用する。Pull Request ごとに自動生成される Branch URL や Deployment URL に対して、各子アプリのデプロイが揃わなくても URL 体験が崩れない。複数チームのリリースを段階的に進める場合は、`flag` フィールドと `@vercel/microfrontends/next/middleware` の `runMicrofrontendsMiddleware` を組み合わせ、特定パスを「フィーチャーフラグが true のときだけ別ゾーンへルーティングする」ように切り替える運用が公式に提供されている。
+
+```ts filename="middleware.ts"
+import type { NextRequest } from "next/server";
+import { runMicrofrontendsMiddleware } from "@vercel/microfrontends/next/middleware";
+
+export async function middleware(request: NextRequest) {
+  const response = await runMicrofrontendsMiddleware({
+    request,
+    flagValues: {
+      "name-of-feature-flag": async () => true,
+    },
+  });
+  if (response) return response;
+}
+
+export const config = {
+  matcher: [
+    "/.well-known/vercel/microfrontends/client-config",
+    "/flagged/path",
+  ],
+};
+```
+
+`/.well-known/vercel/microfrontends/client-config` は、クライアントが「このセッションでフラグ付きパスがどの子アプリに解決されるか」を取得し、ナビゲーション前のプリフェッチを最適化するために使われるエンドポイントである。フラグ運用を入れる場合は、このマッチャを必ず含める必要がある。
+
+## 注意点・セキュリティ観点
+
+Vercel Microfrontends は同一ドメイン上で複数プロジェクトを合成するため、セキュリティと運用の前提が「単一プロジェクト」のときと変わる。
+
+第一に、`basePath`（Next.js）はサポート対象外である。アセットプレフィックスは `withMicrofrontends` が自動で `/vc-ap-<hash>` を付与するため、独自に `basePath` を設定すると二重プレフィックスになり、CDN ルーティングと整合しなくなる。`assetPrefix` を人間可読な値に上書きしたい場合は、`microfrontends.json` の `assetPrefix` を使い、変更時には旧値を含むトラフィックが壊れないよう Preview で十分検証する。
+
+第二に、CSP は単一ドメインに集約された結果、`script-src` / `style-src` / `img-src` の許可ホストが「すべての子アプリのアセットプレフィックス配下」をカバーする必要がある。iframe による埋め込みではないため `frame-src` 由来の制約は緩むが、子アプリごとに別バンドラ・別バージョンの依存を抱えるため、`unsafe-inline` を許さない nonce ベース運用に揃える際は、各子アプリのフレームワーク側で nonce を伝播させる必要がある。
+
+第三に、認証は同一ドメインのため Cookie・LocalStorage を自然に共有できる一方、Cookie の `Path` 属性を子アプリ側で安易に絞ると、ゾーン横断のセッションが壊れることがある。基本は `Path=/` で発行し、機密度の高い値はサーバーサイドのセッション ID に集約する設計が安全である。
+
+第四に、Preview Deployment Protection（パスワード保護や SSO）が有効な場合、ローカルプロキシのフォールバック先が保護されたデプロイになると 401 で失敗する。回避策として、保護対象プロジェクトで「Protection Bypass for Automation」を発行し、`AUTOMATION_BYPASS_<アプリ名を大文字化し非英数字を `_` に置換した値>` という名前で Default app の環境変数に設定する。例えば子アプリ名が `my-docs-app` の場合、変数名は `AUTOMATION_BYPASS_MY_DOCS_APP` となる。
+
+第五に、ドメイン設計は「単一の apex ドメインに集約」が公式の前提である。`example.com` 直下に Web、`example.com/docs/*` に Docs を割り付ける構成は素直に動くが、`docs.example.com` のようなサブドメインに別ゾーンを割り当てる構成は、別グループとして別途設計する必要がある。SEO 観点では、サブドメイン分割と異なり Canonical URL とサイトマップを単一ドメイン下で統合できる利点があるが、各子アプリの `robots.txt` や `sitemap.xml` を Default app 側に集約するか、各ゾーンで分割発行するかを早期に決めておくべきである。
+
+第六に、課金面では「Microfrontends Routing リクエスト数」と「Microfrontends Projects 数」の二軸で課金される。Hobby は 50K リクエスト / 月および 2 プロジェクトまでが含まれる。Pro / Enterprise は 2 プロジェクトを越える分に月 250 ドル / プロジェクト、ルーティングリクエストは 100 万件あたり 2 ドルが従量課金される。使用量はダッシュボードの **Vercel Delivery Network** セクションから確認できるため、リリース後はトラフィック規模と単価をモニタリングし、子アプリ分割の粒度が過剰になっていないかを定期的に見直すべきである。
+
+最後に、`microfrontends.json` の変更は「子アプリのリリース順」に依存するという運用上の罠がある。新パスを追加する際、子アプリ側にハンドラが存在する状態でないと、ルーティングが先行してマージされた瞬間に 404 を返す。公式ドキュメントは、安全側に倒す手段として `flag` ベースのルーティング切替を推奨しており、合わせて `validateRouting`、`validateMiddlewareConfig`、`validateMiddlewareOnFlaggedPaths` の各テストユーティリティを CI に組み込む構成を案内している。Instant Rollback も併用すれば、誤ってルーティングを変更した際でも以前のデプロイへ即時に戻せる。
+
+## 一次ソース（原文）
+
+- Vercel Docs: Microfrontends overview — `https://vercel.com/docs/microfrontends`
+- Vercel Docs: Microfrontends Quickstart — `https://vercel.com/docs/microfrontends/quickstart`
+- Vercel Docs: Path Routing — `https://vercel.com/docs/microfrontends/path-routing`
+- Vercel Docs: Local Development — `https://vercel.com/docs/microfrontends/local-development`
+- Vercel Changelog: Microfrontends now generally available（2025 年 10 月 31 日）— `https://vercel.com/changelog/microfrontends-now-generally-available`
+- Vercel Blog: How Vercel adopted microfrontends（2024 年 10 月 22 日、Mark Knichel / Dan Fein / Brian Emerick）— `https://vercel.com/blog/how-vercel-adopted-microfrontends`
+- Vercel Knowledge Base: Incremental migrations with microfrontends — `https://vercel.com/kb/guide/incremental-migrations-with-microfrontends`

--- a/src/content/knowledge/web-development/vercel-docs/36-collaboration.mdx
+++ b/src/content/knowledge/web-development/vercel-docs/36-collaboration.mdx
@@ -1,0 +1,205 @@
+---
+title: "Collaboration — Comments / Draft Mode / Edit Mode / Toolbar で Preview を共同レビューする"
+description: "Vercel Collaboration スイートの全体像を整理する章。Preview Deployment 上で UI に直接コメントを差し込む Comments、Headless CMS の下書きを実画面で確認する Draft Mode、CMS フィールドへ直接ジャンプできる Edit Mode、これらすべての入口となる Vercel Toolbar の役割をまとめる。Slack / Linear / Jira への連携、Preview Deployment Protection との関係、デザイナー・PM・外部レビュアーを巻き込むレビュー導線、認証境界とプラン依存の制限までを 1 章で扱う。"
+category: "web-development"
+subcategory: "vercel"
+createdAt: 2026-05-10
+sortOrder: 36
+---
+
+## この章の要点
+
+- Vercel Collaboration は、Comments / Draft Mode / Edit Mode / Toolbar の 4 機能から成る Preview Deployment 共同レビューの仕組みである。すべての操作は Vercel Toolbar から呼び出され、Preview Deployment と一体で動作する。
+- Comments は Preview Deployment 上の UI に対して要素ピンを打てる仕組みであり、Pull Request と紐付くため Vercel Bot のコメントから「Add your feedback」リンクで自動ログインできる。全プランで無料・既定有効である。
+- Draft Mode は Headless CMS の未公開コンテンツを実サイトのレイアウトで表示する仕組みであり、ISR の `bypassToken` と `__prerender_bypass` Cookie で実現される。Next.js では `next/headers` の `draftMode().enable()` を使い、Toolbar から切替できる。
+- Edit Mode は Content Source Maps を介して画面上の要素から CMS のフィールドへ直接ジャンプする仕組みである。Contentful / Sanity / Builder.io / TinaCMS / DatoCMS / Payload / Uniform / Strapi が公式対応する。
+- Vercel Toolbar は Comments / Feature Flags / Draft Mode / Edit Mode / Layout Shift / Interaction Timing / Accessibility Audit の入口であり、Preview では既定で挿入される。Production / localhost では `@vercel/toolbar` を明示導入する必要がある。
+- 権限境界は Preview Deployment Protection と SSO に依拠する。チーム外レビュアーへの共有は Pro / Enterprise の Sharable Links で行い、Production への混入を防ぐためにビルド時の Toolbar 注入条件を分離する。
+
+## Vercel Collaboration とは
+
+Vercel Collaboration は、Preview Deployment を「動くデザインモック」として扱うための機能群である。従来、Web サイトのレビューは Figma 上のスクリーンショットコメント、GitHub PR の差分コメント、Slack のスクリーンショット添付に分散していた。これらは「実際に動いている画面」と「議論が行われる場所」が一致しないため、PM やデザイナーが指摘する箇所をエンジニアが正確に再現するまでに往復が発生する。Vercel Collaboration は、この往復を Preview Deployment 上で完結させることを狙いにした仕組みである。
+
+中核となるのは Vercel Toolbar である。Preview Deployment にアクセスすると画面下部にツールバーが表示され、ここを起点として Comments（要素にピンを打つコメント）、Draft Mode（Headless CMS の下書きを表示）、Edit Mode（要素から CMS フィールドへジャンプ）、Feature Flags、Layout Shift / Interaction Timing / Accessibility Audit などの開発・レビュー支援ツールへアクセスできる。Toolbar は Preview では既定で挿入され、ログイン済みのチームメンバーであれば追加設定なしに利用できる。Production や localhost で使う場合は `@vercel/toolbar` パッケージを明示的にレイアウトへ埋め込む必要がある。
+
+Draft Mode と Preview Deployment は名前が似ているが別物である。Preview Deployment は「main 以外のブランチの動的なステージング URL」を指し、Draft Mode は「ISR で静的化されたページのキャッシュをリクエスト時にバイパスして CMS の最新（未公開）コンテンツを取得する」仕組みである。Next.js 13.4 以前は Preview Mode と呼ばれていたが、Preview Deployment との混同を避けるために Draft Mode に改名された経緯が公式ドキュメントに明記されている。
+
+Edit Mode はさらに上のレイヤーで動く仕組みで、ビルド時に挿入される Content Source Maps を解釈して、画面上の要素から対応する CMS のフィールドエディタへ直接遷移する Content Link を提供する。これは Visual Editing と呼ばれる潮流の Vercel 実装であり、PM・編集者が Web 開発者を介さずに本文や見出しの編集に到達できるようになる。
+
+## 何が解説されているか
+
+公式ドキュメントは Comments / Draft Mode / Edit Mode / Toolbar の 4 つを独立したセクションで扱いつつ、Toolbar をハブとして相互参照する構成になっている。それぞれの責務は次の表のとおりである。
+
+| 機能 | 役割 | プラン要件 | 主な依存 |
+| --- | --- | --- | --- |
+| Vercel Toolbar | 全機能の入口 UI。Preview で既定挿入、Production / localhost は `@vercel/toolbar` で導入 | 全プラン | ログイン済み Vercel アカウント |
+| Comments | Preview Deployment 上の要素にコメント・スレッドを紐付け、PR 連動・Slack / Linear / Jira 連携 | 全プラン無料、外部招待は Pro / Enterprise | Toolbar、Preview、Git 連携 |
+| Draft Mode | ISR の `bypassToken` と `__prerender_bypass` Cookie で CMS 下書きを表示 | 全プラン | ISR、Headless CMS |
+| Edit Mode | Content Source Maps で要素 → CMS フィールドへジャンプ（Content Link） | 全プラン（CMS 側の対応必須） | Toolbar、Visual Editing 対応 CMS |
+
+Comments は要素に対するピン留めが特徴で、矩形選択した部分やテキストレンジに紐付けてスレッドを開ける。Pull Request にデプロイが紐付いている場合は Vercel Bot が PR コメント上で「Add your feedback」URL と未解決コメント数を表示する。さらに、Comments には Git Provider のステータスチェックも用意されており、未解決コメントがある状態でのマージを止める運用が組める。GitHub / GitLab / BitBucket の必須チェック設定で「required」にすれば、Comments の解決をマージブロッカーにできる。
+
+Slack 連携は最も使われる外部統合である。`/vercel subscribe` コマンドでチャンネルとプロジェクトを紐付けると、新規コメントごとに Slack スレッドが自動生成され、Slack 側の返信は Vercel 側のスレッドに、Vercel 側の返信は Slack に双方向同期される。Slack 上でも `Resolve` ボタンでスレッドを解決できる。Linear / Jira / GitHub Issues はコメントスレッドからイシュー化する用途で、コメント上のアイコンから「Convert to Issue」を実行すると、コメント本文と添付画像がそのままイシュー本文に流し込まれ、元スレッドは自動 Resolve される（再オープン不可）点が運用上の注意点である。
+
+Comments・Figma Comments・GitHub PR Review の比較を整理する。
+
+| 比較軸 | Vercel Comments | Figma Comments | GitHub PR Review |
+| --- | --- | --- | --- |
+| コメント対象 | 動作中の Preview Deployment（実 HTML） | 静的なデザインカンバス | コードの差分（行単位） |
+| ピン位置 | DOM 要素に紐付き、レスポンシブ追従 | キャンバス座標 | ファイル × 行番号 |
+| 主な参加者 | デザイナー・PM・QA・エンジニア | デザイナー中心 | エンジニア中心 |
+| マージブロック | Git Provider のステータスチェックで強制可 | なし（外部運用） | レビュー必須化で強制可 |
+| 外部招待 | Pro / Enterprise の Sharable Links | Figma の閲覧/編集権限 | リポジトリ権限 |
+| 双方向同期 | Slack / Linear / Jira / GitHub Issues | なし | GitHub 内のみ |
+
+Draft Mode の挙動は ISR を前提にする。各 ISR ルートにはビルド時に暗号論的に強い `bypassToken` が割り当てられ、リクエストに `__prerender_bypass` Cookie が付与され、その値が `bypassToken` と一致した場合のみキャッシュをバイパスしてリクエスト時に CMS から最新データを取得する。Next.js では `next/headers` の `draftMode().enable()` で Cookie を設定する API ルートを書き、Toolbar から「Draft Mode」をトグルすると Toolbar が紫色に変化して有効状態であることを示す。Draft Mode を有効にできるのはチームメンバーのみであり、`?__vercel_draft=1` を付けたシェア URL もチーム外には開けない仕様となっている。
+
+Edit Mode（Content Link）は CMS 統合がインストールされ、かつ画面上の要素が CMS のコンテンツモデルに紐付いている場合のみ Toolbar メニューに表示される。Sanity・Contentful・Builder.io・TinaCMS・DatoCMS・Payload・Uniform・Strapi が公式対応 CMS として列挙されており、追加のコード変更なしに要素ホバーで右上に Content Link が現れ、クリックすると対応する CMS フィールドのエディタへ遷移する。
+
+## 使い方
+
+Vercel Toolbar は Preview Deployment では既定で挿入される。Production や localhost で使う場合は `@vercel/toolbar` パッケージを導入し、レイアウトに `<VercelToolbar />` を埋め込む。Next.js App Router での代表的な実装は次のとおりである。
+
+```tsx filename="app/layout.tsx"
+import { VercelToolbar } from "@vercel/toolbar/next";
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const shouldInjectToolbar = process.env.NODE_ENV === "development";
+
+  return (
+    <html lang="ja">
+      <body>
+        {children}
+        {shouldInjectToolbar && <VercelToolbar />}
+      </body>
+    </html>
+  );
+}
+```
+
+`shouldInjectToolbar` の判定は環境ごとに切り替え、Production には条件付きでしか挿入しないのが定石である。Preview では Vercel が自動でツールバーを差し込むため、`<VercelToolbar />` を明示する必要はない。ローカルで Comments を試す場合は、コメント対象の URL がチーム配下のプロジェクトに紐付いていることが前提となる。
+
+Comments を投稿する手順は単純で、Toolbar を起動（ツールバーをクリック）したあと、メニューから「Comment」を選んでページ要素をクリックするか、テキストをハイライトすればスレッドが立ち上がる。スレッドはマークダウン記法と画像添付に対応し、解決済みは Resolve ボタンで閉じられる。Pull Request 作成者と当該スレッドの参加者にはメール通知が届き、Slack 連携を有効にしているチャンネルにはスレッドが転送される。
+
+Draft Mode を Next.js App Router で有効化する際は、まず ISR を有効化し、`draftMode()` を参照するルートを書く。`draftMode().enable()` を呼ぶ API ルートを Headless CMS の Preview ボタンから叩いてもらう構成が一般的である。
+
+```ts filename="app/api/draft/route.ts"
+import { draftMode } from "next/headers";
+import { redirect } from "next/navigation";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const secret = searchParams.get("secret");
+  const slug = searchParams.get("slug");
+
+  if (secret !== process.env.DRAFT_MODE_SECRET || !slug) {
+    return new Response("Invalid token", { status: 401 });
+  }
+
+  const draft = await draftMode();
+  draft.enable();
+
+  redirect(`/posts/${slug}`);
+}
+```
+
+```tsx filename="app/posts/[slug]/page.tsx"
+import { draftMode } from "next/headers";
+
+async function getPost(slug: string) {
+  const { isEnabled } = await draftMode();
+  const endpoint = isEnabled
+    ? `https://draft.example.com/posts/${slug}`
+    : `https://cdn.example.com/posts/${slug}`;
+
+  const res = await fetch(endpoint, {
+    next: { revalidate: 120 },
+    headers: isEnabled
+      ? { Authorization: `Bearer ${process.env.CMS_DRAFT_TOKEN}` }
+      : {},
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch post: ${res.status}`);
+  }
+
+  return res.json();
+}
+
+export default async function PostPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const post = await getPost(slug);
+
+  return (
+    <article>
+      <h1>{post.title}</h1>
+      <div dangerouslySetInnerHTML={{ __html: post.body }} />
+    </article>
+  );
+}
+```
+
+`draftMode().enable()` は内部的に `__prerender_bypass` Cookie を設定する。CMS 側の Preview ボタンからこの API へ遷移させ、戻り先で下書きが表示されるという流れになる。Toolbar からの切替は `next/headers` の draftMode と同じ Cookie を扱う仕組みで、Toolbar が紫色になっていれば Draft Mode 中だと判別できる。
+
+SvelteKit の場合は `+page.server` の `config.isr.bypassToken` を `BYPASS_TOKEN` 環境変数から渡し、`__prerender_bypass` Cookie を発行する API を別途用意する。フレームワーク非依存で実装する場合は Build Output API v3 の prerender 関数に `bypassToken` を指定すれば同じ仕組みが利用できる。
+
+Edit Mode（Content Link）は CMS 側で Content Source Maps を有効にすれば、コード上の追加実装なしに利用できる。Sanity の場合は Visual Editing パッケージをインストールし、Studio の Presentation Tool と組み合わせる。Contentful は Content Source Maps をプロジェクト設定で有効化したうえで `@contentful/live-preview` を組み込む。Builder.io は Visual Editor からそのまま遷移できる。
+
+```ts filename="sanity.config.ts"
+import { defineConfig } from "sanity";
+import { presentationTool } from "sanity/presentation";
+
+export default defineConfig({
+  name: "default",
+  title: "shogo-works",
+  projectId: process.env.SANITY_PROJECT_ID!,
+  dataset: "production",
+  plugins: [
+    presentationTool({
+      previewUrl: {
+        origin: "https://preview.shogoworks.com",
+        previewMode: {
+          enable: "/api/draft",
+        },
+      },
+    }),
+  ],
+});
+```
+
+Slack 連携の初期設定は Vercel Marketplace の Slack アプリを Add Integration し、Slack ワークスペースを承認したあと、対象チャンネルで `/vercel login`・`/vercel subscribe` を実行する流れになる。プロジェクトとチャンネルを紐付け、ブランチやページパスでフィルタを掛けることで通知ノイズを抑えられる。Linear / Jira / GitHub の各 Issue Tracker は Marketplace から個別にインストールし、コメントスレッドの「Convert to Issue」ボタンで起動する。
+
+## 注意点・セキュリティ観点
+
+最大の注意点は権限境界の設計である。Comments は「Vercel アカウントを持つ全員」が既定でコメントできるが、これはチームメンバーが対象であり、外部レビュアーは Preview Deployment Protection の Sharable Links で個別に招待する必要がある。Sharable Links は Pro / Enterprise プランの機能であり、リンクごとに有効期限・パスワード・コメント可否を制御できる。Production の Deployment Protection を有効化していても、Sharable Links 経由のアクセスは Toolbar で正しく認証され、コメントを残せる。
+
+Draft Mode は「チームメンバーしか有効化できない」前提であるため、`?__vercel_draft=1` シェア URL を渡しても外部の人間が下書きを読むことはできない。一方、`__prerender_bypass` Cookie は値が `bypassToken` と一致しさえすれば成立するため、`bypassToken` を Git にコミットしてしまうと CDN キャッシュをバイパスして CMS へ無限にリクエストを発生させる経路を作りかねない。`bypassToken` は環境変数で管理し、Build Output API v3 を使う場合も生成済みトークンをログに出さないこと。Headless CMS との通信を Bearer 認証する場合の `CMS_DRAFT_TOKEN` も同じ要件になる。
+
+Production への Vercel Toolbar 混入は明示的にコントロールする必要がある。`@vercel/toolbar` を `<VercelToolbar />` として常時挿入してしまうと、未認証ユーザーには表示されないものの、スクリプトと CSS は配信される。CSP（Content Security Policy）を厳格化しているサイトでは Toolbar スクリプトのオリジンを `script-src` に許可する必要があり、CSP nonce を使う構成では Toolbar が読み込めず動作しないことがある。Production で Toolbar を使うのは「常時公開のデザインプレビュー環境」のような限定的な場面に絞り、通常は `process.env.VERCEL_ENV !== "production"` などで条件分岐するのが安全である。Toolbar はビルド時の環境変数で `VERCEL_TOOLBAR_DISABLED=1` を指定するか、ダッシュボードからチーム / プロジェクト / セッション粒度で無効化できるため、ステークホルダーごとに見せるかどうかを切り替えやすい。
+
+Edit Mode（Content Link）は Content Source Maps を本番ビルドに含める設定にすると、ソースマップが Production の HTML に挿入される。これは利便性のかわりに「CMS 側のフィールド構造」がクライアントに露出することを意味する。Sanity / Contentful などの公式 SDK は本番では Source Maps を出力しないことを推奨しており、Preview のみで有効にする条件付きビルドを行うのが定石である。
+
+Slack / Linear / Jira へのコメント変換は「便利だが取り返しがつかない」操作である。Issue Tracker への変換時にスレッドが自動 Resolve されたあと再オープンできない仕様であるため、議論途中のコメントを早まってイシュー化しないこと。Jira では「reporter」が変換した本人になるが「creator」は連携セットアップ時のアカウントになるため、専用 Bot アカウントで連携を組まないと監査ログ上の「誰が作ったか」が一人に偏る点も留意が必要である。
+
+プラン依存の制限は次のとおり整理できる。Comments 自体は全プラン無料・既定有効だが、外部コラボレーターを呼ぶ Sharable Links は Pro 以上、Enterprise では Audit Logs に共有元ユーザーが記録される。Toolbar・Draft Mode・Edit Mode の機能本体に対する課金はない一方、Edit Mode を支える CMS 側の Visual Editing 機能には CMS ベンダーごとの料金プランが影響する。Comments の Slack 連携は無料だが、`October 4, 2023` 以降の Slack アプリは追加権限を要求するため、それ以前にインストールしているチームは再設定が必要である。
+
+最後に運用面で押さえるべきは、Comments のステータスチェックを「required」にするかどうかの設計である。既定では未解決コメントがあっても PR をマージできるため、QA フェーズに合わせて Branch Protection で必須化し、リリース直前に解除するなどの運用ルールが必要になる。Preview Deployment Protection を有効にしているチームでは、Comments の通知メールに含まれる URL から自動ログインできるかどうかが体験を左右するため、外部レビュアーには事前に Sharable Link を発行しておくほうが摩擦が少ない。
+
+## 一次ソース（原文）
+
+- [Comments Overview](https://vercel.com/docs/comments)
+- [Integrations for Comments](https://vercel.com/docs/comments/integrations)
+- [Draft Mode](https://vercel.com/docs/draft-mode)
+- [Edit Mode](https://vercel.com/docs/edit-mode)
+- [Vercel Toolbar](https://vercel.com/docs/vercel-toolbar)
+- [Managing the Vercel Toolbar](https://vercel.com/docs/vercel-toolbar/managing-toolbar)
+- [Adding the Toolbar to Production and Localhost](https://vercel.com/docs/vercel-toolbar/in-production-and-localhost)
+- [Vercel Changelog](https://vercel.com/changelog)

--- a/src/content/knowledge/web-development/vercel-docs/37-flags.mdx
+++ b/src/content/knowledge/web-development/vercel-docs/37-flags.mdx
@@ -1,0 +1,230 @@
+---
+title: "Flags — Vercel が提供する自社 Feature Flags プロバイダーと Flags Explorer"
+description: "Vercel Flags は Vercel 自社製のフィーチャーフラグ・プロバイダーであり、Flags SDK（@vercel/flags / flags パッケージ）と Flags Explorer による Toolbar 上の上書き、Boolean / String / Number に加え 2026-05-07 追加の JSON 値、ターゲティング・Segments・Progressive Rollouts、Edge Middleware / Server Components での評価、LaunchDarkly / Statsig / Hypertune / GrowthBook / Optimizely / Split / PostHog などの外部プロバイダー連携、Runtime Logs / Web Analytics による Observability までを単一ダッシュボードで束ねる。"
+category: "web-development"
+subcategory: "vercel"
+createdAt: 2026-05-10
+sortOrder: 37
+---
+
+## この章の要点
+
+Vercel Flags は Vercel が提供する自社製のフィーチャーフラグ・プロバイダーであり、外部 SaaS を増やさずに Dashboard 上でフラグの作成・ターゲティング・段階的ロールアウト・A/B テストまでを完結できる。アプリ側からの評価には `flags`（旧 `@vercel/flags`）パッケージを軸とする Flags SDK を使い、Next.js（App Router / Pages Router / Middleware）と SvelteKit に対しフレームワークネイティブの `flag()` API を提供する。Vercel Toolbar に組み込まれた Flags Explorer により、サインインしたチームメンバーは本番・Preview・ローカルのいずれの環境でもブラウザ上でフラグを上書きでき、上書きはブランチ単位や URL 単位で共有できる。値の型は Boolean / String / Number に加え 2026-05-07 のチェンジログで JSON 値が追加され、AI モデル設定など複数フラグを 1 つにまとめられるようになった。Flags SDK は Vercel 自社プロバイダーだけでなく LaunchDarkly / Statsig / Hypertune / GrowthBook / Optimizely / Split / PostHog / Flagsmith / Edge Config / OpenFeature 互換各社（AB Tasty / CloudBees / ConfigCat / DevCycle / FeatBit / flagd / Flipt / GO FeatureFlag / Kameloon / Tggl など）にもアダプター経由で接続可能で、Marketplace の課金・SSO に統合される。評価は Edge Middleware / Server Component で実行できるよう設計されており、`reportValue` 経由で Runtime Logs と Web Analytics に自動報告され、コンバージョンや Core Web Vitals との相関分析を Vercel ダッシュボード内で完結できる。
+
+## Vercel Flags とは
+
+フィーチャーフラグ（Feature Flag）はソースコードに条件分岐を埋め込み、その条件を実行時に外部から切り替えることで、デプロイと機能リリースを切り離すための仕組みである。トランクベース開発・カナリアリリース・A/B テスト・キルスイッチ・ベータユーザー限定公開といったユースケースを、長寿命のブランチや再デプロイなしで実現する道具で、近年は LaunchDarkly / Statsig / Optimizely / Split / Hypertune / GrowthBook / PostHog などが SaaS として競合する成熟領域になっている。
+
+Vercel Flags はこの領域に Vercel が自社プロバイダーとして参入したプロダクトで、構造としては三層に整理できる。第一に Vercel Dashboard 上のフラグ管理画面・Segments・Drafts・ロールアウト設定といったコントロールプレーン。第二に `flags` パッケージを起点とする Flags SDK で、Next.js / SvelteKit のためのフレームワーク統合と、各社プロバイダーへ接続するアダプター群を提供する。第三に Vercel Toolbar に同梱される Flags Explorer で、ブラウザ拡張的な UI からフラグの値を上書き・共有・推奨する。これらは「プロバイダーは Vercel 自社、または Marketplace 経由で接続した外部 SaaS のどちらでもよい」という前提で組まれており、Dashboard の `Flags` セクションには両者のフラグが横並びに表示される。
+
+歴史的経緯としては、Vercel は 2023 年から OSS の Flags SDK（当初パッケージ名 `@vercel/flags`、現在の正式名は `flags`）を提供しており、自社では長らく「他社プロバイダーのアダプターを束ねる SDK だけを提供する」中立的な立場を取っていた。一方、A/B テストと型安全フラグに強い Hypertune を Vercel は買収・深く統合し、その評価エンジンと UX をベースに Vercel Flags（自社プロバイダー）を立ち上げ、2026 年に GA 相当へと進化した。`flags-sdk.dev` が SDK のドキュメントポータル、`vercel.com/docs/flags` がプラットフォームとしての公式ドキュメントになっている。
+
+## 何が解説されているか
+
+### フラグ定義と評価コンテキスト
+
+Flags SDK では、フラグを 1 つの TypeScript シンボルとして「コードで定義」する。`flag()` ヘルパに `key`、`decide`（評価関数）、`identify`（コンテキスト取得関数）、`options`（取りうる値の集合）を渡し、エクスポートされたシンボルを呼び出すと評価結果が返る。フラグの所在をコード側に持つことで、ビルド時にディスカバリして Dashboard に Draft として登録する仕組みが成立する。`identify` で生成される評価コンテキストは、ユーザー ID・プラン・国・デバイスなどアプリが知っている属性をプロバイダーに渡す境界点であり、ターゲティングの粒度はこの設計に依存する。
+
+### 値の型と JSON 値（2026-05-07）
+
+Vercel Flags のフラグは Boolean / String / Number に加え、2026-05-07 のチェンジログで JSON 値に対応した。これにより、たとえば「AI モデル名・temperature・max tokens・system prompt」を別々のフラグにせず、1 つの JSON フラグの Variant としてまとめて切り替えられる。チェンジログは「これまで複数の関連フラグに分割していた構成を 1 つに集約できる」と表現しており、AI モデルの A/B 比較、漸進的トラフィックシフト、プロバイダー障害時のクイックスイッチといったユースケースを公式に挙げている。型安全のための JSON Schema 連携も Hypertune 由来の仕組みで提供される。
+
+### ターゲティング・Segments・Drafts・Per-environment
+
+Vercel Flags はデフォルトでは全ユーザーに同一値を返し、`Entities`（ユーザー・チーム・デバイスなどアプリが知っている対象）と、その属性を参照する `Targeting Rules` でパーソナライズを行う。`Segments` は属性ルールの再利用単位で、「Beta Testers」「Internal Team」のような名前付きグループを 1 か所で更新するとそれを参照する全フラグに即時反映される。`Drafts` はコード側で定義してデプロイすると Vercel が Flags Discovery エンドポイント経由で検知し、Dashboard にドラフトとして自動で並べる仕組みで、コードと UI の同期コストを下げる。`Per-environment configuration` により Production / Preview / Development で別々の値を設定できる。グローバル複製により設定変更はミリ秒オーダーで世界中に伝播するとドキュメントは説明している。
+
+### Server Components / Edge Middleware での評価
+
+Flags SDK は App Router / Pages Router / Middleware の各ランタイムで等しく動作するように設計されている。Server Component 内では `await flagShape()` のように非同期に呼び、結果に応じて JSX を分岐する。Middleware 上では Edge Runtime で評価し、`rewrite` でバリアントを別パスに振り分けたうえで、対応する静的キャッシュバケットを返す。`Precompute` パターンを使うと、起こりうるバリアントの組み合わせを事前計算してキャッシュキーに織り込み、Edge キャッシュヒットを保ちながら A/B 分岐を実現できる。
+
+### Embedded Definitions
+
+`Embedded definitions` はビルド時にフラグ定義を取得して Deployment にバンドルする機能で、すべての関数が同一スナップショットで動くことを保証し、Vercel Flags サービスが一時的に到達不能になっても評価が止まらないようランタイムフォールバックを提供する。エッジ評価のレイテンシと耐障害性を両立するための Vercel らしい設計である。
+
+### Flags Explorer / Vercel Toolbar
+
+Flags Explorer は Vercel Toolbar 内のパネルで、サインインしたチームメンバーが「Flags Explorer」権限のもと、現在のページで評価されているフラグを一覧・検索・上書きできる UI である。デフォルトでは上書きはブラウザセッション限定で、他のユーザーや自動テストに影響しない。共有方法は 2 通りある。`Save Recommendations` でブランチに紐づけた推奨上書きを保存すると、そのブランチを開いたチームメンバーに Preview デプロイメント上で適用ノーティスが表示される（Production には表示されない）。`Share` を選ぶと現在のページ URL に上書き内容を埋め込んだリンクが生成され、リンクを開いた人に適用ノーティスが出る。Toolbar をどの環境で有効にするかはチーム設定の `In production and localhost` で制御する。
+
+### 外部プロバイダーアダプター
+
+Flags SDK のもう一つの顔は「アダプター集」である。`flags-sdk.dev` のディレクトリには Vercel / Statsig / Hypertune / GrowthBook / Edge Config / LaunchDarkly / Reflag / PostHog / Flagsmith に加え、OpenFeature 互換として AB Tasty / CloudBees / ConfigCat / DevCycle / FeatBit / flagd / Flipt / GO FeatureFlag / Kameloon / Split / Tggl、その他 Optimizely / Split が並ぶ。アプリ側の `flag()` 呼び出しは変えず、`adapter` を差し替えるだけでバックエンドを切り替えられる設計で、Vercel Marketplace 経由で導入した SaaS は Vercel の請求・SSO・ダッシュボードに統合される。
+
+### Observability と Web Analytics 統合
+
+`reportValue(flagKey, flagValue)` を呼ぶと Vercel がそのリクエストやイベントに紐づけて評価値を記録し、Runtime Logs と Web Analytics で「どのフラグがどの値で、何回評価され、コンバージョンや Core Web Vitals にどう影響したか」を分析できる。Flags SDK 経由で評価した場合は手動 instrumentation 不要で自動報告される。これは外部 BI を経由せず Vercel 内部のテレメトリだけで A/B テストの一次評価が完結することを意味する。
+
+### Vercel Flags vs 外部プロバイダー比較
+
+| 観点 | Vercel Flags（自社） | LaunchDarkly | Statsig | Unleash（OSS） |
+| --- | --- | --- | --- | --- |
+| ホスト | Vercel Platform 内蔵 | 独立 SaaS | 独立 SaaS | OSS / セルフホスト or SaaS |
+| Vercel 課金統合 | あり（標準） | Marketplace 経由で可 | Marketplace 経由で可 | 直接統合は限定的 |
+| 評価ランタイム | Edge / Node / Browser、Embedded definitions あり | Edge / Server / Client SDK | Edge / Server / Client SDK | Server / Client SDK |
+| ターゲティング | Entities / Segments / Per-env | フラグ／セグメント／コホート | フラグ／実験／ホールドアウト | フラグ／戦略 |
+| 実験・統計 | A/B 対応、Web Analytics 連携 | Experimentation 製品あり | 実験プラットフォームが本業 | OSS 範囲では限定 |
+| JSON 値 | 対応（2026-05-07） | 対応 | 対応 | 対応 |
+| Toolbar / 上書き UI | Flags Explorer（標準） | LD UI / SDK Override | Statsig Console / Override API | Unleash UI |
+| Observability | Runtime Logs / Web Analytics 自動連携 | LD 内蔵分析 / 連携 | Statsig 内蔵分析 | 別途 |
+| OpenFeature | アダプター対応 | プロバイダーあり | プロバイダーあり | プロバイダーあり |
+
+## 使い方
+
+### 1. SDK のセットアップ
+
+`flags` パッケージ（旧 `@vercel/flags`）を導入し、必要に応じて `FLAGS_SECRET` を設定する。`FLAGS_SECRET` は Flags Explorer から渡されるオーバーライド Cookie の改ざんを検証するための共有秘密で、本番では必ず環境変数に格納する。
+
+```bash filename="terminal"
+pnpm add flags
+# Vercel Flags（自社プロバイダー）を使う場合
+pnpm add @flags-sdk/vercel
+# 例: LaunchDarkly アダプター
+pnpm add @flags-sdk/launchdarkly
+```
+
+### 2. フラグの定義（Next.js / App Router）
+
+```ts filename="flags.ts"
+import { flag } from 'flags/next';
+
+export const newCheckoutFlag = flag<boolean>({
+  key: 'new-checkout',
+  description: '新しいチェックアウト UI を有効にする',
+  defaultValue: false,
+  options: [
+    { value: false, label: 'Old' },
+    { value: true, label: 'New' },
+  ],
+  identify: async ({ headers, cookies }) => ({
+    visitorId: cookies.get('visitor_id')?.value ?? 'anon',
+    country: headers.get('x-vercel-ip-country') ?? 'JP',
+  }),
+  decide: async ({ entities }) => {
+    // Vercel Flags / 外部プロバイダーへ問い合わせる Adapter で置換可能
+    return entities.country === 'JP' && entities.visitorId.startsWith('beta_');
+  },
+});
+```
+
+### 3. Server Component で評価する
+
+```tsx filename="app/(shop)/checkout/page.tsx"
+import { newCheckoutFlag } from '@/flags';
+
+export default async function CheckoutPage() {
+  const isNew = await newCheckoutFlag();
+  return isNew ? <NewCheckout /> : <LegacyCheckout />;
+}
+```
+
+### 4. Edge Middleware で A/B 振り分け
+
+```ts filename="middleware.ts"
+import { NextResponse, type NextRequest } from 'next/server';
+import { newCheckoutFlag } from '@/flags';
+
+export const config = { matcher: ['/checkout/:path*'] };
+
+export async function middleware(req: NextRequest) {
+  const isNew = await newCheckoutFlag();
+  const url = req.nextUrl.clone();
+  url.pathname = isNew ? `/variants/new${url.pathname}` : `/variants/old${url.pathname}`;
+  return NextResponse.rewrite(url);
+}
+```
+
+### 5. JSON 値で AI モデル設定をひとまとめにする（2026-05-07 追加）
+
+```ts filename="flags/ai-model.ts"
+import { flag } from 'flags/next';
+
+type AIModelConfig = {
+  provider: 'anthropic' | 'openai' | 'xai';
+  model: string;
+  temperature: number;
+  maxTokens: number;
+  systemPrompt: string;
+};
+
+export const aiModelConfig = flag<AIModelConfig>({
+  key: 'ai-model-config',
+  defaultValue: {
+    provider: 'anthropic',
+    model: 'claude-sonnet-4.6',
+    temperature: 0.4,
+    maxTokens: 2048,
+    systemPrompt: 'You are a helpful assistant.',
+  },
+  options: [
+    {
+      label: 'Anthropic Sonnet',
+      value: {
+        provider: 'anthropic',
+        model: 'claude-sonnet-4.6',
+        temperature: 0.4,
+        maxTokens: 2048,
+        systemPrompt: 'You are a helpful assistant.',
+      },
+    },
+    {
+      label: 'xAI Grok Fast',
+      value: {
+        provider: 'xai',
+        model: 'grok-4.1-fast-non-reasoning',
+        temperature: 0.5,
+        maxTokens: 2048,
+        systemPrompt: 'You are a concise assistant.',
+      },
+    },
+  ],
+});
+```
+
+### 6. 外部プロバイダー（LaunchDarkly）への差し替え
+
+`adapter` を差し替えるだけで、アプリ側の呼び出しは変わらない。
+
+```ts filename="flags.ts"
+import { flag } from 'flags/next';
+import { ldAdapter } from '@flags-sdk/launchdarkly';
+
+export const newCheckoutFlag = flag<boolean>({
+  key: 'new-checkout',
+  defaultValue: false,
+  adapter: ldAdapter.variation<boolean>(),
+});
+```
+
+### 7. Toolbar / Flags Explorer の有効化
+
+Vercel Toolbar を Production・Preview・Localhost で有効化する設定をチームレベルで行ったうえで、Flags Explorer 権限を持つメンバーは Toolbar から `Flags Explorer` を開き、検索 → 値選択 → Apply で上書きできる。複数の上書きをチーム共有したい場合はブランチに `Save Recommendations` で紐づけ、単発で共有したい場合は `Share` で URL を生成する。
+
+### 8. Observability（Web Analytics 連携）
+
+Flags SDK で評価したフラグは自動的に `reportValue` 経由で Web Analytics に送られる。SDK を使わず手動で値を送りたい場合のみ `reportValue('new-checkout', true)` を呼ぶ。Web Analytics の Insights では「フラグ ON 群と OFF 群のコンバージョン差」「LCP / INP の差」を自動計算して並べて見られる。
+
+## 注意点・セキュリティ観点
+
+第一にキャッシュとの関係である。Edge Middleware で `rewrite` した先のページが ISR・SSG・Data Cache を持つ場合、フラグのバリアントごとにキャッシュキーを分離しないとバリアントが混線する。`Precompute` パターンや、URL を変える `rewrite` 経由の振り分けが推奨される理由はこれで、`cookies()` を読む Server Component に直接フラグを混ぜると Dynamic レンダリングに転落しがちな点も含めて、ランタイム特性を理解する必要がある。
+
+第二に Cookie / Identity の設計である。`identify` で参照する Cookie・ヘッダがログインユーザーに依存するか匿名訪問者に依存するかでバケッティングの安定性が変わる。匿名 A/B テストでは長命の `visitor_id` Cookie を Edge Middleware で発行し、ログイン後はユーザー ID へ滑らかに引き継ぐ二段構成が定石である。Cookie のドメインスコープ、SameSite、暗号化の有無を要件に合わせて設計しないと「再訪のたびにバリアントが揺れる」事故を起こす。
+
+第三に Stale フラグの整理である。Flags as Code 設計上、コードに残っているフラグだけが Drafts として Dashboard に上がる。逆に「コードからは消したのに Dashboard には残り続ける」「Dashboard では Off にしているのにコードからは参照され続ける」状態を放置するとロールバック・観測の整合が崩れる。リリース完了したフラグは「コード削除 → PR レビュー → Dashboard アーカイブ」の順序で確実に閉じる運用ルールを置くべきである。
+
+第四に不正な上書き防止である。Flags Explorer の上書きは `FLAGS_SECRET` で署名された Cookie に基づいて適用される。シークレットを公開リポジトリやログに漏らすと攻撃者が任意のフラグ値を強制できるため、シークレットローテーション手順とアクセス権限（Flags Explorer 権限）の付与レビューを定期化する。Production の Toolbar 利用は Vercel チームに所属しサインインした人のみであり、未認証ユーザーは Explorer を開けない設計だが、`Share` URL の流出にも注意する。
+
+第五に A/B 計測の観測偏りである。`reportValue` は評価したリクエストにのみ紐づくため、Server Component とクライアントの両方でフラグを評価していると二重カウントが起きる、あるいは評価せずにそのバリアントの UI を出すと未報告になり計測が歪む。1 つのバリアント決定につき 1 度だけ評価する規律と、Web Analytics 上のコンバージョン定義を SRM（Sample Ratio Mismatch）チェックで監視する運用を推奨する。
+
+第六に Edge での評価コストである。Vercel Flags はグローバル複製と Embedded Definitions により評価そのものは極めて軽いが、外部プロバイダー（LaunchDarkly / Statsig 等）を Edge から直接叩くアダプター構成では SaaS の SLA・地理レイテンシがクリティカルパスに入る。Edge Config 連携や、ビルド時に定義をプリフェッチして Edge にバンドルするアダプターを選ぶ、あるいはバックグラウンド更新型のアダプターを選ぶことで、評価レイテンシを Vercel ネットワーク内に閉じ込められる。
+
+第七に SLA とフォールバックである。`flag()` の `defaultValue` と Embedded Definitions のフォールバックを必ず設定し、フラグサービスへの到達不能時にもアプリが安全側に倒れる挙動を保証する。特にキルスイッチ用途のフラグは「Off が安全」になるよう論理を反転させて持っておくのが原則である。
+
+## 一次ソース（原文）
+
+- Flags（Vercel Docs トップ） — https://vercel.com/docs/flags
+- Vercel Flags（自社プロバイダー） — https://vercel.com/docs/flags/vercel-flags
+- Flags Explorer — https://vercel.com/docs/flags/flags-explorer
+- Flags Observability — https://vercel.com/docs/flags/observability
+- Flags SDK Reference — https://vercel.com/docs/flags/flags-sdk-reference
+- Flags SDK 公式ポータル（OSS） — https://flags-sdk.dev
+- Vercel Changelog（2026-05-07: JSON values for Vercel Flags 他） — https://vercel.com/changelog
+- Vercel Toolbar（Flags Explorer 連携元） — https://vercel.com/docs/vercel-toolbar

--- a/src/content/knowledge/web-development/vercel-docs/38-pricing-and-spend-management.mdx
+++ b/src/content/knowledge/web-development/vercel-docs/38-pricing-and-spend-management.mdx
@@ -1,0 +1,196 @@
+---
+title: "Pricing & Spend Management — Active CPU 課金・利用枠・Spend Cap で Vercel コストを設計する"
+description: "Vercel の Hobby / Pro / Enterprise の三プラン構造と、Fluid Compute による Active CPU 課金、Functions / Bandwidth / Image Optimization / Edge Requests / Storage（Blob / KV / Postgres）/ Queues / Workflows / Microfrontends といった機能別の従量課金軸を整理する。さらに Spend Management（Spend Cap・Usage Alerts・Webhook・プロジェクト一括停止）と Cost Observability、Marketplace 経由の外部プロバイダー課金まで、設計と運用の観点で 2026 年 5 月時点の単価とともにまとめる。"
+category: "web-development"
+subcategory: "vercel"
+createdAt: 2026-05-10
+sortOrder: 38
+---
+
+## この章の要点
+
+- Vercel の課金は「プラン定額」「機能別従量課金」「Spend Cap によるガード」の三層構造で構成される。Hobby は永続無料、Pro は $20/ユーザー/月＋ $20 分の利用クレジット、Enterprise はカスタム見積もりという建付けである。
+- Fluid Compute の Active CPU 課金は、I/O 待機中に CPU 課金が止まる仕組みであり、AI 推論や外部 API 呼び出しを含む I/O バウンドな処理で従来比最大 90% 弱（公式の Standard サイズ 100% 稼働比較で約 53%、I/O バウンドな実ワークロードでは公称 85% 級）のコスト削減を実現する。2025 年 6 月 25 日に発表された。
+- Hobby プランには Active CPU 4 時間・Provisioned Memory 360 GB-時・Invocations 100 万回・Fast Data Transfer 100 GB・Edge Requests 100 万回・Build Execution 6,000 分などが含まれる。Pro はクレジットの範囲内で使い、超過分はリージョン別または公開単価で従量課金される。
+- Functions（Active CPU $0.128/時、Provisioned Memory $0.0106/GB-時、Invocations $0.60/100 万回）、Edge Requests（$2/100 万、初回 1,000 万回付与）、Image Optimization（$0.05–$0.0812/1K 変換）、Microfrontends（$2/100 万 Routing、追加プロジェクト $250/月）、Workflows（$20/100 万 Events、データ書込 $0.50/GB）、Observability Plus（Pro $10/月＋ $1.20/100 万 Events）といった単価が、機能ごとに公式に明記されている。
+- Spend Management は Spend Cap・Usage Alerts・Webhook・Production Deployment 一括 Pause を提供する。Vercel が数分間隔で利用量を集計するため上限到達は瞬時には止まらず、DDoS のようなバーストではコスト超過のリスクが残る。WAF / Rate Limit と組み合わせて多層防御を組む必要がある。
+- Cost Observability ダッシュボードと Activity ログ、Webhook payload による外部連携でコスト可視化が可能だが、Marketplace パートナー（外部 DB・LLM プロバイダー等）の利用料は Spend Cap の対象外である点に注意する。
+
+## Vercel Pricing & Spend Management とは
+
+Vercel の課金体系は、プランごとの「定額部分」、機能ごとの「従量課金部分」、超過を抑えるための「Spend Cap」という三層で整理できる。プランは Hobby / Pro / Enterprise の三段階で、それぞれ対象ユーザー像が明確に分かれている。Hobby は個人開発・学習・OSS 用の無料プランで、商用利用は許可されていない。Pro は $20/ユーザー/月の有償プランで、$20 分の Managed Infrastructure 利用クレジットが付帯し、超過分は従量で課金される。Enterprise は SAML SSO・契約リージョン・専任サポート・カスタム上限などを伴うカスタム価格である（出典: [Pricing](https://vercel.com/pricing)、2026 年 5 月時点）。
+
+機能別の従量課金は「Managed Infrastructure（Functions・Bandwidth・Image Optimization・Storage 等）」と「DX Platform（Observability・Web Analytics・Speed Insights 等の運用機能）」の二系統に整理されている。Managed Infrastructure はリクエスト数や転送量で計測され、DX Platform は固定月額または Event 単価で課金される（出典: [Pricing on Vercel](https://vercel.com/docs/pricing)、`last_updated: 2026-02-27`）。
+
+Active CPU 課金は、Fluid Compute と一体化した課金モデルであり、Vercel の Pricing 体系の中核に位置する革新である。従来のサーバーレスは「実行時間 × メモリ」を GB-Hours としてまとめて課金していたため、外部 API レスポンス待ちのアイドル時間まで CPU 単価が乗り続けていた。Active CPU 課金では、CPU は「コードが実際に CPU を消費している時間」のみ計上され、I/O 待機中は止まる。一方、Provisioned Memory はインスタンスの最終リクエスト完了まで連続課金される。これにより、AI Gateway 経由の LLM 呼び出しのように I/O が支配的なワークロードで著しいコスト削減が見込める（出典: [Lower pricing with Active CPU pricing for Fluid Compute](https://vercel.com/changelog/lower-pricing-with-active-cpu-pricing-for-fluid-compute)、2025-06-25）。
+
+Spend Management は、これら従量課金が想定外に膨らむことを防ぐためのガード機能群である。Spend Cap、Usage Alerts、Webhook、Production Deployment の一括 Pause が用意され、Pro プラン以上で利用できる（出典: [Spend Management](https://vercel.com/docs/spend-management)）。Hobby ではそもそも従量課金が発生しないため、利用枠を超えると新たな実行が停止される設計になっており、プランそのものが事実上のキャップとして機能する。
+
+## 何が解説されているか
+
+公式 Pricing ドキュメントは、課金単位を「Resource（課金対象）」と「Metric（計測軸）」のペアで列挙する形式で構成されている。たとえば Vercel Functions は Active CPU・Provisioned Memory・Invocations の三軸、Image Optimization は Transformations・Cache Reads・Cache Writes の三軸といった具合に、機能ごとに独立した単価が定義される。このため、コスト試算は単純な「実行時間 × 単価」では完結せず、機能ごとの利用枠と従量単価をマトリクスで把握する必要がある。
+
+まず、プラン比較を示す。料金は 2026 年 5 月時点の公開価格で、Pro の従量単価はリージョンによって変動するものを含む。
+
+| 項目 | Hobby | Pro | Enterprise |
+| --- | --- | --- | --- |
+| 月額 | 無料（永続） | $20/ユーザー/月（$20 クレジット付） | カスタム |
+| 商用利用 | 不可 | 可 | 可 |
+| Projects 数上限 | 200 | 無制限 | 無制限 |
+| Concurrent Builds | 1 | 12 | カスタム |
+| Static File Uploads | 100 MB | 1 GB | N/A |
+| Build Time / Deployment | 45 分 | 45 分 | 45 分 |
+| Runtime Logs 保持 | 1 時間 | 1 日 | 3 日 |
+| Active CPU 含み | 4 CPU-時 | クレジット内 | カスタム |
+| Provisioned Memory 含み | 360 GB-時 | クレジット内 | カスタム |
+| Invocations 含み | 100 万回 | 100 万回 | カスタム |
+| Fast Data Transfer 含み | 100 GB | 1 TB | カスタム |
+| Edge Requests 含み | 100 万回 | 1,000 万回 | カスタム |
+| Build Execution 含み | 6,000 分 | クレジット内 | カスタム |
+
+出典: [Limits](https://vercel.com/docs/limits)（`last_updated: 2026-03-02`）、[Pricing on Vercel](https://vercel.com/docs/pricing)、[Pricing](https://vercel.com/pricing)。
+
+次に、Pro プランで超過分が発生したときに適用される機能別の従量単価を、設計時に頻出するものに絞ってまとめる。リージョン依存の単価は東京（hnd1）など特定リージョンを指定すると高くなる傾向があり、グローバル平均より割高に試算しておくのが安全である。
+
+| 機能 | 計測軸 | Pro 単価 | Pro の含み枠 |
+| --- | --- | --- | --- |
+| Functions Active CPU | CPU-時 | $0.128/時（リージョン別） | クレジット内 |
+| Functions Provisioned Memory | GB-時 | $0.0106/GB-時（リージョン別） | クレジット内 |
+| Function Invocations | 件 | $0.60/100 万回 | 100 万回 |
+| Fast Data Transfer | GB | リージョン別 | 1 TB |
+| Edge Requests | 件 | リージョン別（公示 $2/100 万 目安） | 1,000 万回 |
+| Image Optimization Transformations | 件 | $0.05–$0.0812/1K | 5K（Hobby）/ 10K（Pro 月） |
+| Image Optimization Cache Reads | 件 | $0.40–$0.64/100 万 | 300K–600K/月 |
+| Image Optimization Cache Writes | 件 | $4.00–$6.40/100 万 | 100K–200K/月 |
+| Edge Config Reads | 件 | $3.00/100 万 | 100 万 |
+| Edge Config Writes | 件 | $5.00/1,000（Pro 換算 $1.00/1,000 含み枠超過分） | 1,000 |
+| ISR Reads | 件 | リージョン別 | 1,000 万 |
+| ISR Writes | 件 | リージョン別 | 200 万 |
+| Blob Storage Size | GB-月 | リージョン別 | 5 GB |
+| Blob Simple Operations | 件 | リージョン別 | 100,000 |
+| Blob Advanced Operations | 件 | リージョン別 | 10,000 |
+| Blob Data Transfer | GB | リージョン別 | 100 GB |
+| Workflow Events | 件 | $20/100 万 | 利用ベース |
+| Workflow Data Written | GB | $0.50/GB | 利用ベース |
+| Workflow Data Retained | GB-月 | $0.50/GB-月 | 利用ベース |
+| Queue API Operations | 件 | リージョン別 | N/A |
+| Microfrontends Routing | 件 | $2/100 万 | 50K（Hobby） |
+| Microfrontends 追加プロジェクト | プロジェクト | $250/月 | 2 |
+| Bulk Redirects | 件 | $0.002/月 × 25,000 件 | 1,000（Pro）/ 10,000（Ent） |
+| Web Analytics Events | 件 | $0.00003/件 | 100,000 |
+| Speed Insights Data Points | 件 | $0.65/データポイント | 10,000 |
+| Observability Plus | Event | $1.20/100 万＋ベース $10/月 | 100 万 |
+| Drains Volume | GB | $0.50/GB | N/A |
+| WAF Rate Limiting | Allowed Requests | リージョン別 | 100 万 |
+
+出典: [Pricing on Vercel](https://vercel.com/docs/pricing)、[Limits](https://vercel.com/docs/limits)。リージョン別単価は [Regional pricing](https://vercel.com/docs/pricing/regional-pricing) を参照のこと。
+
+DX Platform 側の追加機能は固定月額が中心である。Pro プランの代表的な add-on は SAML Single Sign-On（$300/月）、HIPAA BAA（$350/月）、Static IPs（$100/プロジェクト/月）、Preview Deployment Suffix（$100/月）、Flags Explorer（$250/月）、Speed Insights（$10/プロジェクト/月）である（出典: [Pricing on Vercel](https://vercel.com/docs/pricing)）。これらは Spend Cap の対象外で月次固定で課金される。
+
+最後に、AWS / Cloudflare とのシンプルな比較を示す。Vercel は「ホスティング＋ CDN ＋関数＋ DX」を一体料金で提供するため、AWS Lambda + CloudFront のような自前構成と単純比較するのは難しいが、コスト観点での代表例は次のとおりである。
+
+| 観点 | Vercel（Pro） | AWS（Lambda + CloudFront） | Cloudflare（Workers Paid） |
+| --- | --- | --- | --- |
+| 関数の課金軸 | Active CPU + Provisioned Memory + Invocations | GB-Seconds + Requests | CPU time + Requests |
+| アイドル時の CPU 課金 | 停止（Fluid Compute） | 停止（VPC 内処理時間のみ） | 停止 |
+| エッジ関数 | Edge Functions（V8 Isolate） | Lambda@Edge / CloudFront Functions | Workers（V8 Isolate） |
+| バンドル幅 | リージョン別（Fast Data Transfer） | リージョン別（CloudFront DTO） | 含む（Free Tier 大きめ） |
+| Spend Cap | 公式に提供 | Budgets で間接的に通知のみ | 公式に上限通知 |
+| プラットフォーム DX | フレームワーク統合・Preview URL・Observability 一体 | 個別構成が必要 | 一定の統合 |
+
+Vercel の Pricing は単純な単価では Cloudflare のほうが安いケースもあるが、Preview Deployment・Build Pipeline・Observability などの DX が単一料金に内包されている点で総保有コストは別軸の比較になる（一次情報: [Pricing](https://vercel.com/pricing)）。
+
+## 使い方
+
+### Spend Cap の設定
+
+Spend Cap は Pro プランの Owner / Billing ロールで有効化する。手順は次のとおりである（出典: [Spend Management](https://vercel.com/docs/spend-management)）。
+
+1. ダッシュボードのチームを開き、Settings → Billing を選択する。
+2. Spend Management セクションのトグルを Enabled に切り替える。
+3. 上限金額を USD で入力する（請求サイクル単位）。
+4. 上限到達時のアクションとして「通知のみ」「Webhook 発火」「全プロジェクトの Production Deployment 一括 Pause」のいずれか、または複数を選択する。
+
+請求サイクルの途中で金額を変更した場合、現在の累積額が新しい上限を超えていれば、設定したアクションが即座にトリガーされる。Pause を選択すると、Vercel が数分間隔で利用量を集計したうえで全プロジェクトの本番デプロイを停止する。停止後は 503 `DEPLOYMENT_PAUSED` エラーが返り、再開は各プロジェクト単位でダッシュボードか REST API（`Unpause a project`）から手動で行う必要がある。
+
+### Usage Alerts
+
+Spend Cap を設定すると、メールおよび Web 通知が 50% / 75% / 100% の到達時に自動配信される。SMS 通知は 100% 到達時のみ有効化でき、Owner / Billing ロールが Settings → My Notifications → SMS で電話番号を登録すると受信できる（出典: [Spend Management](https://vercel.com/docs/spend-management)）。
+
+### Webhook 連携
+
+Webhook URL を登録すると、上限到達時と請求サイクル終了時に POST リクエストが送信される。検証用の payload は次の形式である（出典: [Spend Management](https://vercel.com/docs/spend-management)）。
+
+```json filename="webhook-payload.json"
+{
+  "budgetAmount": 500,
+  "currentSpend": 500,
+  "teamId": "team_jkT8yZ3oE1u6xLo8h6dxfNc3",
+  "thresholdPercent": 100
+}
+```
+
+リクエストには `x-vercel-signature` ヘッダが付与され、Webhook 保存時に発行される SHA と比較することで偽造リクエストを排除できる。請求サイクル終了時には `{"teamId": "...", "type": "endOfBillingCycle"}` が送信されるため、これをトリガーに Pause したプロジェクトを REST API で自動再開する仕組みを組むのが定石である。
+
+### Cost Observability の使い方
+
+Vercel ダッシュボードの Usage タブでは、機能別・プロジェクト別の利用状況がリアルタイムに近い粒度で可視化される。Functions の Active CPU と Provisioned Memory は別グラフで表示されるため、CPU 偏重なのか Memory 偏重なのかを切り分けて、`maxDuration` を短くするべきか、メモリサイズを下げるべきかの意思決定に使える。Activity ログには Spend Management の操作（金額変更、Pause、Resume）が記録され、監査用途に利用できる（出典: [Spend Management](https://vercel.com/docs/spend-management)）。
+
+### Fluid Compute 有効化前後の試算
+
+Fluid Compute は 2025 年 4 月 23 日以降の新規プロジェクトでデフォルト有効化されている。それ以前のプロジェクトはダッシュボードの Functions Settings、または `vercel.json` の `"fluid": true` で切り替えられる（前章 [Functions & Fluid Compute](./21-functions-and-fluid-compute) 参照）。試算の目安として、AI 推論を 1 日 10 万回・各リクエストが 8 秒間（うち CPU 実時間 1.5 秒・I/O 待機 6.5 秒）・メモリ 2 GB という想定では、従来サーバーレスの GB-Hours 課金では「8 秒 × 2 GB = 16 GB-秒」全量が課金対象であるのに対し、Fluid Compute では Active CPU 課金は 1.5 秒分のみとなる。Active CPU は $0.128/時、Provisioned Memory は $0.0106/GB-時という公式単価を当てはめて月次合計を出し、Invocations $0.60/100 万回を加える形で見積もる。リージョンによっては Active CPU が $0.202/時（hnd1 等）まで上がる点も忘れてはならない。
+
+### AI Gateway / v0 の料金確認
+
+AI Gateway や v0 など Vercel の AI 系プロダクトは別系統の従量課金である。AI Gateway はトークン単位、v0 はクレジット制で、Pro プランでも独立した請求項目として積み上がる。Marketplace 連携で利用する外部 LLM（OpenAI 等）の従量課金は Vercel が代行請求するケースもあるが、Spend Cap の対象には含まれないため、各プロバイダーのダッシュボードでも別途確認する必要がある（出典: [Pricing on Vercel](https://vercel.com/docs/pricing)、[Spend Management](https://vercel.com/docs/spend-management) — `It does not include seats, integrations (such as Marketplace), or separate add-ons` の記述）。
+
+## 注意点・セキュリティ観点
+
+### DDoS によるコスト爆発
+
+Spend Cap は数分間隔の集計に基づくため、瞬間的なバーストでは上限到達を検知してから停止までにラグが発生する。攻撃トラフィックが Edge Requests と Function Invocations を同時に押し上げるシナリオでは、停止前に数百 GB の Fast Data Transfer や数千万件の Invocations が発生する可能性がある。対策として、Vercel WAF の Rate Limiting（Pro 含み 100 万 Allowed Requests）と Bot Filter、Attack Challenge Mode を併用し、関数到達前に弾く多層防御を組む（出典: [Spend Management](https://vercel.com/docs/spend-management) の `Pausing is not instantaneous` の記述）。
+
+### Hobby の商用利用制限
+
+Hobby プランは商用利用が禁じられており、業務サイト・収益化されているプロダクトでの利用は規約違反となる。商用案件は Pro 以上が前提である。Hobby プロジェクトを商用に転用する場合は Pro へ昇格するか、Pro チームへ Transfer する必要がある。
+
+### Active CPU の見落としやすい計上
+
+Active CPU は「コードが CPU を消費している時間」のみ課金されるが、`waitUntil` で投入したバックグラウンド処理やストリーミングレスポンスのループ処理は CPU 時間として計上され続ける。レスポンス送信後にバックグラウンドで重い計算をしている関数は、見かけ上のレスポンスが速くても Active CPU 単価が積み上がりやすい。Observability で関数別・パス別の CPU 時間を定期的に確認することが必須である。
+
+### コミット履歴での秘匿情報除去（Spend 観点）
+
+機微情報の漏洩が Spend に波及するパターンとしては、API Key が漏れて外部から不正に Functions を叩かれ、Active CPU と Invocations が膨れ上がるケースが典型である。`.env` をコミットしないのは当然として、過去コミットに混入していないかを `gitleaks` 等で監査し、漏れていた場合は鍵をローテーションしたうえで、その期間の Spend を Vercel サポートと精査する運用を推奨する。
+
+### 組織外メンバーへの権限
+
+Spend Cap の設定変更は Owner / Billing ロールに限定されている。Developer ロールはコード変更で従量を増やせる一方で Spend Cap を緩める権限がないため、開発者の自由度を保ちつつ財布を守る役割分担が可能である（出典: [Spend Management](https://vercel.com/docs/spend-management)）。逆に Owner を必要以上に付与すると意図せず上限を引き上げられるリスクがあるため、Owner は最小限に絞るべきである。
+
+### Marketplace パートナーの二重請求
+
+Marketplace 経由で Neon、Upstash、Resend などの外部プロバイダーを契約した場合、課金は Vercel 側に統合される。一方、外部プロバイダー側で直接アカウントを持っている場合は二重請求になりかねない。Marketplace 統合を導入する際は、既存の直接契約を停止または Vercel 側へ移管したかを必ず確認する（出典: [Spend Management](https://vercel.com/docs/spend-management) の Marketplace 記述）。
+
+### Provisioned Memory の継続課金
+
+Active CPU と異なり、Provisioned Memory は最後のリクエストが完了してインスタンスが解放されるまで継続課金される。`waitUntil` で投入した非同期処理が長引くとインスタンスのライフタイムが延び、メモリ単価がかさむ。長時間バックグラウンド処理は Workflows や Queues に切り出して計測軸を分離するのが望ましい。
+
+### Build 系コストの見落とし
+
+Build Execution は Hobby が 6,000 分含み、Pro はクレジット内である。CI から Preview を多用するチームは Build 時間が想定以上に伸びやすい。`vercel.json` の `ignoreCommand` や Turbo Build 機（$0.126/分）への切り替え可否を含め、Build マシンのサイズ選定もコスト設計に組み込む（出典: [Pricing on Vercel](https://vercel.com/docs/pricing)、[Limits](https://vercel.com/docs/limits)）。
+
+## 一次ソース（原文）
+
+- [Pricing — Vercel](https://vercel.com/pricing)
+- [Pricing on Vercel（docs）](https://vercel.com/docs/pricing) — `last_updated: 2026-02-27`
+- [Limits — Vercel](https://vercel.com/docs/limits) — `last_updated: 2026-03-02`
+- [Spend Management — Vercel](https://vercel.com/docs/spend-management) — `last_updated: 2026-02-27`
+- [Lower pricing with Active CPU pricing for Fluid Compute（Changelog）](https://vercel.com/changelog/lower-pricing-with-active-cpu-pricing-for-fluid-compute) — 2025-06-25
+- [Vercel Functions: Usage and pricing](https://vercel.com/docs/functions/usage-and-pricing)
+- [Image Optimization: Limits and pricing](https://vercel.com/docs/image-optimization/limits-and-pricing)
+- [Vercel Blob: Usage and pricing](https://vercel.com/docs/vercel-blob/usage-and-pricing)
+- [Microfrontends: Limits and pricing](https://vercel.com/docs/microfrontends#limits-and-pricing)
+- [Workflows pricing](https://vercel.com/docs/workflows/pricing)
+- [Regional pricing](https://vercel.com/docs/pricing/regional-pricing)
+- [How does Vercel calculate usage of resources?](https://vercel.com/docs/pricing/how-does-vercel-calculate-usage-of-resources)
+- [Manage and optimize usage](https://vercel.com/docs/pricing/manage-and-optimize-usage)
+- [Improved infrastructure pricing（Blog）](https://vercel.com/blog/improved-infrastructure-pricing)

--- a/src/content/knowledge/web-development/vercel-docs/99-sources.mdx
+++ b/src/content/knowledge/web-development/vercel-docs/99-sources.mdx
@@ -128,6 +128,27 @@ robots.txt 上の指示（`ai-train=no` / `ai-input=yes` / `search=yes`）に従
 - [Notebooks in Observability](https://vercel.com/changelog/create-and-share-queries-with-notebooks-in-vercel-observability)
 - [OpenTelemetry log drains](https://vercel.com/changelog/correlate-logs-and-traces-with-opentelemetry-in-vercel-log-drains)
 
+## 第 28 章 Queues & Workflows
+
+- [Vercel Queues](https://vercel.com/docs/queues)
+- [Queues Pricing](https://vercel.com/docs/queues/pricing)
+- [Queues SDK](https://vercel.com/docs/queues/sdk)
+- [Vercel Workflows](https://vercel.com/docs/workflows)
+- [Workflows Concepts](https://vercel.com/docs/workflows/concepts)
+- [Workflows Python](https://vercel.com/docs/workflows/python)
+- [Workflows Pricing](https://vercel.com/docs/workflows/pricing)
+- [Workflow SDK](https://workflow-sdk.dev/)
+- [Vercel Queues Public Beta](https://vercel.com/changelog/vercel-queues-now-in-public-beta)
+
+## 第 29 章 Microfrontends
+
+- [Microfrontends Documentation](https://vercel.com/docs/microfrontends)
+- [Microfrontends now Generally Available](https://vercel.com/changelog/microfrontends-now-generally-available)
+- [Microfrontends ローカル開発](https://vercel.com/docs/microfrontends/local-development)
+- [microfrontends.json リファレンス](https://vercel.com/docs/microfrontends/configuration)
+- [Vercel Blog: Microfrontends 採用事例](https://vercel.com/blog)
+- [Cursor on Vercel](https://vercel.com/customers/cursor)
+
 ## 第 30 章 セキュリティ・コンプライアンス
 
 - [Vercel Security](https://vercel.com/docs/security)
@@ -179,6 +200,42 @@ robots.txt 上の指示（`ai-train=no` / `ai-input=yes` / `search=yes`）に従
 - [Static IPs](https://vercel.com/changelog/static-ips-are-now-available-for-more-secure-connectivity)
 - [Trusted IPs GA](https://vercel.com/changelog/trusted-ips-is-now-generally-available-for-enterprise-customers)
 - [DHE 廃止](https://vercel.com/changelog/deprecating-the-dhe-cipher-suite-for-tls-connections)
+
+## 第 36 章 Collaboration
+
+- [Vercel Comments](https://vercel.com/docs/comments)
+- [Draft Mode](https://vercel.com/docs/draft-mode)
+- [Edit Mode](https://vercel.com/docs/edit-mode)
+- [Vercel Toolbar](https://vercel.com/docs/vercel-toolbar)
+- [Toolbar in Production](https://vercel.com/docs/vercel-toolbar/in-production-and-localhost)
+- [Slack 連携](https://vercel.com/integrations/slack)
+- [Linear 連携](https://vercel.com/integrations/linear)
+- [Sanity Presentation Tool](https://www.sanity.io/docs/presentation)
+
+## 第 37 章 Flags
+
+- [Vercel Flags Documentation](https://vercel.com/docs/feature-flags)
+- [Flags SDK](https://flags-sdk.dev/)
+- [Flags Pattern in Next.js](https://vercel.com/docs/feature-flags/flags-pattern-nextjs)
+- [Flags Explorer](https://vercel.com/docs/feature-flags/flags-explorer)
+- [Vercel Flags GA](https://vercel.com/changelog/vercel-flags-ga)
+- [Vercel Flags Public Beta](https://vercel.com/changelog/vercel-flags-is-now-in-public-beta)
+- [Flags JSON 値対応（2026-05-07）](https://vercel.com/changelog)
+- [Workflows in Observability](https://vercel.com/docs/observability)
+
+## 第 38 章 Pricing & Spend Management
+
+- [Vercel Pricing](https://vercel.com/pricing)
+- [Pricing Documentation](https://vercel.com/docs/pricing)
+- [Spend Management](https://vercel.com/docs/spend-management)
+- [Limits](https://vercel.com/docs/limits)
+- [Active CPU Pricing for Fluid Compute](https://vercel.com/changelog/lower-pricing-with-active-cpu-pricing-for-fluid-compute)
+- [Understanding my Invoice](https://vercel.com/docs/pricing/understanding-my-invoice)
+- [Regional Pricing: iad1](https://vercel.com/docs/pricing/regional-pricing/iad1)
+- [Regional Pricing 全リージョン](https://vercel.com/docs/pricing/regional-pricing)
+- [Spend Management hard caps](https://vercel.com/changelog/improved-hard-caps-for-spend-management)
+- [Billing / Usage Cost Data API](https://vercel.com/changelog/access-billing-usage-cost-data-api)
+- [Marketplace](https://vercel.com/docs/integrations/install-an-integration/product-integration)
 
 ## 第 40 章 v0 & AI SDK
 


### PR DESCRIPTION
## Summary
- Vercel 公式ドキュメントの差分リサーチ結果を反映し、未カバーだった 5 領域を独立 1 章ずつ追加
- 各記事は 7,500〜10,000 字、6 セクション構成、公式ドキュメントの WebFetch で数値・日付を裏取り済み
- 99-sources.mdx に第 28 / 29 / 36 / 37 / 38 章のセクションを追加（一次ソース URL 合計 40+ 本）

## 追加記事
| sortOrder | タイトル | カバー範囲 |
|---|---|---|
| 28 | Queues & Workflows | durable event streaming + multi-step workflow（'use workflow' / 'use step'、JS/TS/Python） |
| 29 | Microfrontends | GA（2025-10-31）、1日約10億req、Cursor 等 250+ チーム採用、Zone 設定 |
| 36 | Collaboration | Comments / Draft Mode / Edit Mode / Toolbar スイート |
| 37 | Flags | Vercel 自社 Flags / @vercel/flags SDK / Flags Explorer / 2026-05-07 JSON 値対応 |
| 38 | Pricing & Spend Management | Active CPU pricing（最大 90% 削減）/ プラン別利用枠 / Spend Cap / Cost Observability |

## 関連 PR / 作業の切り分け
- 新 tier「Collaboration & Operations」(sortOrderStart: 36) の knowledgeTiers.ts への追加は #125（feat/knowledge-tier-sidebar）と重複するため、本 PR では行わず #125 側で対応する
- #125 マージ後にこのブランチをリベースすれば、5 記事が新 tier 配下に自動でグループ化される

## Test plan
- [x] npm run check 0 errors / 0 warnings
- [x] npm run build 成功
- [x] dist 配下に 5 ページが生成されていることを確認
- [ ] レビュー時に開発サーバーで本文の事実関係を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)