### PR TITLE
feat(knowledge/cloudflare): Cloudflare アーキテクト視点の教科書（全 50 章）を公開

### DIFF
--- a/src/content/knowledge/web-development/cloudflare-docs/00-overview.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/00-overview.mdx
@@ -1,0 +1,91 @@
+---
+title: "Cloudflareとは — Connectivity Cloud という思想"
+description: "世界330都市以上に分散した自社ネットワーク上に **「コンピュート / ストレージ / セキュリティ / 接続」を統合提供するクラウド** 。AWS/GCP/Azure とは設計思想が異なり、「ユーザーの一番近くで処理する」前提でスタックが組まれている。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 0
+---
+# Cloudflareとは — Connectivity Cloud という思想
+
+## 一行サマリ
+
+世界330都市以上に分散した自社ネットワーク上に **「コンピュート / ストレージ / セキュリティ / 接続」を統合提供するクラウド** 。AWS/GCP/Azure とは設計思想が異なり、「ユーザーの一番近くで処理する」前提でスタックが組まれている。
+
+## Cloudflareが「3大クラウド」と違う3点
+
+### 1. リージョンではなく "エッジ" が単位
+
+AWS は `us-east-1` のようにリージョン単位でリソースを配置する。Cloudflare はコードとデータを世界中のデータセンターに自動分散する。「どこにデプロイするか」を考えず、ユーザー最寄りで実行される。
+
+### 2. エグレス料金がほぼゼロ
+
+R2 (オブジェクトストレージ) と Queues はエグレス（外向き転送）料金が無料。これは S3 のエグレス課金から逃れるための強力な選択肢になる。
+
+### 3. CDN/WAF と Compute が地続き
+
+元々 CDN/DDoS 防御の会社なので、Worker (コード) と WAF/Cache が同じレイヤで動く。「リクエストがオリジンに届く前にコードが走る」のが標準。
+
+## 製品ファミリーの俯瞰
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   Cloudflare Network                    │
+│              （330+都市・Anycast IP・1.1.1.1）            │
+└─────────────────────────────────────────────────────────┘
+   │
+   ├── Developer Platform        ← アプリ構築 (Workers, R2, D1...)
+   ├── AI Platform              ← Workers AI, AI Gateway, Vectorize
+   ├── Application Services     ← CDN, WAF, DDoS, Bot Management
+   ├── Zero Trust (One)         ← Access, Tunnel, Gateway, DLP
+   ├── Network Services         ← Magic Transit, Magic WAN, Spectrum
+   └── Domain & DNS             ← Registrar, DNS, Email Routing
+```
+
+## 「いつCloudflareを第一候補に検討するか」
+
+| 状況 | 推奨理由 |
+|------|---------|
+| グローバル配信が前提のサービス | エッジ実行・Anycastで標準対応 |
+| エグレス料金が痛いストレージ用途 | R2 がエグレス無料 |
+| サーバーレスでスタートアップを高速立ち上げ | Workers + Pages + D1/R2 で完結 |
+| BtoB SaaS で社内アクセス制御が要る | Access + Tunnel で VPN レス |
+| LLM アプリで複数プロバイダ運用 | AI Gateway でキャッシュ・観測一元化 |
+| WordPress/既存サイトを高速化 | CDN + APO だけで導入可能 |
+| グローバルチームの社内ツール公開 | Tunnel + Access が VPN より楽 |
+
+## 「Cloudflareを第一候補にしない方がよい」典型
+
+- **重い計算 / 長時間バッチ**: Workers の CPU 時間制限（数十ms〜数分）。GPU 集中処理も基本不可（Workers AIで提供される一部モデルのみ）
+- **巨大なリレーショナルDB**: D1 は SQLite ベースで規模上限あり。本格 OLTP は Hyperdrive 経由の Postgres などを使う必要がある
+- **マルチクラウドの管理面の中心**: IAM / 組織設計の柔軟性は AWS/GCP に劣る
+- **特定リージョン縛りの規制対応**: Data Localization Suite はあるが、リージョン固定の純度では純AWSの方が単純
+
+## アーキテクト判断フローチャート（簡易）
+
+```
+質問: Webアプリを作る
+  ├─ グローバル & 軽量？ → Workers + Pages + R2/D1
+  ├─ AIアプリで複数LLM使う？ → 上記 + AI Gateway + Vectorize
+  ├─ 既存オリジンのCDN/WAFだけ欲しい？ → Cloudflare 標準プロキシのみ
+  └─ 社内ツール公開したい？ → Tunnel + Access (VPN置換)
+
+質問: ストレージを置く
+  ├─ オブジェクト / 大量転送あり？ → R2（エグレス無料）
+  ├─ KV で十分？ → Workers KV
+  ├─ SQL が要る & 軽量？ → D1
+  ├─ ステートフルなセッション/同期？ → Durable Objects
+  └─ 既存 RDS/Postgres を高速化？ → Hyperdrive
+
+質問: ゼロトラスト導入
+  └─ Cloudflare One (Access + Gateway + Tunnel + DLP + CASB)
+```
+
+## 参考リンク
+
+- [Cloudflare Products 一覧](https://developers.cloudflare.com/products/)
+- [Reference Architectures](https://developers.cloudflare.com/reference-architecture/)
+- [Cloudflare Blog](https://blog.cloudflare.com/)
+
+---
+参照日: 2026-05-03

--- a/src/content/knowledge/web-development/cloudflare-docs/01-cli-tools.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/01-cli-tools.mdx
@@ -1,0 +1,95 @@
+---
+title: "Cloudflare CLI ツール群 — Wrangler / cf CLI / Terraform / Pulumi の使い分け"
+description: "Cloudflare CLI ツール群 — Wrangler / cf CLI / Terraform / Pulumi の使い分け のアーキテクト視点解説。採用判断軸・主要機能・競合比較・料金・CLI 例・制限を整理する。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 1
+---
+# Cloudflare CLI / IaC ツール ガイド
+
+Cloudflareリソースをコードで操る方法は4系統ある。役割が違うので混同しない。
+
+## 4つのツール
+
+### 1. Wrangler — Workers 中心の公式CLI
+
+Workers / Pages / R2 / D1 / KV / Queues などDeveloper Platform のローカル開発・デプロイのデファクト。`wrangler dev` でローカルエミュレーションができ、`wrangler deploy` で本番反映。設定は `wrangler.jsonc` (or `.toml`) に集約する。
+
+```bash
+wrangler init my-worker
+wrangler dev          # ローカル実行
+wrangler deploy       # 本番デプロイ
+wrangler r2 bucket create my-bucket
+wrangler d1 execute mydb --command "SELECT 1"
+```
+
+### 2. cf CLI — 全プロダクト対応の次世代CLI（技術プレビュー）
+
+2026年に発表された新CLI。最終的に Cloudflare API ほぼ3,000操作を統一インタフェースで提供する予定。現状は一部製品のみ。Wranglerと将来統合される計画。
+
+特徴:
+- `--local` でローカル/リモート切替
+- `--json` 全コマンド対応
+- 命名統一 (`get` のみ・`info` 廃止、`--force` のみ・`--skip-confirmations` 廃止)
+
+```bash
+cf workers list --json
+cf r2 bucket get my-bucket --local
+```
+
+参考: [Try the cf CLI Local Explorer](https://blog.cloudflare.com/cf-cli-local-explorer/)
+
+### 3. Terraform — インフラ全体のIaC定番
+
+Cloudflare の Terraform Provider はDNS、WAFルール、ゾーン設定、Access ポリシー、Workers route など **管理系設定** をコード化する用途に強い。アプリのコードデプロイは Wrangler、ガバナンス系は Terraform、と分担するのが現実解。
+
+```hcl
+resource "cloudflare_record" "www" {
+  zone_id = var.zone_id
+  name    = "www"
+  type    = "A"
+  content = "192.0.2.1"
+}
+```
+
+### 4. Pulumi — 言語SDKでIaC
+
+TypeScript / Python / Go などで Cloudflare リソースを記述したい場合の選択肢。Terraform の用途と被るが、既存コードベースの言語に揃えたい場合に。
+
+## 使い分け早見表
+
+| やりたいこと | 推奨ツール |
+|------------|----------|
+| Worker のローカル開発 / デプロイ | **Wrangler** |
+| R2 / D1 / KV / Queues の操作 | **Wrangler** |
+| DNS レコード / WAF / Access ポリシーの管理 | **Terraform** |
+| 一回限りの調査・スクリプト | **cf CLI** または `curl` でAPI |
+| アプリ言語と揃えてIaC | **Pulumi** |
+| GUI で十分 | Cloudflare Dashboard |
+
+## CI/CD パターン
+
+```
+GitHub → GitHub Actions:
+  ├─ wrangler deploy           # アプリコード
+  └─ terraform apply           # ゾーン設定・WAF・Access ポリシー
+```
+
+シークレット管理は `wrangler secret put` または GitHub Secrets → Actions。
+
+## ハマりどころ
+
+- **Wrangler のバージョン差**: v3 と v4 で `wrangler.toml` フォーマットが微妙に変わる。新規は `wrangler.jsonc` 推奨
+- **Terraform Provider のメジャー更新破壊的変更**: 4.x → 5.x で Ruleset 系API がリソース分割された。アップグレード前に CHANGELOG 必読
+- **Account ID と Zone ID の混同**: ほぼ全コマンドで必須。`.env` か CI Secrets に固定しておく
+- **ローカル開発の挙動とprod差**: Workers の `nodejs_compat` フラグ、Durable Objects のトランザクション、Cron Triggers の発火タイミングは要注意
+
+## 参考リンク
+
+- [Wrangler Docs](https://developers.cloudflare.com/workers/wrangler/)
+- [Cloudflare Terraform Provider](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs)
+- [Cloudflare API Reference](https://developers.cloudflare.com/api/)
+
+---
+参照日: 2026-05-03

--- a/src/content/knowledge/web-development/cloudflare-docs/10-access.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/10-access.mdx
@@ -1,0 +1,155 @@
+---
+title: "Cloudflare Access (Cloudflare One)"
+description: "アプリケーションの前段にCloudflareエッジを置き、IdP認証とポリシー判定によってアクセスを制御するアイデンティティ対応プロキシ型のZTNA（Zero Trust Network Access）サービスである。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 10
+---
+# Access (Cloudflare One)
+
+## 一行サマリ
+アプリケーションの前段にCloudflareエッジを置き、IdP認証とポリシー判定によってアクセスを制御するアイデンティティ対応プロキシ型のZTNA（Zero Trust Network Access）サービスである。
+
+## 解決する課題（Why）
+従来型のVPNは「ネットワークに入れたら全部見える」というフラットな信頼モデルであり、退職時のアクセス剥奪が遅れる、踏み台化されやすい、SaaSには適用できない、といった構造的な問題を抱えている。Cloudflare Accessはこれを置き換え、すべてのHTTPリクエストをエッジで認証・認可することで以下を解決する。
+
+- VPNゲートウェイの撤廃と運用負荷の削減。
+- SaaSアプリ・社内Webアプリ・SSH/RDP・MCPサーバーまで同一ポリシーで保護。
+- 退職・権限変更時にIdP側で無効化すればアクセスが即座に剥奪される。
+- デバイスポスチャ・地理・リスクスコアを組み合わせた継続的な評価が可能。
+
+## 主要機能（What）
+- **IdP連携**：Google / Okta / Microsoft Entra ID / GitHub / 任意のSAML・OIDCを統合。複数IdPの同時運用にも対応する。
+- **ポリシーDSL**：Action（Allow / Block / Bypass / Service Auth）× Rule type（Include / Exclude / Require）× Selector（Email / Country / IP / Device posture / User Risk Score 等）の組合せでアクセスを定義する。
+- **Service Token / mTLS**：人間ユーザーを介さないM2M通信向けの認証方式。CI/CDやエージェントから内部APIへのアクセスに使う。
+- **Browser-based RDP / SSH**：クライアントレスでRDP・SSHをブラウザから利用可能。クリップボード制御・UNIXユーザー名制限などの細かいConnection contextを設定できる。
+- **Linked App Token / Managed OAuth**：Accessをアイデンティティ層として外部アプリに渡せる仕組み。
+- **継続評価**：IP・国・デバイスポスチャ・リスクスコアはセッション中もリクエストごとに評価される。
+
+## アクセスフロー
+```
+ユーザー → Cloudflareエッジ（最寄りPoP）
+        ↓ IdPへリダイレクトしSSO認証
+        ↓ JWT発行（Cf-Access-Jwt-Assertion）
+        ↓ Access policy 判定（Service Auth → Bypass → Allow/Block の順）
+        ↓ Tunnel または公開オリジンへルーティング
+       オリジンアプリ
+```
+
+オリジンに到達するリクエストには署名付きJWTが付与され、オリジン側で再検証することで「Cloudflareを経由していないリクエスト」を排除できる。
+
+## 対応IdP
+SAML・OIDC汎用に加え、以下を専用コネクタとして提供する。
+
+- Google / Google Workspace
+- Okta（OIDC・SAML両対応）
+- Microsoft Entra ID（旧Azure AD）
+- GitHub
+- OneLogin（OIDC・SAML）
+- PingOne / PingFederate
+- JumpCloud / Keycloak / Centrify / Citrix ADC（SAML）
+- Amazon Cognito / AWS IAM（SAML）
+- Facebook / LinkedIn / Yandex（ソーシャル）
+- One-time PIN（IdP不要、メール宛にOTP送信）
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- 社内管理ツール（Admin panel、Grafana、Kibana、Jenkins、Argo CD）の保護。
+- staging / preview環境の関係者限定公開。
+- VPN撤廃を前提としたZTNA移行。
+- SaaS（Salesforce / Workday等）にCloudflare Accessを差し込んでSSOを統一。
+- MCPサーバーや内部APIの認可レイヤとして。
+- クライアントレスで外部協力会社にSSH・RDPを配りたいケース。
+
+### 適していないシーン
+- B2C向けのエンドユーザー認証（顧客アカウントのサインアップ・パスワードリセット等のフルライフサイクルが必要）。これはAuth0 / Cognito / Cloudflareの別機能（Managed OAuth）の領域である。
+- IdPを持たない・整備する気がない組織（OTPで凌げる規模ならよいが、本格運用にはIdP前提）。
+- アプリ内の細粒度認可（行レベル権限など）。Accessはあくまで「到達できるか」を制御する層であり、アプリ内RBACは別途必要である。
+
+## 競合・代替
+
+| 観点 | Cloudflare Access | Okta SSO | Tailscale | Twingate |
+|---|---|---|---|---|
+| モデル | アイデンティティ対応プロキシ（HTTP/SSH/RDP） | IdP+SSOブローカー | WireGuardベースのMesh VPN | ZTNAコネクタ型 |
+| クライアント | 不要（HTTPはブラウザのみ） | 不要 | 必要（WireGuardクライアント） | 必要 |
+| SaaS保護 | 可能（SAML IdPとして振る舞う） | 本職 | 不可 | 限定的 |
+| 内部Webアプリ | Tunnelと組合せでDNS不要・IP公開不要 | リバースプロキシ別途必要 | ネットワーク到達で代用 | コネクタ経由 |
+| 価格 | 50ユーザーまで無料 | $2〜/ユーザー/月〜 | 3ユーザーまで無料 | 5ユーザーまで無料 |
+| 強み | エッジで完結・無料枠が広い・Tunnel連携 | IdPとしての成熟度・ガバナンス | 設定の容易さ | UI |
+| 弱み | IdP機能は持たない（前段にIdP必須） | アプリ前段プロキシ機能は別 | HTTPアプリ単位の認可は弱い | 規模感はAccessに劣る |
+
+CloudflareにはWorkersベースのアプリ認証機構もあるが、AccessはIdP統合・ポリシー判定・監査ログまで揃ったマネージドな選択肢であり、自前実装より優先される。
+
+## Tunnel との組合せ
+Accessは「誰が来てよいか」を決めるレイヤで、Cloudflare Tunnel（cloudflared）は「どこへ繋ぐか」を決めるレイヤである。両者の組合せで、
+
+- オリジンサーバーのインバウンドポートを完全に閉じられる（アウトバウンドのみでCloudflareへ接続）。
+- DNSを公開しない内部ホスト名でも社外からアクセスできる。
+- IPアドレスベースの攻撃面がゼロになる。
+
+という構成が成立する。実運用では「Tunnel + Access」をセットで設計するのが定石である。
+
+## 料金モデルの要点
+- **Free**：50ユーザーまでAccess・Gateway基本機能を利用可能。
+- **Standard / Pay-as-you-go**：$7/ユーザー/月程度から、ユーザー数に応じて従量課金。
+- **Enterprise**：User Risk Score、AI controls、SCIMの高度連携、サポートSLAなどが追加される。
+
+無料枠が50ユーザーまであるため、スタートアップや少人数チームではコストゼロでZTNAを導入できる点が大きな差別化要素である。
+
+## CLI / IaC 操作例
+
+### Terraform（cloudflare provider v5）
+```hcl
+resource "cloudflare_zero_trust_access_application" "internal_admin" {
+  account_id       = var.account_id
+  name             = "Internal Admin"
+  domain           = "admin.example.com"
+  type             = "self_hosted"
+  session_duration = "24h"
+  allowed_idps     = [cloudflare_zero_trust_access_identity_provider.google.id]
+  auto_redirect_to_identity = true
+}
+
+resource "cloudflare_zero_trust_access_policy" "allow_company" {
+  account_id     = var.account_id
+  application_id = cloudflare_zero_trust_access_application.internal_admin.id
+  name           = "Allow company emails"
+  precedence     = 1
+  decision       = "allow"
+
+  include = [{
+    email_domain = { domain = "example.com" }
+  }]
+
+  require = [{
+    geo = { country_code = "JP" }
+  }]
+}
+```
+
+### wrangler / cloudflared
+- `cloudflared tunnel create internal-admin`
+- `cloudflared tunnel route dns internal-admin admin.example.com`
+- `cloudflared tunnel run internal-admin`
+
+これでオリジンを公開せずに `admin.example.com` をAccess配下に出せる。
+
+## 制限・注意点
+- SaaSアプリにおいては、Accessはサインオン時とセッション再発行時のみポリシーを評価する。セッション継続中の継続評価はSaaS側のセッション管理に委ねられる。
+- **Bypass**ポリシーはセキュリティ制御を完全に外し、ログも残らない。安易な利用は厳禁で、原則Service Authで代替する。
+- Bypassポリシーにデバイスポスチャを組合せた場合、ZarazやWorkersがリクエストを横取りすると機能しない既知の制約がある。
+- 「Include: Everyone」「Include: One-time PIN」を入れると事実上全公開になる典型的な誤設定がある。
+- User Risk ScoreやSCIM強制再評価などはEnterpriseプランの機能である。
+- オリジン側でJWT検証をしないと、Cloudflareをバイパスする攻撃経路が残る。Tunnelとの併用で塞ぐのが望ましい。
+
+## 参考リンク
+- Cloudflare Access Policies：https://developers.cloudflare.com/cloudflare-one/policies/access/
+- Add web applications：https://developers.cloudflare.com/cloudflare-one/applications/
+- Identity providers：https://developers.cloudflare.com/cloudflare-one/identity/
+- Cloudflare One llms.txt：https://developers.cloudflare.com/cloudflare-one/llms.txt
+- Terraform Provider (cloudflare_zero_trust_access_application)：https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs
+
+---
+参照日: 2026-05-03

--- a/src/content/knowledge/web-development/cloudflare-docs/11-ai-gateway.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/11-ai-gateway.mdx
@@ -1,0 +1,133 @@
+---
+title: "Cloudflare AI Gateway"
+description: "複数LLMプロバイダの前段に置くプロキシで、観測（ログ・分析・コスト追跡）、キャッシュ、レート制限、フォールバック、リトライ、ガードレールを1行のエンドポイント差し替えだけで提供するCloudflareのマネージドサービスである。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 11
+---
+# AI Gateway
+
+## 一行サマリ
+複数LLMプロバイダの前段に置くプロキシで、観測（ログ・分析・コスト追跡）、キャッシュ、レート制限、フォールバック、リトライ、ガードレールを1行のエンドポイント差し替えだけで提供するCloudflareのマネージドサービスである。
+
+## 解決する課題（Why）
+- マルチプロバイダ運用でログ・分析が分散し、横断的に「誰が・どのモデルで・いくら使ったか」を把握できない。
+- プロバイダ障害やレート制限によるリクエスト失敗で、本番AI機能の可用性が落ちる。
+- 同一プロンプトの重複呼び出しでトークン課金が膨らむ。
+- アプリ側に直接APIキーを持たせると、悪用・暴走時のコスト爆発を止められない。
+- 機密情報の流入・流出（PII等）に対するガードレールが各アプリ実装に依存する。
+
+## 主要機能（What）
+- **ロギング / コスト追跡**：リクエスト・レスポンス・トークン数・コストを自動保存し、ダッシュボードと分析APIから参照する。
+- **キャッシュ**：標準キャッシュ（完全一致）に加え、セマンティックキャッシュ（意味的近似）でヒット率を引き上げる。Cache TTLは最大1か月。
+- **レート制限**：ゲートウェイ単位でリクエスト数を制御し、暴走・コスト爆発を抑止する。
+- **フォールバック**：プロバイダAが失敗したらBに自動切替し、可用性を確保する。
+- **リトライ**：一過性エラーに対する自動再試行で成功率を底上げする。
+- **ガードレール（DLP連携）**：Cloudflare One DLPプロファイルを共有し、入出力の機密検出・マスキングを行う。
+- **データセット / Logpush**：保存ログを外部ストレージへエクスポートし、長期保管・他システム連携を可能にする。
+- **Universal Endpoint**：単一エンドポイントから複数プロバイダを呼び分け、フォールバックチェーンを宣言的に定義できる。
+
+## 対応プロバイダ
+公式に対応するネイティブプロバイダ（2026-05時点）:
+
+OpenAI / Anthropic / Workers AI / Amazon Bedrock / Google Vertex AI / Google AI Studio / Azure OpenAI / Mistral AI / Cohere / Groq / DeepSeek / Perplexity / Replicate / HuggingFace / OpenRouter / xAI (Grok) / Cerebras / Baseten / Cartesia / Deepgram / ElevenLabs / Fal AI / Ideogram / Parallel。
+
+OpenAI互換SDKを使うプロバイダはOpenAI互換モードで透過的に通る。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- すでにCloudflareエコシステム（Workers / Pages / R2 / D1）でアプリを構築している。
+- 複数LLMプロバイダを併用し、横断的な可観測性とフォールバックを最小工数で揃えたい。
+- エッジに近い場所でキャッシュ・レート制限を効かせて、レイテンシとコストを同時に下げたい。
+- DLP・監査ログ要件があり、Cloudflare One側のポリシーと統合したい。
+- PoC段階で「とりあえず1行で観測層を入れたい」スタートアップ・社内ツール。
+
+### 適していないシーン
+- 評価実験（eval）、プロンプト管理、データセット運用まで含めたLLMOps全体を1ツールで賄いたい場合（LangSmith / Langfuse / Braintrustの方が深い）。
+- プロンプトテンプレートのバージョン管理・A/Bテスト・人間レビューワークフローを重視する場合（Portkey / Helicone Promptsの方が機能が厚い）。
+- オンプレ・閉域ネットワーク内で完結させたい場合（Cloudflareエッジを経由する前提が崩れる）。
+- 1リクエスト25MBを超える巨大ペイロードを扱うユースケース。
+
+## 競合・代替
+
+| 観点 | AI Gateway | Helicone | Portkey | LangSmith |
+|---|---|---|---|---|
+| 提供形態 | マネージド（エッジ） | マネージド/OSS | マネージド/OSS | マネージド |
+| 導入コスト | エンドポイント差し替え1行 | エンドポイント差し替え1行 | SDK or プロキシ | SDK埋め込み |
+| キャッシュ | 標準＋セマンティック | あり | あり | なし（評価寄り） |
+| フォールバック | あり（宣言的） | あり | あり（強力） | なし |
+| プロンプト管理 | 弱い | あり | 強い | 強い |
+| eval / トレース深掘り | 弱い | 中 | 中 | 強い |
+| 価格 | 無料枠あり、従量 | 無料枠あり | 無料枠あり | 有料寄り |
+| 強み | エッジ近接・Cloudflareスタック統合 | OSS・シンプル | ルーティング戦略 | LangChain連携・eval |
+
+その他、OpenLLMetry（OpenTelemetryベースの計測ライブラリ）やBraintrust（eval特化）は補完的に併用されることが多い。
+
+## 料金モデルの要点
+- **本体は無料で利用可能**（全プランで提供）。Gateway数は無料プラン10/有料プラン20。
+- 無料プラン：ログ保存はアカウント全体で10万件まで。
+- 有料プラン：ゲートウェイあたり1000万ログまで。
+- 上限到達時は「自動削除」または「保存停止」を選択。Logpushで外部退避可。
+- セマンティックキャッシュ等の高度機能は従量課金がかかる場合があるため、料金ページで最新を確認する。
+
+## CLI / IaC 操作例
+ベースURLを差し替えるだけで導入できる。OpenAI SDKでの例:
+
+```ts
+import OpenAI from "openai";
+
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+  baseURL: "https://gateway.ai.cloudflare.com/v1/<ACCOUNT_ID>/<GATEWAY_ID>/openai",
+});
+
+const res = await openai.chat.completions.create({
+  model: "gpt-4o-mini",
+  messages: [{ role: "user", content: "hello" }],
+});
+```
+
+Workers Bindingsでも利用可能:
+
+```toml
+# wrangler.toml
+[ai]
+binding = "AI"
+
+[[ai_gateway]]
+binding = "GATEWAY"
+gateway_id = "my-gateway"
+```
+
+Universal Endpointでフォールバックチェーンを宣言:
+
+```bash
+curl https://gateway.ai.cloudflare.com/v1/<ACCOUNT_ID>/<GATEWAY_ID> \
+  -H "Content-Type: application/json" \
+  -d '[
+    {"provider":"workers-ai","endpoint":"@cf/meta/llama-3.1-8b-instruct","headers":{...},"query":{...}},
+    {"provider":"openai","endpoint":"chat/completions","headers":{...},"query":{...}}
+  ]'
+```
+
+## 制限・注意点
+- キャッシュ可能なリクエストサイズは25MB/リクエスト、Cache TTLは最大1か月。
+- カスタムメタデータは1リクエストあたり5エントリまで。
+- ログサイズは1ログ10MBまで（超過分は保存されない）。
+- ログ保存レートは500ログ/秒/ゲートウェイ。
+- Logpushジョブはアカウントあたり4、Logpushペイロードは1MB/ログ。
+- DLPはCloudflare One側のプロファイルを共有するため、Cloudflare One側の設定権限と整合を取る必要がある。
+- すべてのトラフィックがCloudflareエッジを経由するため、特定リージョン要件・閉域要件があるユースケースでは適合性を要確認。
+- セマンティックキャッシュは類似性閾値の設計次第で「誤ヒット」のリスクがある。重要な動的応答にはキャッシュ除外設定を入れる。
+
+## 参考リンク
+- 公式トップ: https://developers.cloudflare.com/ai-gateway/
+- Limits: https://developers.cloudflare.com/ai-gateway/reference/limits/
+- 対応プロバイダ一覧: https://developers.cloudflare.com/ai-gateway/providers/
+- Pricing: https://developers.cloudflare.com/ai-gateway/reference/pricing/
+- Universal Endpoint: https://developers.cloudflare.com/ai-gateway/providers/universal/
+
+---
+参照日: 2026-05-03

--- a/src/content/knowledge/web-development/cloudflare-docs/12-d1.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/12-d1.mdx
@@ -1,0 +1,182 @@
+---
+title: "Cloudflare D1"
+description: "D1 は Cloudflare のサーバーレス SQL データベースであり、SQLite 互換のクエリと Workers バインディングで動作する。1 アカウントあたり最大 5 万 DB を作成でき、テナントごと・ユーザーごとに DB を分ける「水平スケールアウト型」設計が前提となる。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 12
+---
+# D1
+
+## 一行サマリ
+
+D1 は Cloudflare のサーバーレス SQL データベースであり、SQLite 互換のクエリと Workers バインディングで動作する。1 アカウントあたり最大 5 万 DB を作成でき、テナントごと・ユーザーごとに DB を分ける「水平スケールアウト型」設計が前提となる。
+
+## 解決する課題（Why）
+
+従来のマネージド RDB は「常時起動するインスタンス」を前提とし、Workers のようなエッジ実行環境からは接続プールやレイテンシで相性が悪い。D1 は以下を解決する。
+
+- 接続プール不要。Workers バインディング経由で直接クエリを発行できる。
+- スケール to ゼロ。クエリを実行しない時間は課金されない。
+- DB 作成コストが実質ゼロ。マルチテナント SaaS で「テナント＝1 DB」設計が経済合理的に成立する。
+- バックアップ／PITR が標準装備（Time Travel）で運用負荷を持たない。
+
+## 主要機能（What）
+
+- **SQLite ベース**：SQLite の SQL セマンティクスと型システムをそのまま採用。スキーマ・クエリは標準 SQLite と互換。
+- **Workers Binding API / HTTP REST API / Wrangler CLI** の 3 経路でアクセス可能。
+- **Time Travel**：過去 30 日（Free は 7 日）の任意の 1 分単位に DB を復元できるポイントインタイムリカバリ。バックアップ設定は不要で常時有効。
+- **Global Read Replication**：読み込みリードレプリカをグローバルに自動配置し、リード遅延を低減。書き込みは引き続きプライマリ（単一の Durable Object）に集約。
+- **Batch / Prepared Statement**：`db.batch()` でトランザクション的に複数文を実行。バインドパラメータは最大 100。
+- **インポート／エクスポート**：`wrangler d1 execute --file` で SQL ダンプを取り込み可能（最大 5 GB）。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+
+- Workers / Pages を前提としたエッジアプリケーションの永続層。
+- マルチテナント SaaS で「テナントごとに DB を分離したい」要件。1 アカウント 5 万 DB が利用可能。
+- 1 DB あたり 10 GB 以下に収まる、明確に分割できるドメインデータ。
+- 平均レスポンス 1 ms 〜 数十 ms の OLTP ワークロードで、書き込みが秒間数十〜数百以下に収まる規模。
+- バックアップ運用を持ちたくない小〜中規模プロジェクト。
+
+### 適していないシーン（重要）
+
+- **書き込み TPS が高いワークロード**：各 D1 DB は単一の Durable Object に紐づき、シングルスレッドで逐次処理される。平均クエリ 1 ms なら理論上限は約 1000 QPS、100 ms なら 10 QPS。書き込みは数 ms 単位で複数拠点に永続化されるため、単一 DB で秒間数百以上の書き込みは破綻する。
+- **1 DB で 10 GB を超えるデータ**：DB あたり 10 GB は引き上げ不可。シャーディング設計が必須。
+- **長時間クエリ・大量更新**：単一 SQL の実行上限は 30 秒。数十万行を一括 UPDATE / DELETE する DDL バッチは平台限界に抵触するため、1000 行単位等に分割する必要がある。
+- **PostgreSQL 固有機能**（拡張、JSONB、PostGIS、CTE 上の高度な最適化、ストアド）に依存するワークロード。
+- **強整合の地理分散書き込み**：書き込みは単一プライマリ Durable Object に集約されるため、書き込み元のリージョンによってはレイテンシが大きくなる。
+
+## 競合・代替
+
+| 観点 | D1 | Neon (Postgres) | Turso (libSQL) | Supabase (Postgres) | PlanetScale (MySQL) | Hyperdrive + RDS/Postgres |
+|---|---|---|---|---|---|---|
+| エンジン | SQLite | PostgreSQL | SQLite (libSQL) | PostgreSQL | MySQL/Vitess | PostgreSQL/MySQL |
+| デプロイ形態 | サーバーレス（Workers 統合） | サーバーレス（ブランチ機能） | エッジ分散 | マネージド | マネージド | 外部 DB を Workers 高速化 |
+| スケール to ゼロ | 対応 | 対応 | 対応 | 一部 | 非対応 | 外部 DB に依存 |
+| 書き込みスケール | 単一 DO（弱） | 単一プライマリ＋スケール | 単一プライマリ | 強い | 非常に強い（シャーディング） | バックエンド依存 |
+| マルチテナント DB 分離 | 5 万 DB 無料 | プロジェクト/ブランチ単位 | 数万 DB 対応 | 1 プロジェクト 1 DB | DB 数に課金 | 不向き |
+| Workers との相性 | ネイティブ | Hyperdrive 経由 | ネイティブ／HTTP | Hyperdrive 経由 | Hyperdrive 経由 | ネイティブ |
+| バックアップ／PITR | Time Travel 30 日 | ブランチ＋PITR | ブランチ | PITR（有料） | ブランチ | RDS 機能 |
+| 主用途 | エッジ OLTP・テナント分離型 SaaS | フル機能 Postgres が必要なエッジ | エッジ分散 SQLite | Postgres + Auth + Storage 統合 | 大規模 OLTP | 既存 Postgres 資産の延命 |
+
+選定基準：Workers 中心かつ DB を細かく分けられるなら D1、Postgres の機能や単一 DB の書き込みスループットが必要なら Neon＋Hyperdrive、エッジ書き込み分散重視なら Turso、フルスタック BaaS なら Supabase。
+
+## 料金モデルの要点
+
+| 項目 | Workers Free | Workers Paid |
+|---|---|---|
+| Rows read | 500 万 / 日 | 月 250 億まで無料、超過分 $0.001 / 100 万行 |
+| Rows written | 10 万 / 日 | 月 5000 万まで無料、超過分 $1.00 / 100 万行 |
+| Storage | 合計 5 GB | 5 GB 含む、超過分 $0.75 / GB-月 |
+| データ転送（egress） | 無料 | 無料 |
+| 読み込みレプリカ | 追加料金なし | 追加料金なし（通常の rows_read 課金のみ） |
+
+- **課金はクエリ＋ストレージのみ**。インスタンス時間課金なし、転送量課金なし。
+- **Rows read はスキャン行数**。フルスキャンは行数ぶん丸ごと加算されるため、インデックス設計が直接コストに効く。
+- **Rows written**：INSERT / UPDATE / DELETE で書き込まれた行数。インデックスがある列を更新すると追加で書き込みが発生する。
+- 100 KB の行も 1 KB の行も 1 行は 1 行としてカウントされる。
+- 各クエリのレスポンスに含まれる `meta.rows_read` / `meta.rows_written` で実測可能。
+
+## CLI / IaC 操作例
+
+### Wrangler
+
+```bash
+# DB 作成
+wrangler d1 create my-app-db
+
+# wrangler.toml にバインディング登録
+# [[d1_databases]]
+# binding = "DB"
+# database_name = "my-app-db"
+# database_id = "<UUID>"
+
+# マイグレーション
+wrangler d1 migrations create my-app-db init
+wrangler d1 migrations apply my-app-db --remote
+
+# 任意 SQL の実行
+wrangler d1 execute my-app-db --remote --command "SELECT count(*) FROM users"
+
+# ダンプ取り込み
+wrangler d1 execute my-app-db --remote --file ./seed.sql
+
+# Time Travel
+wrangler d1 time-travel info my-app-db
+wrangler d1 time-travel restore my-app-db --bookmark <bookmark>
+```
+
+### Drizzle ORM
+
+```ts
+// schema.ts
+import { sqliteTable, integer, text } from "drizzle-orm/sqlite-core";
+
+export const users = sqliteTable("users", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  email: text("email").notNull().unique(),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+});
+
+// worker.ts
+import { drizzle } from "drizzle-orm/d1";
+import { eq } from "drizzle-orm";
+import { users } from "./schema";
+
+export interface Env { DB: D1Database }
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const db = drizzle(env.DB);
+    const url = new URL(req.url);
+    const email = url.searchParams.get("email");
+    if (!email) return new Response("email required", { status: 400 });
+
+    const found = await db.select().from(users).where(eq(users.email, email)).all();
+    return Response.json(found);
+  },
+};
+```
+
+```bash
+# Drizzle Kit でスキーマからマイグレーション SQL を生成 → wrangler で適用
+npx drizzle-kit generate
+wrangler d1 migrations apply my-app-db --remote
+```
+
+## 制限・注意点
+
+| 項目 | 値 |
+|---|---|
+| 1 アカウントの DB 数 | 50,000（Paid）／ 10（Free） |
+| 1 DB の最大サイズ | 10 GB（引き上げ不可） |
+| 1 アカウントの総ストレージ | 1 TB（Paid）／ 5 GB（Free） |
+| Time Travel 保持期間 | 30 日（Paid）／ 7 日（Free） |
+| 1 Worker 呼び出しあたりのクエリ数 | 1,000（Paid）／ 50（Free） |
+| 1 テーブルの最大カラム数 | 100 |
+| 1 行の最大サイズ | 2 MB |
+| SQL ステートメントの最大長 | 100 KB |
+| 1 クエリのバインドパラメータ最大 | 100 |
+| 単一クエリの最大実行時間 | 30 秒 |
+| インポート最大ファイルサイズ | 5 GB |
+| 1 Worker から D1 への同時接続 | 6 |
+
+- **書き込みは単一の Durable Object に集約**される。リードレプリカを増やしても書き込みスループットは上がらない。
+- **書き込みプライマリのリージョンは選べない**（自動配置）。書き込み元 Worker の地理位置によっては数十〜数百 ms のレイテンシが追加される。これがグローバル書き込みワークロードでは決定的な制約になる。
+- **大量バッチは分割必須**。100 万行の UPDATE は 1000 行 × 1000 バッチに割って実行する設計を初期から入れる。
+- 過剰な並列リクエストはキューイングされ、キュー溢れで `overloaded` エラーになる。リトライ設計が前提。
+- ダッシュボードや Wrangler から実行したクエリも課金対象。
+
+## 参考リンク
+
+- 公式 Overview: https://developers.cloudflare.com/d1/
+- Limits: https://developers.cloudflare.com/d1/platform/limits/
+- Pricing: https://developers.cloudflare.com/d1/platform/pricing/
+- Workers Binding API: https://developers.cloudflare.com/d1/worker-api/
+- Time Travel: https://developers.cloudflare.com/d1/reference/time-travel/
+- Read Replication: https://developers.cloudflare.com/d1/best-practices/read-replication/
+
+---
+参照日: 2026-05-03

--- a/src/content/knowledge/web-development/cloudflare-docs/13-durable-objects.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/13-durable-objects.mdx
@@ -1,0 +1,169 @@
+---
+title: "Cloudflare Durable Objects"
+description: "グローバル一意性を持つステートフルアクター。世界に1つだけ存在する単一インスタンスへ、ストレージ・WebSocket・RPCを束ねて配置するサーバーレス実行単位。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 13
+---
+# Durable Objects
+
+## 一行サマリ
+グローバル一意性を持つステートフルアクター。世界に1つだけ存在する単一インスタンスへ、ストレージ・WebSocket・RPCを束ねて配置するサーバーレス実行単位。
+
+## 解決する課題（Why）
+KVやD1では「強整合な単一書き手」「クライアント間のリアルタイム調停」が解けない。KVは結果整合、D1は共有DBに対する楽観ロック前提で、複数Workerからの同時更新を直列化するロジックは自前で組む必要がある。Durable Objectsは「特定IDの処理は世界で1つのインスタンスに集約される」という保証によって、分散ロック・コーディネーター・順序付けキュー・接続ファンアウトといった分散システムの典型課題を、単一スレッドのコードとして書ける形に落とし込む。
+
+## 主要機能（What）
+- **グローバル単一インスタンス**: ID単位で世界に1つだけアクティブ化される
+- **Storage API**: KV API と SQL API の二系統。SQLite-backed が標準（GA、Free planでも利用可）
+- **In-memory state**: アクティブな間はメモリ上の状態を保持、アイドル後にハイバネート
+- **WebSocket Hibernation API**: アイドル中の接続を維持しつつ duration 課金を発生させない
+- **Alarms API**: 将来時刻に自身を起動して定期処理を実行
+- **RPC**: WorkerからJavaScriptネイティブなメソッド呼び出しでDurable Objectを操作
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- リアルタイムチャット、コラボ編集、マルチプレイヤーゲームの部屋単位調停
+- レート制限カウンタ、在庫数・席数のような「強整合な単一書き手」
+- ユーザー単位・テナント単位のセッション/ステート管理
+- WebSocketファンアウト（1接続=1 DOで状態保持）
+- 順序保証が必要なイベント処理、軽量なジョブキュー
+- AIエージェントの会話状態・ツール実行履歴の保持
+
+### 適していないシーン
+- 全ユーザー横断の集計・分析クエリ（→ D1 / Workers Analytics Engine）
+- 大容量バイナリ（→ R2、DO Storageは1オブジェクト10GBまで）
+- 単一IDあたり1,000 req/秒を恒常的に超えるホットキー型ワークロード
+- グローバルに分散した読み取りキャッシュ用途（→ KV）
+
+## 概念モデル（必須セクション）
+- **Object ID**: ランダム生成（`idFromName` でないユニークID）または名前由来（`idFromName("room-123")`）。同じIDは世界で常に同じインスタンスにルーティングされる
+- **グローバル単一性**: アクティブなインスタンスは常に1つ。ヘルシーなサーバー間で自動マイグレートされ、アプリ側はライフサイクルを管理しない
+- **In-memory state + Storage**: メモリ上の状態 + アクター直下に同居する永続ストレージ。同居しているため強整合かつ低レイテンシ
+- **SQLite Storage（推奨）**: 各Durable ObjectがSQLiteデータベースを丸ごと1つ持つ。`ctx.storage.sql.exec()` でSQL実行、KVライクな `put/get` も内部的に隠しテーブルで処理
+- **Single-threaded cooperative concurrency**: ブラウザのJSと同じく協調的マルチタスキング。レースコンディションが構造的に発生しない
+- **Actor model**: メッセージ（HTTP/RPC）受信 → 単一スレッドでロジック実行 → メッセージ送信、というアクターパターンそのもの
+
+## 競合・代替（Akka / Orleans / Erlang/OTP / Lambda + DynamoDB の発想差）
+- **Akka / Microsoft Orleans**: アクターモデルとしての発想は同一だが、これらはクラスタ運用・ノード障害時のリバランスを自前で構築する必要がある。Durable ObjectsはCloudflareのグローバルネットワークがランタイム自体を担い、配置・移動・障害復旧が透過的
+- **Erlang/OTP**: プロセス単位の隔離と単一スレッド実行という思想は近いが、OTPはあくまで言語ランタイム。Durable ObjectsはエッジネットワークそのものがOTP的役割を果たす
+- **AWS Lambda + DynamoDB**: ステートレスFaaS + 外部KV。書き込み調停は条件付きwriteや楽観ロックで自前実装が必要。Durable Objectsは「コード = 単一の書き手」なので、調停ロジックがそもそも不要
+- **Redis / Memcached**: 共有キャッシュとしての高速性はあるが、計算とストレージが分離されているためネットワークラウンドトリップが発生。DOは計算とストレージが同居
+- 思想差を一言で言うと、Durable Objectsは「アクターランタイムがCDNに溶け込んだ」プロダクトであり、開発者はインフラを意識せずアクター指向で設計できる
+
+## 料金モデルの要点
+- **Compute（リクエスト）**: Free 100,000/日、Paid 100万/月込み + $0.15/100万。WebSocketの受信メッセージは20:1で集約課金
+- **Compute（Duration）**: Free 13,000 GB-s/日、Paid 400,000 GB-s/月込み + $12.50/100万 GB-s。128MB固定割当で課金。Hibernation中は課金されない点が重要
+- **SQLite Storage（2026年1月7日以降課金開始）**: 行読み 5M/日（Free）、25B/月込み + $0.001/100万行（Paid）。行書き 100K/日（Free）、50M/月込み + $1.00/100万行。ストレージ 5 GB込み + $0.20/GB-月
+- **KV Storage（Paid限定、レガシー）**: 4KB単位の request units 課金
+- **コスト最適化の鉄則**: WebSocket Hibernation APIを必ず使う。例3（非Hibernation）の月$416が、例4（Hibernation）では月$10まで下がる
+
+## CLI / IaC 操作例
+
+### wrangler.jsonc
+```jsonc
+{
+  "name": "chat-room",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-01-01",
+  "durable_objects": {
+    "bindings": [
+      { "name": "ROOM", "class_name": "ChatRoom" }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["ChatRoom"]
+    }
+  ],
+  "limits": {
+    "cpu_ms": 30000
+  }
+}
+```
+
+### Durable Objectクラス定義
+```typescript
+import { DurableObject } from "cloudflare:workers";
+
+export class ChatRoom extends DurableObject {
+  sql: SqlStorage;
+
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    this.sql = ctx.storage.sql;
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS messages (
+        id INTEGER PRIMARY KEY,
+        user TEXT NOT NULL,
+        body TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      )
+    `);
+  }
+
+  async postMessage(user: string, body: string): Promise<number> {
+    const created_at = Date.now();
+    const result = this.sql.exec(
+      "INSERT INTO messages (user, body, created_at) VALUES (?, ?, ?) RETURNING id",
+      user, body, created_at
+    ).one();
+    return result.id as number;
+  }
+
+  async listMessages(): Promise<unknown[]> {
+    return this.sql.exec("SELECT * FROM messages ORDER BY id DESC LIMIT 50").toArray();
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    const roomName = url.searchParams.get("room") ?? "default";
+    const id = env.ROOM.idFromName(roomName);
+    const stub = env.ROOM.get(id);
+
+    // RPC呼び出し
+    const messageId = await stub.postMessage("alice", "hello");
+    const messages = await stub.listMessages();
+    return Response.json({ messageId, messages });
+  },
+};
+```
+
+### デプロイ
+```bash
+npx wrangler deploy
+```
+
+## 制限・注意点
+- **単一インスタンスのスループット**: ソフトリミット約1,000 req/秒。ホットキーが想定される場合は、ID設計でシャーディングする
+- **CPU per request**: デフォルト30秒、`limits.cpu_ms` で最大5分まで延長可。CPU時間はI/O待ちを含まない
+- **Storage per Durable Object**: 10GB（SQLite-backed、Paid）。超過すると書き込みが `SQLITE_FULL` で失敗、読み取りと削除は継続可能
+- **キー/値サイズ**: SQLite-backedは key+value 合計2MB、SQL stringやBLOB行も2MB
+- **WebSocket受信メッセージ**: 32 MiB
+- **Durable Objectクラス数**: アカウントあたり Paid 500、Free 100
+- **Free plan**: SQLite-backed のみ。KV-backed はPaid限定
+- **Hibernationを阻害する要因に注意**: 非HibernationなWebSocket、ペンディングなPromise/タイマーがあるとアイドル判定されず duration 課金が継続する
+
+## ユースケース具体例
+- **マルチプレイヤーゲームのルーム**: `idFromName("room-${roomId}")` でルームごとに1 DO、参加者全員のWebSocketをHibernation API経由で保持
+- **AIエージェントのセッション**: `idFromName("agent-${userId}")` でユーザー単位のエージェント状態（会話履歴、ツール呼び出し中間結果）をSQLiteに永続化
+- **APIレート制限**: `idFromName("ratelimit-${apiKey}")` でAPIキーごとにカウンタDO、強整合な秒間/分間カウントを実現
+- **在庫・席予約**: 商品IDや座席IDでDO化、SQLトランザクションで「残数 > 0 ならデクリメント」を安全に実行
+- **コラボ編集（Liveblocks/Yjs風）**: ドキュメント単位でDO、CRDT状態をin-memory + 永続化
+- **AI Gateway / D1 / Stream Live**: Cloudflare自身もこれらの内部でDOを多用している
+
+## 参考リンク
+- 公式トップ: https://developers.cloudflare.com/durable-objects/
+- What are Durable Objects?: https://developers.cloudflare.com/durable-objects/concepts/what-are-durable-objects/
+- Limits: https://developers.cloudflare.com/durable-objects/platform/limits/
+- Pricing: https://developers.cloudflare.com/durable-objects/platform/pricing/
+- Blog「Durable Objects: Easy, Fast, Correct — Choose three」
+- Blog「Zero-latency SQLite storage in every Durable Object」
+
+---
+参照日: 2026-05-03

--- a/src/content/knowledge/web-development/cloudflare-docs/14-hyperdrive.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/14-hyperdrive.mdx
@@ -1,0 +1,126 @@
+---
+title: "Cloudflare Hyperdrive"
+description: "Workersから既存のPostgreSQL/MySQLへのアクセスを高速化する、グローバル接続プーリング+クエリキャッシュサービス。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 14
+---
+# Hyperdrive
+
+## 一行サマリ
+Workersから既存のPostgreSQL/MySQLへのアクセスを高速化する、グローバル接続プーリング+クエリキャッシュサービス。
+
+## 解決する課題（Why）
+Cloudflare Workersは300以上のロケーションで稼働するステートレス環境のため、中央集権的な既存DB（RDS等）に接続するたびに以下の問題が発生する。
+
+- 新規TCP/TLS接続の確立に複数ラウンドトリップを要し、遠隔地からだとリクエストごとに数百msのレイテンシが発生する
+- ステートレスなWorkerが大量に分散実行されると、DB側の最大コネクション数を即座に枯渇させる
+- 同じ読み取りクエリを世界中のリージョンから繰り返し実行すると、オリジンDBに不要な負荷がかかる
+
+Hyperdriveはこの「Workersと既存RDBの相性問題」を、コードを書き換えずに解消するための専用ミドルウェアである。
+
+## 主要機能（What）
+- 既存PostgreSQL/MySQLへの接続文字列ベースのプロキシ
+- Cloudflareエッジでの接続セットアップ（TLS含む）
+- オリジンDB近傍リージョンでの常駐コネクションプール（transaction mode）
+- 読み取り（非ミューテーション）クエリの自動キャッシュ（`max_age`設定可能）
+- 標準ドライバ（`pg`, `postgres.js`, `mysql2`等）と既存ORMをそのまま利用可能
+- Workers Placementとの併用でさらなるレイテンシ削減
+
+## 仕組み（必須セクション）
+Hyperdriveは3層構成で動作する。
+
+1. **エッジ接続セットアップ**: Workerからの接続要求をWorkerに最も近いCloudflareエッジで終端。TLSハンドシェイク等のセットアップコストを同一ロケーション内に閉じ込める。
+2. **コネクションプーリング**: オリジンDBに近いリージョンに常駐するコネクションプールを保持。Worker→Hyperdriveエッジ→Hyperdriveプール→DB という経路で、既存ウォームコネクションを再利用する。プールはtransaction mode（トランザクション完了で接続返却、`RESET`される）。
+3. **クエリキャッシング**: クエリをパースしてSELECT等の読み取りを判定。設定された`max_age`の間、レスポンスをキャッシュし、オリジンDBへの問い合わせ自体を省略する。
+
+Hyperdriveは分散システムなので、クライアントが既存プールに到達できない場合は新規プールが立ち上がる（可用性を優先）。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- 既存のPostgreSQL/MySQL（RDS, Aurora, Cloud SQL, Neon, Supabase, PlanetScale, CockroachDB, Timescale等）をそのまま使い続けたい
+- D1のサイズ上限・トランザクション制約・Postgres互換性不足が壁になっている
+- 既存ORM（Prisma, Drizzle, TypeORM等）やSQL資産を捨てずにWorkersへ移行したい
+- グローバルにユーザーがいるが、DBは1リージョンに集約したい
+- 読み取り偏重ワークロードでDB負荷を下げたい
+
+### 適していないシーン
+- そもそも新規プロジェクトでCloudflareに閉じてよい → D1で十分なケースが多い
+- 全クエリが書き込み中心でキャッシュ効果が薄く、かつDBが地理的に近い → Hyperdriveのメリットが薄い
+- 60秒を超える長時間クエリ・バッチ処理（クエリは強制終了される）
+- セッション固定の前提（`SET`を跨いで保持したい等）が必要なアプリ → transaction mode制約と相性が悪い
+- DBがCloudflareネットワークから到達できない閉域内（Tunnel等の併用が前提となる）
+
+## 対応DB
+- **PostgreSQL系**: PostgreSQL本体、Neon、Supabase、AWS RDS Postgres、Aurora Postgres、Google Cloud SQL Postgres、Azure Database for PostgreSQL、CockroachDB、Timescale等
+- **MySQL系**: MySQL本体、PlanetScale、AWS RDS MySQL、Aurora MySQL、Google Cloud SQL MySQL等
+
+ドライバは`postgres.js` / `node-postgres (pg)` / `mysql2`等の標準ライブラリがそのまま動く。Named prepared statementsは`postgres.js`と`node-postgres`が最適。
+
+## 料金モデルの要点
+- Workersプランに同梱され、Hyperdrive固有の追加料金は無い
+- 接続プーリング・クエリキャッシュ自体に追加課金は発生しない
+- データ転送（egress）課金も無い
+- Free: 100,000クエリ/日（00:00 UTCリセット）、Paid: 無制限
+- 課金カウント対象は「Hyperdrive経由のあらゆるDBステートメント」（SELECT/INSERT/UPDATE/DELETE/DDL、キャッシュHit/Missを問わず同等にカウント）
+
+## CLI / IaC 操作例
+
+設定作成（接続文字列を渡す）。
+```bash
+npx wrangler hyperdrive create my-hyperdrive \
+  --connection-string="postgres://user:password@db.example.com:5432/mydb"
+```
+
+`wrangler.jsonc` にバインディング追加。
+```jsonc
+{
+  "name": "my-worker",
+  "hyperdrive": [
+    {
+      "binding": "HYPERDRIVE",
+      "id": "<生成されたID>"
+    }
+  ],
+  "placement": {
+    "region": "aws:us-east-1"
+  }
+}
+```
+
+Worker側コード（`pg`ドライバ）。
+```ts
+import { Client } from "pg";
+
+export default {
+  async fetch(request, env, ctx): Promise<Response> {
+    const client = new Client({
+      connectionString: env.HYPERDRIVE.connectionString,
+    });
+    await client.connect();
+    const result = await client.query("SELECT * FROM pg_tables");
+    return Response.json(result.rows);
+  },
+} satisfies ExportedHandler<{ HYPERDRIVE: Hyperdrive }>;
+```
+
+## 制限・注意点
+- **設定数**: Free 10 / Paid 25（アカウントあたり）
+- **オリジンDB接続数**: Free 約20 / Paid 約100（設定あたり）。分散システム特性上、稀に超過する場合あり
+- **クエリ最大実行時間**: 60秒（超過は強制終了）
+- **キャッシュ対象レスポンス上限**: 50MB（超えるものはキャッシュされないがWorkerには返る）
+- **初期接続タイムアウト**: 15秒、**アイドル接続タイムアウト**: 10分
+- **Pooling mode**: transaction modeのみ。`SET`はトランザクション/単一クエリ内に閉じる。複数クエリで状態を保持するために長時間トランザクションを張るのは反パターン（プール再利用性を損なう）
+- **Named prepared statements**: 一部ドライバでは未対応・性能劣化あり
+- 接続枯渇エラー（`Failed to acquire a connection from the pool`）は長時間クエリ/トランザクションが主因。クエリの短縮で対処する
+
+## 参考リンク
+- 概要: https://developers.cloudflare.com/hyperdrive/
+- 仕組み: https://developers.cloudflare.com/hyperdrive/concepts/how-hyperdrive-works/
+- Limits: https://developers.cloudflare.com/hyperdrive/platform/limits/
+- Pricing: https://developers.cloudflare.com/hyperdrive/platform/pricing/
+
+---
+参照日: 2026-05-03

--- a/src/content/knowledge/web-development/cloudflare-docs/15-images.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/15-images.mdx
@@ -1,0 +1,131 @@
+---
+title: "Cloudflare Images"
+description: "Cloudflare Imagesは、画像のストレージ・オンザフライ変換・グローバル配信をエッジで統合提供するマネージド画像基盤である。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 15
+---
+# Images
+
+## 一行サマリ
+Cloudflare Imagesは、画像のストレージ・オンザフライ変換・グローバル配信をエッジで統合提供するマネージド画像基盤である。
+
+## 解決する課題（Why）
+- デバイス・ブラウザ別に複数サイズの画像を事前生成・保管するコストを排除する。
+- レスポンシブ画像、サムネイル、AVIF/WebPトランスコードなどの最適化を、アプリ側のロジックを増やさずに実現する。
+- 画像CDN・変換サーバ・ストレージという三層を別々に契約・運用する手間をなくす。
+- オリジン画像が大きい場合の帯域コストとLCPなどCore Web Vitals悪化を抑える。
+
+## 主要機能（What）
+- **保存（Images storage）**: 画像をCloudflareにアップロードし、変換済みバリアントを含めて配信まで完結。
+- **オンザフライ変換（Image Transformations）**: R2や任意のオリジンに置いた画像をURLパラメータ（`width`、`height`、`format`、`quality`、`fit`、`gravity`、`onerror`等）で動的にリサイズ・再エンコード。
+- **Workers Bindings**: Workers内から`env.IMAGES.input(...).transform(...).output(...)`形式で変換APIを呼び出し可能。
+- **Predefined variants**: `thumbnail=100x100`、`hero=1600x500`のような名前付きバリアントを事前定義し、URLで指定して呼び出す。
+- **Polish連携**: ZoneレベルでJPEG/PNG/WebP/AVIFへの自動最適化を行うCloudflare Polishと併用可能。
+- **AI機能**: 公式ドキュメント上、画像理解（draw / describe）はWorkers AI側のVision系モデル経由で扱う設計。Images本体は最適化・配信レイヤに特化。
+
+## 2つのモード（必須）
+### モード1: Cloudflare Imagesにアップロード保存
+- 画像をImagesにアップロードし、ストレージ・変換・配信をすべて任せる。
+- 課金は **Images Stored**（保管）と **Images Delivered**（配信回数）。
+- バリアントはストレージ消費にカウントされない。
+
+### モード2: 既存R2 / 外部URLにTransformationだけ適用
+- 画像はR2や任意のオリジンに置き、URLパターン（例: `/cdn-cgi/image/width=800,format=auto/<source>`）で変換のみ呼び出す。
+- 課金は **Images Transformed**（ユニーク変換数）のみ。
+- Free planでも月5,000ユニーク変換まで利用可能。
+
+## アーキテクト視点：いつ選ぶか
+### 適しているシーン
+- ECサイト・メディアサイトで多数のサムネイル・解像度を動的に必要とする場合。
+- すでにCloudflareにフロントを乗せており、Polish・R2・Workersと統合したい場合。
+- 画像CDN契約と原本ストレージを一本化してベンダーを減らしたい場合。
+- ユーザー投稿画像（UGC）を受け取り、即座に配信用に最適化したい場合。
+
+### 適していないシーン
+- 動画ストリーミングが主用途（→ Cloudflare Stream）。
+- 高度な画像生成・編集AI（背景除去、生成塗りつぶし等）を必須とする場合（Cloudinaryの方が機能網羅）。
+- 既存のimgix / Cloudinaryで複雑なカスタム変換パイプラインを構築済みで、移行コストが利得を上回る場合。
+- オフライン一括バッチ変換が中心で、エッジキャッシュの恩恵を受けない用途。
+
+## 競合・代替
+
+| 観点 | Cloudflare Images | Cloudinary | imgix | Vercel Image |
+|---|---|---|---|---|
+| ポジション | 最適化＋配信＋ストレージ統合 | 高機能DAM＋AI編集 | URLベースの画像変換特化 | Next.js統合の画像最適化 |
+| 課金軸 | 変換ユニーク数・保管・配信 | クレジット制（変換・帯域） | オリジン画像数・帯域 | Source Images・Transformations |
+| AI/編集機能 | 限定的（Workers AIで補完） | 豊富（背景除去、生成塗り等） | 中程度 | 限定的 |
+| ストレージ統合 | Images本体＋R2 | 自前ストレージあり | 別途必要 | Vercel Blob |
+| CDN | Cloudflare（300+拠点） | Akamai系 | Fastly系 | Vercel Edge |
+| 価格感 | 低〜中（小〜中規模で割安） | 高 | 中〜高 | 中 |
+
+S3 + Lambda@Edge + CloudFrontやBunny Optimizerと比較すると、Cloudflare Imagesは「設定の少なさ」と「Free tierで5,000変換」が優位。一方、細粒度の変換ロジックやAI編集はCloudinaryに分がある。
+
+## 料金モデルの要点
+- **Free plan**: 月5,000ユニーク変換まで無料。超過すると新規変換は`9422`エラー（既存キャッシュは継続配信、課金なし）。
+- **Paid plan**:
+  - Images Transformed: 最初の5,000ユニーク変換込み、以降 **$0.50 / 1,000ユニーク変換**。
+  - Images Stored: **$5 / 100,000枚 / 月**（保管）。
+  - Images Delivered: **$1 / 100,000配信 / 月**。
+- ユニーク変換は「原本画像 × パラメータ組合せ」単位。同月内の同一URLリクエストはキャッシュヒットでも初回1回のみ課金。
+- `format=auto`は配信形式（AVIF/WebP）が分かれても1ユニークとしてカウント。
+- R2併用時はR2のストレージ・オペレーション課金が加算される。
+
+## CLI / IaC 操作例
+
+### Wranglerで変換用Bindingを設定
+```toml
+# wrangler.toml
+name = "image-worker"
+main = "src/index.ts"
+compatibility_date = "2026-01-01"
+
+[images]
+binding = "IMAGES"
+```
+
+### Worker内から変換
+```typescript
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const origin = await fetch("https://example.com/source.jpg");
+    const result = await env.IMAGES
+      .input(origin.body!)
+      .transform({ width: 800, format: "auto", quality: 85 })
+      .output({ format: "image/avif" });
+    return result.response();
+  },
+};
+```
+
+### URL変換（Zone有効化後）
+```
+https://example.com/cdn-cgi/image/width=800,format=auto,quality=85/https://origin.example.com/photo.jpg
+```
+
+### REST APIで画像アップロード
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -F "file=@photo.jpg" \
+  "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/images/v1"
+```
+
+## 制限・注意点
+- 入力画像の最大解像度・サイズ・対応フォーマットは公式の[limits and supported formats](https://developers.cloudflare.com/images/reference/)で要確認（一般に最大解像度・最大ファイルサイズに上限あり）。
+- Transformationsをzoneで使う場合、ダッシュボードで明示的に有効化が必要。
+- デフォルトでは同一zoneのオリジンのみソース許可。外部URLからの変換はSource origins設定が必須。
+- Workers Bindings経由の変換は、URLが同一でも呼び出すたびに1ユニーク変換としてカウントされる（URL方式のキャッシュ重複排除と挙動が異なる）。
+- 変換結果のキャッシュ寿命はEdge Cache TTLに従うため、Cache Rulesでの調整が必要なケースあり。
+- Free planの`9422`エラー時は`onerror=redirect`で原本にフォールバック可能（同一ドメインのソースに限る）。
+
+## 参考リンク
+- 公式概要: https://developers.cloudflare.com/images/
+- Pricing: https://developers.cloudflare.com/images/pricing/
+- Transformations Overview: https://developers.cloudflare.com/images/transform-images/
+- Optimization features: https://developers.cloudflare.com/images/optimization/features/
+- Workers Bindings: https://developers.cloudflare.com/images/optimization/transformations/bindings/
+
+---
+参照日: 2026-05-03

--- a/src/content/knowledge/web-development/cloudflare-docs/16-kv.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/16-kv.mdx
@@ -1,0 +1,183 @@
+---
+title: "Cloudflare Workers KV"
+description: "Cloudflareのグローバル分散KVストア。世界中のエッジから低レイテンシで読み込めるため、読み込み比率が圧倒的に高く結果整合性で許容できるユースケース（設定値・認証情報・キャッシュ・フィーチャーフラグ等）に最適化されている。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 16
+---
+# Workers KV
+
+## 一行サマリ
+
+Cloudflareのグローバル分散KVストア。世界中のエッジから低レイテンシで読み込めるため、読み込み比率が圧倒的に高く結果整合性で許容できるユースケース（設定値・認証情報・キャッシュ・フィーチャーフラグ等）に最適化されている。
+
+## 解決する課題（Why）
+
+従来のリージョン型KVS（DynamoDBやElastiCache）はリージョン外からのアクセスでレイテンシが跳ね上がる。グローバルにユーザーを抱えるアプリケーションでは、リージョン選定・レプリケーション設計・接続プール管理がアーキテクトの負担になる。Workers KVはCloudflareの300超データセンターに自動レプリケートし、Workersのバインディング経由でゼロ設定の低レイテンシ読み込みを提供する。「読み込みが多く、わずかな伝搬遅延を許容できる」ワークロードを最小コードで実装できる。
+
+## 主要機能（What）
+
+- Workersバインディングによる`get` / `put` / `delete` / `list` API
+- REST API経由での外部アプリからの操作
+- キーごとのメタデータ（最大1024バイト）保存
+- TTL指定による自動削除（`expirationTtl`）
+- リード時のエッジキャッシュ（`cacheTtl`、最小30秒）
+- ネームスペース単位での論理分離（1アカウントあたり1,000ネームスペース）
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン（読込多い・結果整合性OK）
+
+- グローバル配信の設定値・フィーチャーフラグ
+- APIレスポンスキャッシュ
+- ユーザープリファレンス・認証セッションのキャッシュ層
+- A/Bテストのバリアント割り当て
+- 静的アセットのメタデータ・ルーティングテーブル
+- 読込:書込比が概ね100:1以上のワークロード
+
+### 適していないシーン（強整合・高頻度書込み）
+
+- 在庫数・残高・カウンタなど強整合が必須の処理 → Durable Objectsを使う
+- 同一キーへの秒間1回超の書込み（書込みレート制限）
+- リレーショナルクエリやJOIN・トランザクション → D1
+- 大容量バイナリ（25 MiB超） → R2
+- 書込み即時に全リージョンへ反映が必要なケース（最大60秒の伝搬遅延あり）
+
+## 結果整合性の仕組み（必須セクション）
+
+Workers KVはEventually Consistent（結果整合）モデルを採用する。書込みは中央データセンターに集約された後、世界中のエッジへ非同期にレプリケートされる。各エッジには直近のリードキャッシュが保持され、デフォルトで最大60秒間は古い値が返却される可能性がある。
+
+挙動の要点:
+
+- 書込み直後の同一キー読み込みでも、別リージョンでは旧値が返ることがある
+- `cacheTtl`を短くすればフレッシュさは増すが、オリジン読み込みが増えコストとレイテンシが上がる
+- 同一キーへの書込みは1秒1回までに制限される
+- 強整合が必要な値はWorkers KVに置かず、Durable Objectsへ寄せる（KVはあくまで読込最適化レイヤ）
+
+リード戦略の指針:
+
+- 全エッジで完全一致が必要 → Workers KV不適合
+- 「数十秒以内に伝搬すれば良い」 → Workers KVが最適
+- 書込み元と読み込み元が同じWorker実行内 → ローカル変数や`waitUntil`でカバー
+
+## 競合・代替（DynamoDB / Redis / Memcached / Durable Objects / D1）
+
+| 観点 | Workers KV | DynamoDB | Redis (ElastiCache) | Durable Objects | D1 |
+|---|---|---|---|---|---|
+| 配置 | グローバル分散（自動） | リージョン（Global Tables有） | リージョン | グローバル単一インスタンス | リージョン分散 |
+| 整合性 | 結果整合（最大60秒） | 強整合オプション有 | 強整合 | 強整合 | 強整合 |
+| クエリ | Key-Value + プレフィックスリスト | KV + GSI/LSI | 多様なデータ構造 | 任意ロジック | SQL |
+| 書込みレート | 同一キー1/秒 | 高スループット | 非常に高い | シングルライタ | 中 |
+| 値サイズ上限 | 25 MiB | 400 KB | メモリ依存 | 128 KiB（KV API） | カラム制限内 |
+| 料金 | 読込 $0.50/M、書込 $5/M | 読込/書込ユニット課金 | インスタンス時間課金 | リクエスト+期間課金 | 行スキャン課金 |
+| 主用途 | グローバル設定・キャッシュ | OLTP | セッション・キャッシュ | 強整合カウンタ・状態 | リレーショナル |
+
+選定の指針: 「グローバル読込重視・結果整合OK」ならKV、「強整合の状態管理」ならDurable Objects、「リレーショナル」ならD1、「大容量オブジェクト」ならR2。
+
+## 料金モデルの要点
+
+Free / Paidプランで無料枠と従量課金が異なる。
+
+- 読込: 100,000/日（Free）/ 1000万/月、超過分$0.50/100万（Paid）
+- 書込: 1,000/日（Free）/ 100万/月、超過分$5.00/100万（Paid）
+- 削除: 1,000/日（Free）/ 100万/月、超過分$5.00/100万（Paid）
+- リスト: 1,000/日（Free）/ 100万/月、超過分$5.00/100万（Paid）
+- ストレージ: 1 GB / 1 GB+ $0.50/GB-月
+
+ポイント:
+
+- データ転送（egress）課金なし
+- 存在しないキーへのGETも課金対象（404でも操作回数にカウント）
+- バルク読込は読み込んだキー数で課金
+- ダッシュボード・wrangler経由の操作も課金対象
+- 書込みコストが読込の10倍。書込み頻度が高いワークロードは設計を見直す
+
+## CLI / IaC 操作例
+
+```bash
+# ネームスペース作成
+wrangler kv namespace create "MY_KV"
+
+# プレビュー用ネームスペース作成
+wrangler kv namespace create "MY_KV" --preview
+
+# キー書込み
+wrangler kv key put --binding=MY_KV "user:123" '{"plan":"pro"}'
+
+# TTL付き書込み（60秒で失効）
+wrangler kv key put --binding=MY_KV "session:abc" "token" --ttl 60
+
+# キー読込
+wrangler kv key get --binding=MY_KV "user:123"
+
+# キー削除
+wrangler kv key delete --binding=MY_KV "user:123"
+
+# プレフィックス指定リスト
+wrangler kv key list --binding=MY_KV --prefix "user:"
+
+# バルク書込み（JSONファイル）
+wrangler kv bulk put --binding=MY_KV ./data.json
+```
+
+`wrangler.jsonc`でのバインディング定義:
+
+```jsonc
+{
+  "kv_namespaces": [
+    {
+      "binding": "MY_KV",
+      "id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "preview_id": "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
+    }
+  ]
+}
+```
+
+Workers内での利用:
+
+```typescript
+export default {
+  async fetch(request, env): Promise<Response> {
+    await env.MY_KV.put("KEY", "VALUE", { expirationTtl: 3600 });
+    const value = await env.MY_KV.get("KEY", { cacheTtl: 60 });
+    const list = await env.MY_KV.list({ prefix: "user:" });
+    await env.MY_KV.delete("KEY");
+    return new Response(value);
+  },
+} satisfies ExportedHandler<{ MY_KV: KVNamespace }>;
+```
+
+## 制限・注意点
+
+| 項目 | 制限値 |
+|---|---|
+| キーサイズ | 512バイト |
+| 値サイズ | 25 MiB |
+| キーメタデータ | 1024バイト |
+| 同一キーへの書込み | 1秒に1回 |
+| 異なるキーへの書込み（Free） | 1,000/日 |
+| 1Worker起動あたりのオペレーション | 1,000 |
+| アカウントあたりネームスペース数 | 1,000 |
+| ストレージ（Free） | 1 GB |
+| `cacheTtl`最小値 | 30秒 |
+
+注意点:
+
+- 同一キーの高頻度書込みは構造的に不可能。カウンタや在庫管理には使わない
+- Free planでは1日1,000書込み制限があり、本番運用前提ならPaid必須
+- 書込み伝搬は最大60秒、強整合を期待するコードは書かない
+- 1 Worker呼び出しで1,000オペレーションを超える設計はバルクAPIに切り替える
+- REST APIはCloudflare REST APIのレートリミットが別途適用される
+
+## 参考リンク
+
+- [Workers KV Overview](https://developers.cloudflare.com/kv/)
+- [KV Limits](https://developers.cloudflare.com/kv/platform/limits/)
+- [KV Pricing](https://developers.cloudflare.com/kv/platform/pricing/)
+- [Workers Binding API](https://developers.cloudflare.com/kv/api/)
+- [KV REST API](https://developers.cloudflare.com/api/operations/workers-kv-namespace-list-namespaces)
+
+---
+参照日: 2026-05-03

--- a/src/content/knowledge/web-development/cloudflare-docs/17-pages.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/17-pages.mdx
@@ -1,0 +1,136 @@
+---
+title: "Cloudflare Pages"
+description: "Cloudflare Pages は、Git 連携または Direct Upload で静的アセットを Cloudflare のグローバルネットワークに即時配信し、Pages Functions により Workers ランタイムでサーバサイド処理も実行できるフルスタック JAMstack ホスティングである。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 17
+---
+# Pages
+
+## 一行サマリ
+Cloudflare Pages は、Git 連携または Direct Upload で静的アセットを Cloudflare のグローバルネットワークに即時配信し、Pages Functions により Workers ランタイムでサーバサイド処理も実行できるフルスタック JAMstack ホスティングである。
+
+## 解決する課題（Why）
+従来の静的サイトホスティングは「CDN 配信は速いが、API・認証・SSR を組み込もうとすると別サービス（Lambda、API Gateway）が必要で構成が分散する」という問題を抱える。Pages は静的アセット配信と Workers ベースのサーバ処理を 1 プロジェクトに統合し、Git push から本番デプロイ・プレビューデプロイ・ロールバックまでを単一パイプラインで完結させる。Edge ネットワーク上に配置されるためオリジンレイテンシが消え、無料枠でも商用レベルの帯域・リクエスト数を扱える。
+
+## 主要機能（What）
+- **Git 連携 / Direct Upload / C3 CLI**：GitHub・GitLab 接続による自動ビルド、ビルド済みアセットの直接アップロード、`create-cloudflare`（C3）からの初期化に対応。
+- **Pages Functions**：`functions/` ディレクトリに配置したコードを Workers ランタイムで実行。ファイルベースルーティング、Middleware、KV / D1 / R2 / Durable Objects への Bindings、Node.js 互換 API のサブセットを提供。
+- **プレビューデプロイ**：ブランチ・PR ごとに一意 URL を発行（無制限）。
+- **Rollbacks**：本番デプロイを過去のバージョンへワンクリックで切り戻し。
+- **Redirects / Headers**：`_redirects`・`_headers` ファイルによる宣言的設定。
+- **カスタムドメイン・自動 TLS・HTTP/3・Brotli・Smart Placement** を標準搭載。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- Astro / Next.js / Nuxt / SvelteKit / Hugo などの静的・ハイブリッド SSG/SSR サイト。
+- マーケティング LP、ドキュメントサイト、ブログ、コーポレートサイトなど Edge 配信が活きる用途。
+- 軽量な API・フォーム処理・認証ミドルウェアを同一リポジトリで完結させたいプロジェクト。
+- プレビュー URL を活用したレビュー文化を持つチーム。
+- D1 / R2 / KV と密結合させたフルスタック JAMstack 構成。
+
+### 適していないシーン
+- 重量級バックエンド処理、長時間実行ジョブ、WebSocket を多用するアプリ（Workers の制約に従う）。
+- ファイル数が極端に多いサイト（無料 20,000、有料 100,000 ファイル制限）。
+- 単一ファイル 25 MiB 超を直接配信したいケース（R2 + 公開バケットへ分離が必要）。
+- 月 500 ビルドを超える高頻度デプロイを Free プランで運用したいケース。
+- Cloudflare 公式が「新規は Workers を推奨」と案内しており、長期的に最大限の機能拡張を求める場合は Workers 単体構成のほうが将来性がある（公式ドキュメントに「Migrate to Workers」リンクが常設）。
+
+## Workers との関係（Pages 特有：必須セクション）
+Pages Functions は内部的には Cloudflare Workers ランタイムで動作する。両者の使い分けは以下の通り。
+
+| 観点 | Pages | Workers |
+|---|---|---|
+| 主目的 | 静的アセット配信 + 付随的なサーバ処理 | コードファースト、汎用エッジ実行環境 |
+| 静的アセット | 一級市民。`_headers` / `_redirects` で宣言的に制御 | `assets` バインディングで近年対応 |
+| ルーティング | `functions/` ディレクトリのファイルベース（規約駆動） | `wrangler.toml` の `routes` または `fetch` ハンドラ内で自由に記述 |
+| デプロイ単位 | プロジェクト＝サイト。Git 連携前提のワークフロー | Worker 単位。Git 連携も可だが必須ではない |
+| ビルド | Cloudflare 側でフレームワーク自動ビルド | ローカル / CI でビルドし `wrangler deploy` |
+| 制限 | Builds 月 500（Free）、ファイル数・サイズ制限あり | リクエスト課金。アセット制限は別体系 |
+| 課金 | Functions リクエストは Workers 課金枠を消費（Standard usage model） | 同左 |
+
+Cloudflare 公式は近年 Workers の Static Assets 機能を強化し、ドキュメントナビにも「Migrate to Workers」を常設している。新規プロジェクトでフルスタックを志向する場合、Workers 単体のほうが将来の機能追従性が高い。一方、既存の SSG / フレームワークを Git 連携で素早く載せ替える用途では Pages が依然として最短経路である。
+
+## 競合・代替
+
+| プロバイダ | 違い |
+|---|---|
+| Vercel | Next.js 最適化と DX が圧倒的。Edge Functions と Serverless Functions の二層構造。帯域課金が高めで、Cloudflare に対し中〜大規模で価格差が出る。 |
+| Netlify | 元祖 JAMstack。Build Plugins が豊富、Forms / Identity など独自機能あり。Edge Functions は Deno ベース。ビルド時間課金が中心。 |
+| AWS Amplify Hosting | AWS エコシステムとの統合（Cognito / AppSync）が強み。CloudFront 経由の配信。設定が AWS 標準で複雑だが企業要件に強い。 |
+| Firebase Hosting | Google のエコシステム（Auth / Firestore / Cloud Functions）と一体運用。Cloud Run 統合で SSR 可能。Asia 配信は良好。 |
+| S3 + CloudFront | フルセルフ構築。柔軟性最大だが、ビルドパイプライン・キャッシュ無効化・ACM 証明書管理を自前で組む必要あり。コストは大規模配信で最安クラス。 |
+
+差別化軸：Pages は「Cloudflare ネットワークの広さと Workers エコシステム（D1 / R2 / KV / Durable Objects / Queues）への密結合」「無料枠の太さ（無制限帯域・無制限リクエスト・月 500 ビルド）」が最大の武器。
+
+## 料金モデルの要点
+- **配信**：帯域・リクエスト数ともに無制限・無料（Free プラン含む）。
+- **ビルド**：Free 月 500 / 同時 1、Pro 月 5,000 / 同時 5、Business 月 20,000 / 同時 20。タイムアウト 20 分。
+- **Functions**：Workers 課金枠を共有（Standard usage model）。Free は 1 日 100,000 リクエスト、Paid は $5/月で 1,000 万リクエスト含み、超過分は $0.30/100 万リクエスト。
+- **カスタムドメイン**：Free 100 / Pro 250 / Business 500 / Enterprise 500+。
+- **ファイル数**：Free 20,000 / Paid 100,000（`PAGES_WRANGLER_MAJOR_VERSION=4` 設定が必要）。
+- **ファイルサイズ**：1 ファイル最大 25 MiB。超過分は R2 に逃がす設計が定石。
+
+## CLI / IaC 操作例
+
+```bash
+# プロジェクト初期化（C3）
+npm create cloudflare@latest my-site -- --framework=astro
+
+# ローカル開発（Pages Functions 含む）
+npx wrangler pages dev ./dist
+
+# Direct Upload による本番デプロイ
+npx wrangler pages deploy ./dist --project-name=my-site --branch=main
+
+# プロジェクト一覧
+npx wrangler pages project list
+
+# デプロイ履歴
+npx wrangler pages deployment list --project-name=my-site
+
+# シークレット設定（Functions 用）
+npx wrangler pages secret put API_KEY --project-name=my-site
+```
+
+`wrangler.toml`（Pages Functions 用）：
+
+```toml
+name = "my-site"
+compatibility_date = "2026-04-01"
+pages_build_output_dir = "./dist"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "my-db"
+database_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+[[r2_buckets]]
+binding = "ASSETS"
+bucket_name = "my-assets"
+```
+
+Terraform は `cloudflare_pages_project` リソースでプロジェクト・ビルド設定・環境変数・カスタムドメインを宣言的に管理可能。
+
+## 制限・注意点
+- **Free プランのビルド回数**：月 500 回上限。CI で頻繁にプレビュー生成するチームは Pro 必須。
+- **同時ビルド**：Free は 1。マージ集中時にキューイングが発生。
+- **ビルドタイムアウト**：20 分固定。重い SSG はビルド分割または事前ビルド戦略が必要。
+- **ファイル数 20,000 / 100,000**：画像が多い E コマース・ギャラリー系は要注意。R2 + 動的配信に切り替える。
+- **単一ファイル 25 MiB**：動画・大型 PDF は R2 へ。
+- **`_headers` / `_redirects`**：ヘッダ 100 ルール、リダイレクト 2,000 静的 + 100 動的まで。超える場合は Bulk Redirects または Functions で実装。
+- **新規プロジェクトの方向性**：Cloudflare 自身が「Migrate to Workers」を案内しており、Pages は機能追加よりも Workers Static Assets への統合が今後の主軸。新規構築時は Workers 単体構成も比較検討すべき。
+- **Functions のコールドスタート**：Workers 同様ほぼゼロだが、大規模 Bindings 利用時はリージョン配置（Smart Placement）の検証が必要。
+- **プロジェクト数**：1 アカウントあたりソフトリミット 100。短期間の大量作成はスロットリング対象。
+
+## 参考リンク
+- Cloudflare Pages Overview: https://developers.cloudflare.com/pages/
+- Pages Limits: https://developers.cloudflare.com/pages/platform/limits/
+- Pages Functions: https://developers.cloudflare.com/pages/functions/
+- Migrate to Workers: https://developers.cloudflare.com/workers/static-assets/migration-guides/migrate-from-pages/
+- Wrangler Pages Commands: https://developers.cloudflare.com/workers/wrangler/commands/#pages
+
+---
+参照日: 2026-05-03

--- a/src/content/knowledge/web-development/cloudflare-docs/18-queues.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/18-queues.mdx
@@ -1,0 +1,152 @@
+---
+title: "Cloudflare Queues"
+description: "Cloudflare Queues は Workers と統合された、エグレス料金ゼロのグローバル分散メッセージキューである。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 18
+---
+# Queues
+
+## 一行サマリ
+Cloudflare Queues は Workers と統合された、エグレス料金ゼロのグローバル分散メッセージキューである。
+
+## 解決する課題（Why）
+- Worker 間や外部システムとの非同期処理を、配信保証付きで実現する必要がある。
+- 既存クラウドのキュー（SQS / Pub/Sub）は egress 料金とリージョン固定が運用コストを押し上げる。
+- リクエスト処理から重い後段処理を切り離し、ピーク吸収・バッチ化・リトライを統一的に扱いたい。
+- Cloudflare Workers / R2 / D1 とゼロ設定で連携する非同期基盤がほしい。
+
+## 主要機能（What）
+- **Producer**: Worker から `env.MY_QUEUE.send(msg)` / `sendBatch([...])` で投入。最大 256KB / バッチ。
+- **Consumer (Push)**: バインドした Worker が自動起動。バッチ最大 100 件、待機時間最大 60 秒で受信。
+- **Consumer (Pull)**: Cloudflare 外のインフラから HTTP REST で pull 可能。`visibilityTimeout` は最大 12 時間。
+- **Dead Letter Queue (DLQ)**: 最大リトライ超過のメッセージを別キューに転送。
+- **Batching / Retries / Delays**: バッチサイズ・待機時間・遅延配信（最大 24 時間）・リトライ回数（最大 100）を設定可能。
+- **Message Retention**: 既定 4 日、最大 14 日（Free プランは 24 時間固定）。
+- **Event Subscriptions**: R2 などの Cloudflare イベントをキューにルーティング。
+- **Observability**: Wrangler / ダッシュボードからバックログ・スループット監視。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- Cloudflare Workers / R2 / D1 を中核に据えた非同期処理基盤。
+- ファンアウトせず、producer → queue → consumer の単純な疎結合化を求めるユースケース。
+- エグレス料金を回避したいクロスリージョン / マルチクラウド連携（pull consumer で外部から取得）。
+- バッチ処理に向く ETL、Webhook 受け取り、メール送信、画像処理ジョブなど。
+- スパイク吸収バッファ（5,000 msg/sec/queue まで）。
+
+### 適していないシーン
+- ミリ秒レイテンシ・厳密な順序保証（FIFO）が必須なケース。Queues は順序保証を明示しない。
+- 1キューあたり 5,000 msg/sec を超える超高スループット要件 → Kafka 系。
+- Pub/Sub 型のファンアウト配信（1 メッセージを N consumer に同報）→ 単独では非対応。
+- 128KB 超のペイロード（R2 へオフロードして参照を流す設計が必要）。
+- Cloudflare 外で完結する純粋オンプレ構成（メリット薄）。
+
+## 競合・代替（SQS / Pub/Sub / SNS / Kafka / RabbitMQ）
+
+| 観点 | Cloudflare Queues | AWS SQS | GCP Pub/Sub | Apache Kafka |
+|---|---|---|---|---|
+| エグレス料金 | 無料 | リージョン外で発生 | リージョン外で発生 | 自前運用次第 |
+| スループット上限 | 5,000 msg/sec/queue | ほぼ無制限（Standard） | 数百万 msg/sec | 数百万 msg/sec |
+| 配信保証 | At-least-once | At-least-once（FIFO は exactly-once） | At-least-once | At-least-once / exactly-once |
+| 順序 | 保証なし | FIFO キューあり | 順序キーで保証 | パーティション内で保証 |
+| 課金単位 | 64KB 単位の operation | リクエスト数 + データ転送 | データ量 + 操作 | 自前 / Confluent 従量 |
+| 適性 | Workers 統合・低コスト非同期 | AWS 中心の汎用キュー | GCP 中心ファンアウト | 大規模ストリーミング |
+
+## 料金モデルの要点
+- **課金単位**: 64KB ごとに 1 operation。write / read / delete それぞれカウント。
+- **Free プラン**: 10,000 ops/日、保持 24 時間固定。
+- **Paid プラン**: 1,000,000 ops/月まで無料、超過分 $0.40 / 100 万 ops。
+- **エグレス料金 / 帯域料金は一切なし**。
+- 標準的なメッセージ処理は 1 件あたり 3 ops（write + read + delete）。
+- リトライは追加 read を消費。DLQ 送りは追加 write を消費。
+- 概算式: `((メッセージ数 * 3) - 1,000,000) / 1,000,000 * $0.40`。
+- 例: 1日100万件・30日 → 月 $35.60。127KB×1億件/月 → 月 $239.60。
+
+## CLI / IaC 操作例
+
+キュー作成と Worker バインド。
+
+```bash
+# キュー作成
+npx wrangler queues create my-queue
+
+# DLQ 作成
+npx wrangler queues create my-queue-dlq
+
+# コンシューマ設定
+npx wrangler queues consumer add my-queue my-worker
+```
+
+`wrangler.jsonc` 設定例。
+
+```jsonc
+{
+  "name": "my-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-04-01",
+  "queues": {
+    "producers": [
+      { "binding": "MY_QUEUE", "queue": "my-queue" }
+    ],
+    "consumers": [
+      {
+        "queue": "my-queue",
+        "max_batch_size": 10,
+        "max_batch_timeout": 5,
+        "max_retries": 3,
+        "dead_letter_queue": "my-queue-dlq"
+      }
+    ]
+  },
+  "limits": { "cpu_ms": 300000 }
+}
+```
+
+Worker コード例。
+
+```typescript
+export default {
+  // Producer（HTTP リクエストハンドラ）
+  async fetch(req: Request, env: Env) {
+    await env.MY_QUEUE.send({ userId: "u_123", action: "signup" });
+    return new Response("queued");
+  },
+
+  // Consumer（push型）
+  async queue(batch: MessageBatch, env: Env) {
+    for (const msg of batch.messages) {
+      try {
+        await processMessage(msg.body);
+        msg.ack();
+      } catch (e) {
+        msg.retry({ delaySeconds: 30 });
+      }
+    }
+  }
+};
+```
+
+## 制限・注意点
+- **メッセージサイズ**: 128KB 上限。超過時は R2 にオフロードしポインタを送る設計に切り替える。
+- **per-queue スループット**: 5,000 msg/sec。超過時は `Too Many Requests` で send が失敗する。
+- **保存期間**: 最大 14 日（Free は 24 時間固定）。期限切れメッセージは自動削除され、課金は write + delete のみ。
+- **バックログ上限**: キューあたり 25GB。超過すると `Storage Limit Exceeded`。
+- **同時 consumer 起動**: push 型で 250 並列。
+- **CPU 時間**: consumer Worker は既定 30 秒、最大 5 分まで `cpu_ms` で拡張可能。Wall time は 15 分上限。
+- **順序保証なし**: 順序が要件ならアプリ側でシーケンス管理が必要。
+- **pull consumer**: `visibilityTimeout` 最大 12 時間。明示的 ack/retry を忘れると再配信される。
+- **アカウント上限**: 1 アカウントあたり 10,000 キュー。
+- メッセージあたり約 100 バイトの内部メタデータがサイズに加算される。
+
+## 参考リンク
+- [Cloudflare Queues 公式ドキュメント](https://developers.cloudflare.com/queues/)
+- [Limits](https://developers.cloudflare.com/queues/platform/limits/)
+- [Pricing](https://developers.cloudflare.com/queues/platform/pricing/)
+- [JavaScript APIs](https://developers.cloudflare.com/queues/configuration/javascript-apis/)
+- [Dead Letter Queues](https://developers.cloudflare.com/queues/configuration/dead-letter-queues/)
+- [Pull Consumers](https://developers.cloudflare.com/queues/configuration/pull-consumers/)
+
+---
+参照日: 2026-05-03

--- a/src/content/knowledge/web-development/cloudflare-docs/19-r2.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/19-r2.mdx
@@ -1,0 +1,190 @@
+---
+title: "Cloudflare R2"
+description: "Cloudflare R2 は、エグレス料金が無料の S3 互換オブジェクトストレージである。Cloudflare のグローバルネットワーク上で動作し、配信コストを劇的に圧縮しながら既存の S3 エコシステムをそのまま利用できる。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 19
+---
+# R2
+
+## 一行サマリ
+
+Cloudflare R2 は、エグレス料金が無料の S3 互換オブジェクトストレージである。Cloudflare のグローバルネットワーク上で動作し、配信コストを劇的に圧縮しながら既存の S3 エコシステムをそのまま利用できる。
+
+## 解決する課題（Why）
+
+クラウドオブジェクトストレージの本質的なコスト構造は「保管」よりも「外向き転送（egress）」にある。S3 / GCS / Azure Blob はいずれも、インターネットへのデータ転送に対して GB あたり数セント〜十数セントの egress 料金を課金する。動画配信・画像配信・データレイクからの分析クエリ・ML モデル配布など、読み出し量が多いワークロードでは、ストレージ単価より egress が支配的なコスト要因になる。
+
+R2 はこの egress 料金を完全に廃止する。ストレージとオペレーションのみで課金され、インターネットへの転送は無料である。これは「同一クラウド内でしかコスト最適化できない」というベンダーロックインを解く設計上の意思表明であり、Bandwidth Alliance の延長線上にある。
+
+加えて、R2 は S3 API 互換であるため、aws-sdk・boto3・rclone などの既存資産をエンドポイント差し替えだけで流用できる。「移行コストを払わずに egress 料金から逃げる」ことが R2 の中核的な提供価値である。
+
+## 主要機能（What）
+
+- S3 互換 API（`https://<ACCOUNT_ID>.r2.cloudflarestorage.com`）
+- ストレージクラス2種：Standard / Infrequent Access
+- Workers バインディング経由のゼロレイテンシアクセス（同一エッジで動作する Workers から直接読み書き）
+- パブリックバケット（カスタムドメイン接続で CDN 配信、`r2.dev` はテスト用）
+- Location Hints（バケット作成時に主要アクセス地域を指示）
+- バケットスコープトークン（細粒度の認可）
+- Lifecycle ルール、CORS、サーバサイド暗号化
+- マルチパートアップロード（最大 4.995 TiB）
+- イベント通知、Super Slurper / Sippy による S3 等からのデータ移行
+- R2 Data Catalog（Iceberg ベースのテーブルカタログ、public beta）
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+
+- **配信主体のワークロード**：動画・画像・大容量アセット配信、ゲームのパッチ配信、ML モデルの公開ホスティング。読み出しが書き込みを大きく上回るほど R2 の優位が拡大する。
+- **Cloudflare Workers / Pages との組み合わせ**：エッジ実行と同一プレーン上にあり、Workers バインディング経由なら認証・ネットワーキング設定が不要。
+- **マルチクラウド分析基盤**：データレイク本体を R2 に置き、Snowflake・Databricks・BigQuery など複数の分析エンジンから読み出す構成で、egress が常に無料となるためベンダーロックインを回避できる。
+- **バックアップ・アーカイブ**：Infrequent Access クラスで $0.01/GB-month、復元時も egress 無料。
+- **AWS からの脱出**：S3 互換 API のため、エンドポイントとシグネチャ設定の差し替えで移行可能。Sippy で段階的にコピーできる。
+
+### 適していないシーン
+
+- **AWS 内部完結のワークロード**：データの読み出し先がすべて同一リージョンの EC2 / Lambda 等で、egress が発生しない構成。S3 のままで十分。
+- **超低レイテンシの強整合トランザクション**：S3 Express One Zone のような単一 AZ 専用低レイテンシは提供されない。
+- **高頻度書き込み・書き込み主体ワークロード**：Class A オペレーション（書き込み系）が支配的だと、R2 の単価面の優位が薄れる。1秒間に同一キーへの書き込みは 1 回まで、というスロットリングもある。
+- **AWS 固有機能依存**：Object Lambda、Inventory、S3 Select、Replication（Cross-Region Replication）など S3 独自機能を前提にした設計。R2 は API 互換だが機能差分がある。
+
+## S3 / GCS / Azure Blob との比較（必須セクション・表形式）
+
+| 観点 | R2 | S3 | GCS | Azure Blob |
+|---|---|---|---|---|
+| エグレス | **無料** | $0.05〜0.09/GB（上限あり） | $0.08〜0.12/GB | $0.05〜0.087/GB |
+| 互換 API | S3 互換 | 標準 | S3 互換あり（XML API） | 独自 REST（S3 互換は別ゲートウェイ） |
+| ストレージ単価（Standard） | $0.015/GB-month | $0.023/GB-month | $0.020/GB-month | $0.018/GB-month |
+| 低頻度クラス | Infrequent Access $0.01/GB-month | S3 IA / Glacier 系 | Nearline / Coldline / Archive | Cool / Cold / Archive |
+| 書き込み(Class A)単価 | $4.50/M req | $5.00/M req | $5.00/M req | 同等水準 |
+| 読み込み(Class B)単価 | $0.36/M req | $0.40/M req | $0.40/M req | 同等水準 |
+| 整合性 | 強整合（read-after-write） | 強整合 | 強整合 | 強整合 |
+| レプリケーション | 自動マルチサイト保管、Location Hints で地域指定 | リージョン選択＋CRR/SRR 構成 | マルチリージョン / デュアルリージョン | GRS / RA-GRS |
+| 性能特性 | エッジネットワーク前提、CDN 接続が前提設計 | リージョン内 EC2 と組むと最高性能 | リージョン内 GCE/BigQuery と最適 | リージョン内 Azure サービスと最適 |
+| Free Tier | 10 GB-month + 1M Class A + 10M Class B（毎月） | 5 GB（12ヶ月限定） | 5 GB（米国限定リージョン） | 5 GB（12ヶ月限定） |
+| ロックイン度 | 低（egress 無料で他クラウドへも自由） | 高（egress が事実上の足かせ） | 中 | 中 |
+
+## 料金モデルの要点
+
+R2 の課金は3軸のみ。
+
+- **ストレージ**：Standard $0.015/GB-month、Infrequent Access $0.01/GB-month。GB-month は 1 日あたりピーク量を 30 日平均する。
+- **Class A オペレーション（状態を変える系）**：$4.50 / 100万リクエスト（Standard）。`PutObject`、`CopyObject`、`ListObjects`、`CreateMultipartUpload`、`UploadPart`、`PutBucketCors` など。
+- **Class B オペレーション（読み出し系）**：$0.36 / 100万リクエスト（Standard）。`GetObject`、`HeadObject`、`HeadBucket` など。
+- **Free オペレーション**：`DeleteObject`、`DeleteBucket`、`AbortMultipartUpload` は無料。
+- **データ取得料**：Standard はゼロ。Infrequent Access のみ $0.01/GB の retrieval fee が発生し、最低保管期間は 30 日。
+- **Egress**：常時ゼロ。S3 API・Workers API・`r2.dev`・カスタムドメイン経由いずれも無料。
+
+**Forever Free 枠（毎月リセット、Standard のみ）**：
+
+- ストレージ 10 GB-month
+- Class A 100 万リクエスト
+- Class B 1,000 万リクエスト
+- Egress 無制限
+
+請求は切り上げ（1,000,001 オペレーション → 200 万請求、1.1 GB-month → 2 GB-month）。401 で蹴られた未認証リクエストは課金されない。
+
+## CLI / IaC 操作例
+
+### Wrangler でバケット操作
+
+```bash
+# バケット作成（Location Hint 付き）
+npx wrangler r2 bucket create my-assets --location apac
+
+# オブジェクトのアップロード
+npx wrangler r2 object put my-assets/path/image.png --file ./image.png
+
+# 取得
+npx wrangler r2 object get my-assets/path/image.png --file ./out.png
+
+# Lifecycle 設定（JSON ファイル指定）
+npx wrangler r2 bucket lifecycle set my-assets --file lifecycle.json
+```
+
+### Workers バインディング（`wrangler.toml`）
+
+```toml
+[[r2_buckets]]
+binding = "ASSETS"
+bucket_name = "my-assets"
+```
+
+```ts
+export default {
+  async fetch(req: Request, env: { ASSETS: R2Bucket }): Promise<Response> {
+    const obj = await env.ASSETS.get("path/image.png");
+    if (!obj) return new Response("Not Found", { status: 404 });
+    return new Response(obj.body, { headers: { "content-type": "image/png" } });
+  },
+};
+```
+
+### S3 SDK（aws-sdk v3）からのアクセス
+
+```ts
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+
+const s3 = new S3Client({
+  region: "auto",
+  endpoint: `https://${ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  credentials: {
+    accessKeyId: process.env.R2_ACCESS_KEY_ID!,
+    secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,
+  },
+});
+
+await s3.send(new PutObjectCommand({
+  Bucket: "my-assets",
+  Key: "path/image.png",
+  Body: fileBuffer,
+  ContentType: "image/png",
+}));
+```
+
+### Terraform
+
+```hcl
+resource "cloudflare_r2_bucket" "assets" {
+  account_id = var.cf_account_id
+  name       = "my-assets"
+  location   = "APAC"
+}
+```
+
+## 制限・注意点
+
+- オブジェクトサイズ上限：1 オブジェクトあたり 4.995 TiB。
+- 単一 PUT のアップロード上限：4.995 GiB。それ以上はマルチパート（最大 10,000 パート）。
+- 同一キーへの並行書き込みは 1 秒あたり 1 回まで。超えると HTTP 429。
+- アカウントあたりバケット数上限：1,000,000。
+- バケット管理操作（作成・削除・設定）は 50 req/s。
+- オブジェクトキー長 1,024 バイト、メタデータ 8,192 バイト。
+- リージョンは `auto` 固定（互換のため `us-east-1` と空文字も受理）。
+- `r2.dev` はテスト用で本番利用不可。スループット・レート両方が変動的にスロットルされる。本番は必ずカスタムドメインを接続する。
+- S3 API 互換だが**未実装機能あり**：Object Lock、S3 Select、Inventory、Replication 等は提供されない。マイグレーション前に依存 API を要確認。
+- Infrequent Access は最低 30 日課金、retrieval fee あり。短期間で消えるオブジェクトを誤って IA に置くと割高になる。
+
+## ユースケース具体例
+
+- **動画・画像配信**：R2 + Cloudflare CDN で egress 無料配信。`assets.example.com` をカスタムドメインで紐付け、Cache Rules でキャッシュ TTL を制御する。
+- **データレイク**：Parquet / Iceberg を R2 に保管し、R2 Data Catalog 経由で Snowflake・DuckDB・Spark から読み出す。複数分析エンジンを跨いでも egress 課金が発生しない。
+- **バックアップ・アーカイブ**：データベースの日次スナップショット、ログ、長期保管対象を IA クラスに格納。restore 時の転送も無料。
+- **ML モデル・データセット配布**：Hugging Face 的なモデル配布や大規模データセット公開で、ダウンロード課金が発生しない。
+- **ポッドキャスト・大容量メディア配信**：従来 S3 + CloudFront で発生していた数百ドル〜数千ドル規模の egress を実質ゼロに。
+- **静的サイト・SPA のアセットホスティング**：Cloudflare Pages / Workers と組み合わせ、世界中に低レイテンシ配信。
+- **AWS 脱出の中継点**：Sippy で読み出し時に段階移行、移行完了後は S3 を停止。
+
+## 参考リンク
+
+- [Cloudflare R2 Overview](https://developers.cloudflare.com/r2/)
+- [R2 Pricing](https://developers.cloudflare.com/r2/pricing/)
+- [R2 Limits](https://developers.cloudflare.com/r2/platform/limits/)
+- [S3 API compatibility](https://developers.cloudflare.com/r2/api/s3/api/)
+- [R2 Pricing Calculator](https://r2-calculator.cloudflare.com/)
+- [Workers R2 Binding API](https://developers.cloudflare.com/r2/api/workers/)
+
+---
+参照日: 2026-05-03

--- a/src/content/knowledge/web-development/cloudflare-docs/20-stream.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/20-stream.mdx
@@ -1,0 +1,143 @@
+---
+title: "Cloudflare Stream"
+description: "Cloudflare Stream は、動画のアップロード・エンコード・保存・配信・プレイヤを単一APIで提供するサーバーレス動画基盤である。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 20
+---
+# Stream
+
+## 一行サマリ
+Cloudflare Stream は、動画のアップロード・エンコード・保存・配信・プレイヤを単一APIで提供するサーバーレス動画基盤である。
+
+## 解決する課題（Why）
+自前で「FFmpeg によるトランスコード」「S3 などのオブジェクトストレージ」「CloudFront など CDN」「HLS/DASH のマニフェスト生成」「Video.js などのプレイヤ」「署名URLによるアクセス制御」「ライブ配信用 RTMP/SRT インジェスト」を組み合わせるパイプラインを構築・運用しなくて済む。Stream は H.264 + 適応的ビットレートストリーミング（360p〜1080p）を自動生成し、Cloudflareのグローバルネットワーク経由で配信するため、インフラ運用コストとエッジ最適化の二重の負担を一気に剥がせる。
+
+## 主要機能（What）
+- VOD アップロード（直接アップロード、URLからの取り込み、TUS による再開可能アップロード、Direct Creator Upload による署名付き一回限りURL）
+- ライブ配信（Live Input：RTMPS/SRT インジェスト、低遅延HLS、DVR、自動録画）
+- 自動トランスコード（H.264、ABR、複数解像度、Closed GOP 推奨）
+- HLS / DASH マニフェスト自動生成
+- 組み込み Stream Player（iframe 埋め込み）と独自プレイヤ向けマニフェストURL の両対応
+- Signed URL によるアクセス制御（有効期限、IP/地域制限）
+- MP4 ダウンロード（オフライン視聴用）
+- Simulcasting（YouTube/Twitch などへの同時配信、SRT/RTMP Live Outputs）
+- 静止画・アニメーションサムネイル生成
+- 視聴分析（per-creator 単位、視聴ログ）
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- VOD 配信プラットフォーム（オンライン講座、社内ナレッジ、メディアサイト）
+- ユーザー投稿型動画サービス（Direct Creator Upload で安全に直アップ）
+- ライブ配信を含むイベント・ウェビナー基盤
+- 社内トレーニング・eラーニング教材配信
+- Cloudflare の他サービス（Workers, R2, Access）と統合した動画ワークフロー
+
+### 適していないシーン
+- 4K/HDR 配信が必須なプレミアムコンテンツ（HDR は SDR に再エンコードされる、最大 1080p）
+- 30GB を超える元ファイルをそのまま扱いたいケース
+- DRM（Widevine/PlayReady/FairPlay）が契約上必須な OTT 大規模商用配信（Mux や AWS Media Services の方が成熟）
+- 元ファイルをそのまま再ダウンロードして配布する用途（オリジナル入力ファイルは取得不可）
+- HLS/DASH ではなく独自プロトコルや特殊コーデック（AV1, VP9）が必要な要件
+
+## 競合・代替
+
+| 観点 | Cloudflare Stream | Mux | api.video | Bunny Stream | AWS MediaConvert + CloudFront |
+|---|---|---|---|---|---|
+| 課金軸 | 保存分（min）+ 配信分（min） | エンコード + 配信 + 保存 | 取り込み + 配信 | 保存（GB）+ 配信（GB） | エンコード秒 + ストレージ + 配信 |
+| 配信単価の目安 | $1 / 1,000 min | $0.00096/min 程度（プラン依存） | $0.30/1,000 min（配信） | $0.005〜0.06/GB | CloudFront 従量＋AWS egress |
+| ライブ配信 | 標準対応（RTMPS/SRT、DVR） | 標準対応、低遅延に強い | 標準対応 | 標準対応 | MediaLive 別サービス |
+| プレイヤ提供 | あり（iframe） | Mux Player | あり | あり | なし（自前/サードパーティ） |
+| DRM | なし（Signed URL のみ） | あり（追加課金） | あり | なし | あり（SPEKE 連携） |
+| エッジ統合 | Cloudflare 全機能と直結 | 独自CDN | 独自CDN | Bunny CDN | AWS CloudFront |
+| 強み | 単純な料金、Workers連携 | 分析・QoEメトリクス | API設計の素直さ | 価格と速度 | 柔軟なパイプライン構築 |
+
+## 料金モデルの要点
+- **保存**：1,000分あたり $5 のプリペイド。ファイルサイズではなく動画の長さで課金。エンコード後の複数解像度や MP4 ダウンロード生成分は課金対象外。
+- **配信**：1,000分あたり $1 のポストペイド従量課金。HLS/DASH セグメント単位で計上。クライアントのプリロード・バッファも配信扱い、ブラウザキャッシュからの再生は非課金。
+- **取り込み・エンコード・帯域は無料**。配信課金にエッジ転送費用が含まれるため、CloudFront のような egress 別請求が発生しない。
+- ライブと VOD は同じ単価で課金され、視聴者ゼロのライブは配信課金 $0、録画分のみ保存課金。
+- Direct Creator Upload は `maxDurationSeconds` 分の保存枠が一時的に予約され、未使用なら解放される。
+- 大規模利用はエンタープライズ契約でボリューム割引あり。
+
+## CLI / IaC 操作例
+
+```bash
+# 直接アップロード（ファイル）
+curl -X POST -H "Authorization: Bearer $CF_API_TOKEN" \
+  -F file=@video.mp4 \
+  https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/stream
+
+# URL からの取り込み
+curl -X POST -H "Authorization: Bearer $CF_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://example.com/source.mp4","meta":{"name":"sample"}}' \
+  https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/stream/copy
+
+# Direct Creator Upload URL 発行（最大 600 秒の動画想定）
+curl -X POST -H "Authorization: Bearer $CF_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"maxDurationSeconds":600}' \
+  https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/stream/direct_upload
+
+# Live Input（RTMPS/SRT 受信エンドポイント）の作成
+curl -X POST -H "Authorization: Bearer $CF_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"recording":{"mode":"automatic"}}' \
+  https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/stream/live_inputs
+
+# Signed URL 用の鍵を発行
+curl -X POST -H "Authorization: Bearer $CF_API_TOKEN" \
+  https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/stream/keys
+```
+
+```hcl
+# Terraform：Live Input を IaC 管理
+resource "cloudflare_stream_live_input" "main_event" {
+  account_id = var.account_id
+  meta = { name = "main-event" }
+  recording = {
+    mode              = "automatic"
+    require_signed_urls = true
+  }
+}
+```
+
+```html
+<!-- 埋め込みプレイヤ -->
+<iframe
+  src="https://customer-<CODE>.cloudflarestream.com/<VIDEO_UID>/iframe"
+  allow="accelerometer; gyroscope; autoplay; encrypted-media; picture-in-picture;"
+  allowfullscreen></iframe>
+
+<!-- 独自プレイヤ向け HLS -->
+<video controls>
+  <source src="https://customer-<CODE>.cloudflarestream.com/<VIDEO_UID>/manifest/video.m3u8"
+          type="application/x-mpegURL">
+</video>
+```
+
+## 制限・注意点
+- 1動画あたり最大 **30GB**、デフォルトで **同時 120本** までキューイング/エンコード可能。
+- 元の入力ファイルそのものは再ダウンロード不可（MP4 Downloads は再エンコード版）。
+- 解像度は **360p〜1080p** までで、4K/HDR は SDR に再エンコードされ配信される。
+- 推奨入力：MP4 / H.264 high profile / AAC / 30fps以下 / Closed GOP / Fast Start（moov atom 先頭）。
+- HDR は対応外（SDR にダウンコンバート）、AV1/VP9 出力なし。
+- CSP を設定する場合は `videodelivery.net` と `*.cloudflarestream.com` を `frame-src` / `media-src` / `connect-src` 等に追加する必要がある。
+- サブスク解約後 **30日** で動画は削除される。
+- 保存枠を使い切ると新規アップロードが拒否される（エンタープライズは継続可）。
+- DRM は標準では提供されないため、有料コンテンツ保護は Signed URL ベースとなる。
+- PageSpeed Insights では複数プレイヤ埋め込み時にスコア低下する傾向があるため、lazy loading またはサムネイル先行表示を推奨。
+
+## 参考リンク
+- 公式ドキュメント: https://developers.cloudflare.com/stream/
+- 料金: https://developers.cloudflare.com/stream/pricing/
+- FAQ: https://developers.cloudflare.com/stream/faq/
+- Live Input: https://developers.cloudflare.com/stream/stream-live/
+- Direct Creator Uploads: https://developers.cloudflare.com/stream/uploading-videos/direct-creator-uploads/
+- Signed URLs: https://developers.cloudflare.com/stream/viewing-videos/securing-your-stream/
+
+---
+参照日: 2026-05-03

--- a/src/content/knowledge/web-development/cloudflare-docs/21-tunnel.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/21-tunnel.mdx
@@ -1,0 +1,146 @@
+---
+title: "Cloudflare Cloudflare Tunnel"
+description: "cloudflared デーモンがオリジンからCloudflareエッジへアウトバウンド接続のみを張り、公開IP・インバウンド開放なしで内部サービスを安全に公開・接続する仕組みである。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 21
+---
+# Cloudflare Tunnel
+
+## 一行サマリ
+cloudflared デーモンがオリジンからCloudflareエッジへアウトバウンド接続のみを張り、公開IP・インバウンド開放なしで内部サービスを安全に公開・接続する仕組みである。
+
+## 解決する課題（Why）
+- オリジンサーバーに公開IPアドレスを割り当てたくない、または割り当てられない（NAT越え、CGNAT配下、家庭・社内環境）。
+- ファイアウォールでインバウンドポート（80/443等）を開けたくない。開けるとDDoSや脆弱性スキャンの対象になる。
+- 従来型VPN（IPSec/OpenVPN）の運用負荷（証明書配布、クライアント設定、固定IP）から脱却したい。
+- 開発環境やオンプレシステムを、特定メンバー・SaaS・クラウドから安全に到達可能にしたい。
+- Cloudflare WAF/Bot Management/Access の前段保護を、オリジンを露出させずに適用したい。
+
+## 主要機能（What）
+- **cloudflared デーモン**: オリジン側で動作する軽量Goバイナリ。常駐してCloudflareエッジへ持続的トンネルを確立。
+- **Public Hostname**: トンネルに紐づく公開ホスト名（example.com）からオリジンへルーティング。HTTP/HTTPS/SSH/RDP等に対応。
+- **Private Network ルーティング**: CIDR単位で内部ネットワーク全体をCloudflare WARP クライアント経由で到達可能に（VPN代替）。
+- **Connector レプリカ**: 同一トンネルに複数 cloudflared プロセスを並列起動し、HA・無停止デプロイ・負荷分散を実現。
+- **TLS 1.3 + 耐量子暗号**: トンネル経路はデフォルトで暗号化、将来の量子計算機脅威にも対応。
+- **リモート管理（dashboard管理）/ ローカル設定ファイル管理（config.yml）** の2方式を選択可。
+
+## 仕組み（必須セクション）
+1. オリジン側ホスト（VM/コンテナ/RasPi等）に `cloudflared` をインストール。
+2. `cloudflared tunnel login` でCloudflareアカウントを認証し、トンネル（UUID識別）を作成する。
+3. 起動した cloudflared はCloudflareエッジ（最寄りデータセンター）へ **outbound HTTPS/QUIC** で接続を張りっぱなしにする。複数Connector接続が冗長化される。
+4. ユーザーが公開ホスト名にアクセスすると、CFエッジは該当トンネルにリクエストを多重化転送し、cloudflared がオリジン上のローカルサービス（例: `http://localhost:3000`）へプロキシする。
+5. ファイアウォールはアウトバウンドのみ許可すればよく、インバウンドは完全クローズドのままにできる（Zero Trust の前提条件）。
+
+```
+[Origin] → cloudflared --(outbound TLS)--> [CF Edge] ← User
+              ↑                              ↑
+       インバウンド完全閉鎖              WAF/Access/Bot
+```
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- 社内ツール（Backstage、Grafana、Wiki等）を社外から安全に公開したい。
+- オンプレ・自宅サーバーをHTTPSで公開したい（ngrokの本番代替）。
+- 開発環境を顧客やチームメンバーに一時共有したい。
+- Kubernetesクラスタ内サービスを公開IP・LoadBalancerなしで公開したい。
+- VPNを廃止しゼロトラスト（ZTNA）へ移行したい。社員のデバイスから内部ネットワークへ。
+- ハイブリッドクラウド構成でオンプレ↔クラウド間を専用線なしで繋ぎたい。
+
+### 適していないシーン
+- Cloudflare以外のCDN/WAFを前段に置きたい場合（経路がCFに固定される）。
+- 超低レイテンシ・極端な高スループットが要求される（金融取引等）。トンネル経由の追加ホップ分のオーバーヘッドあり。
+- 完全オフライン環境（cloudflared がCFエッジへ常時接続必須）。
+- UDP固有プロトコル（一部対応するが要設計確認）。
+
+## 競合・代替
+
+| 観点 | Cloudflare Tunnel | ngrok | Tailscale | Twingate | AWS Site-to-Site VPN |
+|---|---|---|---|---|---|
+| モデル | Outbound Tunnel + ZTNA | Outbound Tunnel | WireGuard P2P Mesh | ZTNA Connector | IPSec VPN |
+| 公開IP不要 | はい | はい | はい | はい | いいえ（VGW必要） |
+| 無料枠 | 基本無料・無制限 | 制限あり（同時接続/帯域） | 個人/小規模無料 | 無料プランあり | なし（時間課金） |
+| 認証統合 | Cloudflare Access（IdP連携） | 限定的 | OIDC連携 | IdP統合強い | IAM/別途 |
+| 公開URL | カスタムドメイン標準 | ランダムまたは有料カスタム | プライベートのみ | プライベートのみ | プライベートのみ |
+| WAF/DDoS | CF全機能適用 | 一部 | なし | なし | なし |
+| ベンダーロック | Cloudflare依存 | ngrok依存 | 比較的軽 | Twingate依存 | AWS依存 |
+
+ngrok は開発用途、Tailscale は社員間Mesh、Tunnel は「公開＋ZTNA」を一気通貫で提供する点で差別化される。
+
+## Access との組合せ（必須セクション）
+Cloudflare Tunnel 単体では、公開ホスト名を知っていれば誰でもアクセスできてしまう。これを認証ゲートで保護するのが **Cloudflare Access** である。
+
+- Tunnel = 「内部サービスをCFエッジに繋げる輸送層」
+- Access = 「CFエッジでIdP認証・ポリシー判定を行う認可層」
+
+組み合わせパターン（典型ZTNA構成）:
+1. オリジンに cloudflared を配置し Tunnel を確立（インバウンド遮断）。
+2. 公開ホスト名 `internal-tool.example.com` をトンネルに紐づける。
+3. Access Application を同ホスト名に設定し、Google Workspace / Okta / Azure AD などのIdPを連携。
+4. ポリシー例: 「`@example.com` ドメインかつ社用デバイスのみ許可」。
+5. ユーザーは ブラウザでSSO → Access JWT発行 → Tunnel経由でオリジン到達。VPNクライアント不要。
+
+これによりVPN置換・SaaS的アクセス体験・きめ細かな条件付きアクセス（デバイス姿勢、地理、時間帯）を実現できる。SSH/RDPもブラウザレンダリングで提供可能（Browser Rendering連携）。
+
+## 料金モデルの要点
+- **cloudflared / Tunnel 自体は無料**。トンネル本数・帯域・データ転送量に追加料金なし。
+- **Cloudflare Zero Trust（Access含む）**: 50ユーザーまで無料、超過分は$7/user/月（Standardプラン、2026年時点目安）。
+- **Private Network（WARP経由内部ネット到達）** もZero Trustライセンス枠内。
+- 課金されるのは「ユーザー数（Access利用時）」と「上位機能（Browser Isolation、Gateway DLP等）」であり、トンネル基盤は実質無料で利用できる。
+
+## CLI / IaC 操作例
+
+### cloudflared CLI（ローカル管理トンネル）
+```bash
+# インストール（macOS）
+brew install cloudflared
+
+# 認証（ブラウザでCFアカウントを選択）
+cloudflared tunnel login
+
+# トンネル作成（UUIDが発行される）
+cloudflared tunnel create my-tunnel
+
+# DNSレコードを公開ホスト名にバインド
+cloudflared tunnel route dns my-tunnel app.example.com
+
+# 設定ファイル（~/.cloudflared/config.yml）
+# tunnel: <UUID>
+# credentials-file: /root/.cloudflared/<UUID>.json
+# ingress:
+#   - hostname: app.example.com
+#     service: http://localhost:3000
+#   - service: http_status:404
+
+# 起動（フォアグラウンド検証）
+cloudflared tunnel run my-tunnel
+
+# サービス化（systemd登録）
+sudo cloudflared service install
+```
+
+### リモート管理トンネル（Dashboard / API / Terraform）
+- ダッシュボードで作成 → 発行された Tunnel Token を使い `cloudflared tunnel run --token <TOKEN>` だけで起動。
+- 設定（ingress, public hostname）はダッシュボードから編集、即時反映。
+- Terraform `cloudflare_tunnel` / `cloudflare_tunnel_config` リソースでIaC化可能。
+
+## 制限・注意点
+- cloudflared は常にCFエッジへ接続できる必要がある。完全閉域網では使えない。
+- 経路がCloudflareネットワークに固定される（マルチCDN戦略との両立は要設計）。
+- 1トンネルあたりのConnector数・同時接続数にアカウント制限あり（Account limits参照）。
+- 大量のWebSocket/長時間接続は接続上限・タイムアウト挙動に注意。
+- cloudflared プロセスの権限管理（非rootで動かす、トークン漏洩対策）が必須。トークンはトンネル全権限を持つ。
+- ログ・メトリクスはデフォルトで控えめ。本番運用ではログレベル・メトリクスエンドポイント設定を行い、ヘルスアラートを構成する。
+- 設定変更（ingress追加等）はリモート管理なら即時、ローカル管理なら cloudflared 再起動が必要。
+
+## 参考リンク
+- 公式: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/
+- Get started: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/get-started/
+- Configure a tunnel: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/configure-tunnels/
+- Reference architecture: Cloudflare One Reference Architecture（公式ドキュメント内）
+- 関連スキル: Cloudflare Access（ZTNA）、Cloudflare WARP（クライアント）
+
+---
+参照日: 2026-05-03

--- a/src/content/knowledge/web-development/cloudflare-docs/22-turnstile.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/22-turnstile.mdx
@@ -1,0 +1,147 @@
+---
+title: "Cloudflare Turnstile"
+description: "画像選択もチェックボックスもほぼ不要な、Cloudflareの次世代CAPTCHA代替。サイトをCloudflareにプロキシしていなくても利用できる独立サービスである。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 22
+---
+# Turnstile
+
+## 一行サマリ
+画像選択もチェックボックスもほぼ不要な、Cloudflareの次世代CAPTCHA代替。サイトをCloudflareにプロキシしていなくても利用できる独立サービスである。
+
+## 解決する課題（Why）
+従来のreCAPTCHAは「信号機を選べ」「横断歩道を選べ」といった操作でユーザー体験を著しく劣化させ、変換率を下げる。さらにGoogleによる行動追跡やCookie利用に対するプライバシー懸念が強く、GDPR/CCPA対応上のリスクにもなる。Turnstileはこれらを解決する。
+
+- ユーザーの操作（画像選択など）を原則ゼロにする
+- 個人を追跡するためのCookieやフィンガープリントを送信しない（Privacy Addendumに準拠）
+- どのCDN・どのインフラ上でも動作する独立したCAPTCHA代替を提供する
+
+## 主要機能（What）
+- **3つのウィジェットモード**: Managed（推奨・自動判定）／ Non-interactive（操作不要だが表示あり）／ Invisible（完全非表示）
+- **Siteverify API**: サーバー側でトークンを検証する公式エンドポイント
+- **Pre-clearance**: SPAやサイト内遷移で、Cloudflare Challengeの「事前クリア」Cookieを発行しUXを向上させる
+- **Turnstile Analytics**: 発行チャレンジ数・解決率・メトリクスを可視化
+- **WCAG 2.2 AAA準拠**: アクセシビリティの最高水準を満たす
+- **モバイル対応**: iOS / Android / WebView 向け実装ガイドあり
+- **無料**: 利用量に上限なしで無償提供
+
+## 動作の仕組み（簡易）
+1. ブラウザに軽量JavaScriptウィジェットを埋め込む
+2. ウィジェットが proof-of-work、proof-of-space、Web API調査、ブラウザの癖検出など複数の非対話チャレンジをバックグラウンド実行する
+3. 信号を集めてリスクを評価し、必要時のみチェックボックス表示にフォールバックする
+4. 成功時は最大2,048文字のトークンが発行される
+5. サーバー側がそのトークンを `https://challenges.cloudflare.com/turnstile/v0/siteverify` に送信し、シークレットキーとともに正当性を検証する
+6. トークンは300秒（5分）で失効、かつ一度しか検証できない
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- お問い合わせフォーム・ログイン・新規登録・コメント投稿・パスワードリセットなど、bot流入を防ぎたい入口全般
+- reCAPTCHAからのリプレース（既存スクリプトの貼り替えで移行可能）
+- プライバシー重視のサービス（GDPR領域、ヘルスケア、金融など）
+- Cloudflareをプロキシ層に入れていないが、bot対策だけ欲しいケース（マルチクラウド・他社CDN利用環境）
+- SPAでの体験を維持したまま保護したいケース（Pre-clearance活用）
+
+### 適していないシーン
+- 高度な敵対的bot（決済不正・スクレイピング業者）に対する単独防御。Bot Management・WAF・レート制限と組み合わせるべき
+- ネイティブモバイルアプリ専用（WebViewが使えず、モバイル実装が許容できない場合）
+- ブラウザ環境を持たないAPIクライアント間通信（mTLSやAPIキーを使うべき）
+- ユーザー認証・認可そのもの（CAPTCHAは「人間判定」であって「本人判定」ではない）
+
+## 競合・代替
+
+| 観点 | Turnstile | reCAPTCHA v3 | hCaptcha |
+|---|---|---|---|
+| 提供元 | Cloudflare | Google | Intuition Machines |
+| 操作要否 | 原則不要（Managedで必要時のみ） | 不要（スコア型） | 画像選択あり（Enterpriseで非表示化可） |
+| プライバシー | Cookie/追跡なし、Privacy Addendum明示 | Google追跡あり、GDPR懸念強い | Google非依存、追跡少なめ |
+| 料金 | 完全無料・無制限 | 無料枠あり、Enterprise有償 | 無料プランあり、Pro/Enterprise有償 |
+| サーバー検証 | Siteverify API必須 | siteverify必須 | siteverify必須 |
+| Cloudflare依存 | 不要（独立サービス） | 不要 | 不要 |
+| アクセシビリティ | WCAG 2.2 AAA | 部分対応 | アクセシブル代替あり |
+
+## 料金モデルの要点
+- **完全無料**。利用回数・サイト数の上限なし
+- 有償プランや「Turnstile Enterprise」のような分離は存在しない
+- ビジネス価値: bot対策で年数十万円〜数百万円かかる他社CAPTCHAをゼロ円で置換可能
+
+## 実装例（必須）
+
+### 1. クライアント側（HTML埋め込み・implicit rendering）
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+</head>
+<body>
+  <form action="/login" method="POST">
+    <input type="email" name="email" required />
+    <input type="password" name="password" required />
+
+    <!-- Turnstileウィジェット。dataのsitekeyは公開してよい -->
+    <div class="cf-turnstile"
+         data-sitekey="0x4AAAAAAAxxxxxxxxxxxxx"
+         data-theme="auto"
+         data-size="normal"></div>
+
+    <button type="submit">ログイン</button>
+  </form>
+</body>
+</html>
+```
+
+フォーム送信時、`cf-turnstile-response` という名前で自動的にトークンが付与される。
+
+### 2. サーバー側（Node.js / Hono などでの検証）
+
+```ts
+// POST /login のハンドラ
+app.post('/login', async (c) => {
+  const body = await c.req.parseBody();
+  const token = body['cf-turnstile-response'];
+  const ip = c.req.header('CF-Connecting-IP') ?? '';
+
+  const form = new FormData();
+  form.append('secret', process.env.TURNSTILE_SECRET_KEY!); // サーバー側のみ保持
+  form.append('response', String(token));
+  if (ip) form.append('remoteip', ip);
+
+  const res = await fetch(
+    'https://challenges.cloudflare.com/turnstile/v0/siteverify',
+    { method: 'POST', body: form }
+  );
+  const outcome = (await res.json()) as { success: boolean; 'error-codes'?: string[] };
+
+  if (!outcome.success) {
+    return c.text(`Turnstile verification failed: ${outcome['error-codes']?.join(',')}`, 403);
+  }
+
+  // ここから本来の認証処理
+  return c.text('OK');
+});
+```
+
+### 3. テストキー
+本番デプロイ前に、Cloudflare公式のテスト用sitekey/secret keyを使えば、実チャレンジを発火させずに統合テストができる。
+
+## 制限・注意点
+- **サーバー検証は必須**。クライアント側で完結させると無意味であり、Turnstile Analyticsの検証メトリクスがゼロのままになる
+- **トークンの有効期限は300秒、再利用不可**。長時間入力フォームでは再発行（リフレッシュ）の仕組みを用意する
+- **`challenges.cloudflare.com` への接続が必要**。CSPで `script-src` `frame-src` `connect-src` を許可する
+- **シークレットキーをクライアントに露出させない**。GitやフロントエンドJSへの混入は事故の典型例
+- **Invisibleモード使用時はプライバシーポリシーへの記載義務**がある（Cloudflare Turnstile Privacy Addendumへの参照）
+- **CAPTCHAは万能ではない**。WAF・Bot Management・レート制限と多層防御で組み合わせる
+- **古いブラウザは非対応**。エラー状態（Outdated or unsupported browser）が表示される
+
+## 参考リンク
+- [Turnstile Overview (Cloudflare Docs)](https://developers.cloudflare.com/turnstile/)
+- [Get started](https://developers.cloudflare.com/turnstile/get-started/)
+- [Turnstile widgets (Concepts)](https://developers.cloudflare.com/turnstile/concepts/widget/)
+- [Turnstile Privacy Addendum](https://www.cloudflare.com/application-services/products/turnstile-privacy/)
+
+---
+参照日: 2026-05-03

--- a/src/content/knowledge/web-development/cloudflare-docs/23-vectorize.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/23-vectorize.mdx
@@ -1,0 +1,222 @@
+---
+title: "Cloudflare Vectorize"
+description: "Cloudflare Workersから低レイテンシで利用できるグローバル分散型ベクトルデータベース。RAG・セマンティック検索・レコメンド用途のembedding保存とANN検索を担う。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 23
+---
+# Vectorize
+
+## 一行サマリ
+Cloudflare Workersから低レイテンシで利用できるグローバル分散型ベクトルデータベース。RAG・セマンティック検索・レコメンド用途のembedding保存とANN検索を担う。
+
+## 解決する課題（Why）
+LLMアプリケーションで「自社データに基づく回答」を実現するには、テキストや画像をembedding化してベクトル検索する基盤が必要となる。PineconeやWeaviateは別クラウドに置く必要があり、Workersから呼ぶたびに外部APIへのレイテンシ・egress・別契約・別IAMが発生する。Vectorizeはこの構成を「Workersバインディング1本」に圧縮し、Workers AI（embedding生成）・R2（原本ファイル）・D1（メタ情報）と同一ネットワーク内で完結させる。インフラ運用ゼロ、egress無料、従量課金で小さく始められる点が本質的な価値である。
+
+## 主要機能（What）
+- **インデックス（Index）**: ベクトル集合の単位。作成時に次元数（dimensions）と距離関数（cosine / euclidean / dot-product）を固定する。
+- **名前空間（Namespace）**: 1インデックス内で論理分割する仕組み。マルチテナントSaaSでテナント分離に使う。
+- **メタデータフィルタ**: ベクトルにJSONメタデータを紐付け、`metadataIndexes`を作成すれば`filter`句で事前絞り込みができる（例: `tenant_id`、`lang`、`published_after`）。
+- **メタデータインデックス**: フィルタ高速化のため明示的にインデックス対象フィールドを宣言する。1インデックスあたり最大10件。
+- **upsert / query / getByIds / deleteByIds / list**: 基本CRUD。Workers内ではバインディング経由、外部からはREST APIで操作可能。
+- **Workers AIとの直結**: `@cf/baai/bge-base-en-v1.5`等のembeddingモデルが同一プラットフォーム上で動く。
+- **AI Search（旧AutoRAG）連携**: R2に置いたドキュメントを自動チャンク化→embedding→Vectorize格納→検索までをマネージドで提供。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- Cloudflare Workers / Pages / Workers AI を主軸にしたAIアプリケーション
+- 中小規模（〜1000万ベクトル/インデックス）のRAG、社内文書検索、商品レコメンド
+- グローバルにエッジから低レイテンシで検索したいユースケース
+- egress課金を避けたい・契約をCloudflare 1社に集約したい場合
+- プロトタイピング〜本番初期段階で、運用ノードを抱えたくないケース
+
+### 適していないシーン
+- 1インデックスに1000万件超のベクトルを格納したい大規模検索基盤
+- 1536次元を超える高次元embedding（OpenAI `text-embedding-3-large` の3072次元等）をネイティブで扱いたい場合（次元削減が必要）
+- ハイブリッド検索（BM25＋ベクトル）やリランキングをDB側で完結させたい場合 → OpenSearchやWeaviateが優位
+- 既存PostgreSQLにデータがあり、トランザクション整合性を保ったままベクトル検索したい場合 → pgvector
+- HNSWパラメータ（efConstruction、M値）を細かくチューニングしたい高度ユーザー
+
+## 競合・代替
+
+| 観点 | Vectorize | Pinecone | pgvector | Qdrant |
+|---|---|---|---|---|
+| 提供形態 | サーバーレス（Workersバインディング） | フルマネージドSaaS | PostgreSQL拡張（自前/RDS等） | OSS / Cloud |
+| 最大次元 | 1536 | 制限緩い（〜20000） | 2000（実用） | 制限緩い |
+| 最大件数/Index | 1000万 | 数億〜 | DBサイズ依存 | ノード次第 |
+| 距離関数 | cosine / euclidean / dot | cosine / euclidean / dot | 同左 | 同左＋manhattan |
+| メタデータフィルタ | あり（要index宣言） | あり（柔軟） | SQL WHERE | 強力 |
+| ハイブリッド検索 | なし | sparse-dense対応 | 別途FTS併用 | あり |
+| 課金軸 | クエリ次元数＋保存次元数 | Pod時間 or サーバーレス読書 | DB料金 | ノード/リソース |
+| エコシステム | Workers AI / R2 / D1 と同居 | LangChain等広く対応 | RDB資産流用 | OSS自由度 |
+| egress | 無料 | あり | クラウド依存 | 構成次第 |
+
+WeaviateはGraphQL中心でモジュラー、ChromaはローカルOSSで開発用途、Turbopufferは同じくサーバーレス＋オブジェクトストレージ型でVectorizeと最も思想が近い競合。OpenSearchはKNNプラグインで本格検索基盤を組む選択肢。
+
+## 料金モデルの要点
+- 課金軸は2つだけ: **クエリ次元数**と**保存次元数**。CPU・メモリ・インデックス数・active hoursは課金対象外。
+- Workers Paid 月額無料枠: クエリ5000万次元、保存1000万次元。
+- 超過分: クエリ $0.01 / 100万次元、保存 $0.05 / 1億次元。
+- Workers Free 枠: クエリ3000万次元、保存500万次元。
+- egress無料、HTTP API/CLIからのクエリも課金対象。空インデックスは保存課金ゼロ。
+- 計算式: `((queried + stored) * dims * $0.01/1M) + (stored * dims * $0.05/100M)`
+- 実例: 768次元 × 5万ベクトル × 月20万クエリ ≒ **$1.94 / 月**。1536次元 × 50万ベクトル × 月100万クエリで **$23.42 / 月**。
+
+## CLI / IaC 操作例
+
+### インデックス作成（wrangler）
+```bash
+# cosine距離、768次元（Workers AI bge-base-en-v1.5想定）
+wrangler vectorize create my-rag-index \
+  --dimensions=768 \
+  --metric=cosine
+
+# メタデータインデックス追加（filter高速化）
+wrangler vectorize create-metadata-index my-rag-index \
+  --property-name=tenant_id \
+  --type=string
+```
+
+### wrangler.toml バインディング
+```toml
+[[vectorize]]
+binding = "VECTORIZE"
+index_name = "my-rag-index"
+
+[ai]
+binding = "AI"
+```
+
+### Worker内でのupsert・query
+```typescript
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const { query } = await req.json<{ query: string }>();
+
+    // 1. クエリ文字列をembedding化（Workers AI）
+    const { data } = await env.AI.run("@cf/baai/bge-base-en-v1.5", {
+      text: [query],
+    });
+    const vector = data[0];
+
+    // 2. Vectorizeに類似検索（メタデータフィルタ付き）
+    const matches = await env.VECTORIZE.query(vector, {
+      topK: 5,
+      returnMetadata: "all",
+      filter: { tenant_id: { $eq: "acme" } },
+    });
+
+    return Response.json(matches);
+  },
+} satisfies ExportedHandler<Env>;
+```
+
+## 制限・注意点
+- **最大次元数: 1536** （float32）。OpenAI `text-embedding-3-large` (3072次元) はそのまま入らないため、`dimensions` パラメータで縮約するか別モデルを選ぶ。
+- **インデックスあたり最大1000万ベクトル**。これを超える規模は別インデックス分割（テナント別 / 期間別）の設計が必要。
+- **メタデータ上限: 1ベクトルあたり10KiB**。原本テキストはR2/D1に逃がし、Vectorizeにはポインタとフィルタ用フィールドのみ持たせる設計が定石。
+- **メタデータインデックス上限: 10件 / インデックス**、1フィールドあたりインデックス対象データ最大64バイト。
+- **topK上限: メタデータ込みで50件、メタデータなしで100件**。リランキング前提で広く取りたい場合は要工夫。
+- **upsertバッチ: Workers経由1000件、HTTP API 5000件**。アップロードファイル最大100MB。
+- **インデックスのスキーマは作成後変更不可**（次元数・距離関数）。embeddingモデル変更時はインデックス作り直しになる。
+- **強整合性ではない**: upsert直後の即時クエリで取得できないことがある。書き込み後数秒の伝搬を見込む。
+- 削除済みベクトルが課金対象に含まれるかなど、詳細は最新ドキュメントで都度確認。
+
+## RAG構成例
+
+### 構成
+```
+[ユーザー質問]
+      │
+      ▼
+┌──────────────────────────────┐
+│  Cloudflare Worker (Hono等)  │
+└──────┬───────────────────┬───┘
+       │ ①embed            │ ④回答生成
+       ▼                   ▼
+  Workers AI            Workers AI
+ (bge-base-en-v1.5)   (llama-3.1等)
+       │                   ▲
+       │ ②query            │ ③context
+       ▼                   │
+   Vectorize ──── matches ─┘
+       │
+       │ メタデータに doc_id / r2_key
+       ▼
+       R2 (原本Markdown / PDF)
+       D1 (権限・テナント情報)
+```
+
+### インジェスト側コード例
+```typescript
+// 1. R2のドキュメントを読む → チャンク分割
+const obj = await env.R2.get("docs/policy.md");
+const text = await obj!.text();
+const chunks = splitIntoChunks(text, 500); // 500トークン目安
+
+// 2. embedding一括生成
+const { data: vectors } = await env.AI.run(
+  "@cf/baai/bge-base-en-v1.5",
+  { text: chunks }
+);
+
+// 3. Vectorizeへupsert
+await env.VECTORIZE.upsert(
+  vectors.map((values, i) => ({
+    id: `policy-${i}`,
+    values,
+    metadata: {
+      tenant_id: "acme",
+      doc_id: "policy",
+      chunk_index: i,
+      r2_key: "docs/policy.md",
+    },
+  }))
+);
+```
+
+### クエリ側コード例
+```typescript
+// 1. 質問をembed
+const { data } = await env.AI.run("@cf/baai/bge-base-en-v1.5", {
+  text: [userQuestion],
+});
+
+// 2. Vectorize検索（テナント分離をfilterで担保）
+const { matches } = await env.VECTORIZE.query(data[0], {
+  topK: 5,
+  returnMetadata: "all",
+  filter: { tenant_id: { $eq: tenantId } },
+});
+
+// 3. R2から原本チャンク取得 → プロンプト合成
+const contexts = await Promise.all(
+  matches.map(async (m) => {
+    const obj = await env.R2.get(m.metadata!.r2_key as string);
+    return await obj!.text();
+  })
+);
+
+// 4. LLMに投入
+const answer = await env.AI.run("@cf/meta/llama-3.1-8b-instruct", {
+  messages: [
+    { role: "system", content: "以下のコンテキストのみを根拠に回答せよ。" },
+    { role: "user", content: `${contexts.join("\n---\n")}\n\nQ: ${userQuestion}` },
+  ],
+});
+```
+
+マネージドでよければ **AI Search（旧AutoRAG）** が上記パイプラインを一括代替する。R2バケットを指定すれば自動でチャンク化・embedding・Vectorize格納・更新監視まで担う。
+
+## 参考リンク
+- 公式トップ: https://developers.cloudflare.com/vectorize/
+- Limits: https://developers.cloudflare.com/vectorize/platform/limits/
+- Pricing: https://developers.cloudflare.com/vectorize/platform/pricing/
+- Get started: https://developers.cloudflare.com/vectorize/get-started/intro/
+- AI Search: https://developers.cloudflare.com/ai-search/
+- Workers AI（embeddingモデル）: https://developers.cloudflare.com/workers-ai/models/
+
+---
+参照日: 2026-05-03

--- a/src/content/knowledge/web-development/cloudflare-docs/24-workers.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/24-workers.mdx
@@ -1,0 +1,123 @@
+---
+title: "Cloudflare Workers"
+description: "Cloudflareのグローバルネットワーク上でJavaScript / TypeScript / Python / Rust等のコードを実行する、コールドスタートを排した V8 isolate ベースのサーバーレス実行基盤。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 24
+---
+# Workers
+
+## 一行サマリ
+Cloudflareのグローバルネットワーク上でJavaScript / TypeScript / Python / Rust等のコードを実行する、コールドスタートを排した V8 isolate ベースのサーバーレス実行基盤。
+
+## 解決する課題（Why）
+従来のサーバーレス（AWS LambdaやCloud Functions）は、リージョン固定・コールドスタート遅延・コンテナ起動コスト・egress課金といった構造的な制約を抱える。Workers はリクエストをユーザー最寄りのエッジロケーションで V8 isolate により直接処理することで、ミリ秒級のレイテンシと実質ゼロのコールドスタートを実現する。フロントエンド配信（静的アセット + SSR）からAPI、Cron、AI推論、長時間バッチまでを単一プラットフォームに統合し、データ転送（egress）課金が存在しない点も大きい。
+
+## 主要機能（What）
+- V8 isolate による軽量実行（コンテナ不要、コールドスタートなし、起動時間1秒以内）
+- グローバルエッジ配信（Cloudflareネットワーク全ロケーションで自動デプロイ）
+- 言語サポート: JavaScript / TypeScript / Python / Rust / WebAssembly
+- Bindings によるストレージ・サービス連携（KV / R2 / D1 / Durable Objects / Queues / Hyperdrive / Vectorize / Workers AI）
+- Static Assets 統合（フロントエンドフレームワーク React / Next / Astro / Svelte / Vue 等のフルスタック対応）
+- Cron Triggers / Queue Consumer / Durable Object Alarms による非同期・スケジュール実行
+- Service Bindings による Worker 間通信（インターネットを経由しない内部呼び出し）
+- 観測性（Workers Logs、Tail Workers、Logpush、DevTools プロファイリング）
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- グローバルに分散したユーザーへ低レイテンシでAPI/SSRを返したい
+- コールドスタートが許容できない（決済・認証・チャット等の対話型ワークロード）
+- egress量が多く、AWS/GCPのデータ転送コストが収益を圧迫している
+- LP/フロントエンド + 軽量API/BFF を1つのデプロイ単位で配信したい
+- AI推論（Workers AI）や Vectorize によるRAGをエッジで完結させたい
+- Cron / Queue による非同期処理を別サービスを立てずに同居させたい
+
+### 適していないシーン
+- CPU時間が長い重い計算（1リクエストあたり5分超のCPU処理が必要）
+- 128 MB を超えるメモリを必要とする処理（大規模ML推論、巨大データのインメモリ処理）
+- Node.js のフルAPIや任意のネイティブバイナリが必要なケース（互換レイヤはあるが完全ではない）
+- レガシーOS依存・特定リージョン固定の規制要件があるワークロード（データ所在地要件はJurisdictional Restrictionsで対応可能だが要設計）
+- ステートフルなTCP/UDPの長時間維持が中心（一部はDurable Objects / TCP socket APIで対応可能）
+
+## 競合・代替（AWS / GCP / Azure / OSS）
+
+| プロバイダ | 対抗サービス | 違い |
+|---|---|---|
+| AWS | Lambda / Lambda@Edge / CloudFront Functions | Lambdaはリージョン固定でコンテナベース、コールドスタートあり。CloudFront FunctionsはCPU・実行時間が極めて短い（1ms / 10KB）。egress課金あり |
+| AWS | App Runner / Fargate | 常駐コンテナ。スケール・課金粒度が粗く、エッジ配信ではない |
+| GCP | Cloud Functions / Cloud Run | リージョン配置。Cloud Runはコンテナ単位でスケールするがエッジではない |
+| Azure | Azure Functions | リージョンベースFaaS。コールドスタートあり |
+| Vercel | Edge Functions / Serverless Functions | Edge Functionsは実体としてCloudflare Workers基盤を一部利用。VercelはDX重視、価格は割高傾向 |
+| Netlify | Edge Functions | Deno Deploy基盤。ネットワーク・統合機能ともCloudflareより限定的 |
+| Deno | Deno Deploy | V8 isolate + エッジ配信で最も思想が近い競合。Cloudflareに比べBindingsエコシステムが小さい |
+| OSS | Fastly Compute@Edge | WASMベースのエッジ実行。言語選択の幅は広いがランタイムDXは異なる |
+
+## 料金モデルの要点
+- 無料枠: 100,000 リクエスト / 日、CPU時間 10ms / リクエスト、Worker数 100、KV・Hyperdrive 等の基本枠を含む
+- Standard プラン（Workers Paid）: 月額 $5 から、リクエスト 1,000万 / 月 + $0.30 / 100万、CPU時間 3,000万 ms / 月 + $0.02 / 100万 ms
+- duration（wall-clock 時間）への課金なし（CPU時間のみ課金）。Lambda 等の duration 課金モデルとの最大の差
+- egress / bandwidth 課金が一切ない（R2 含めCloudflareの一貫した方針）
+- 静的アセットへのリクエストは無料・無制限
+- 注意点: CPU時間ベース課金なので、I/O待ちが多いWorkerは安価。逆に重い計算・SSRはCPU時間が膨らみコスト増。Wrangler の `limits.cpu_ms` 設定で denial-of-wallet 対策を必ず入れる
+
+## CLI / IaC 操作例
+
+```bash
+# プロジェクト初期化
+npm create cloudflare@latest my-worker
+
+# ローカル開発（Miniflare 経由のローカル isolate）
+npx wrangler dev
+
+# リモート（実エッジ）でのデバッグ
+npx wrangler dev --remote
+
+# デプロイ
+npx wrangler deploy
+
+# バンドルサイズ確認（gzip後3MB / 10MB上限）
+npx wrangler deploy --outdir bundled/ --dry-run
+
+# 起動時間プロファイル（1秒上限の調査）
+npx wrangler check startup
+```
+
+`wrangler.jsonc` での CPU 時間上限設定例:
+
+```jsonc
+{
+  "name": "my-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-04-01",
+  "limits": {
+    "cpu_ms": 30000
+  },
+  "kv_namespaces": [
+    { "binding": "MY_KV", "id": "xxxxxxxx" }
+  ]
+}
+```
+
+## 制限・注意点
+- CPU時間: Free 10 ms / 呼び出し、Paid 最大 5 分（デフォルト30秒）
+- メモリ: 128 MB / isolate（Free・Paid 共通）
+- Worker サイズ: gzip後 Free 3 MB / Paid 10 MB（圧縮前 64 MB）
+- 起動時間: グローバルスコープのパース・実行は1秒以内（超過すると `error code 10021`）
+- サブリクエスト: Free 50 / リクエスト、Paid 1,000（最大1,000万まで設定可）
+- 同時接続: 1呼び出しあたり レスポンスヘッダ受信前の接続は最大6本まで
+- リクエスト本文サイズ: Free/Pro 100 MB、Business 200 MB、Enterprise 500 MB（Cloudflare アカウントプランに依存）
+- ルート: 1 zone あたり 1,000 ルート、カスタムドメイン 100、`wrangler dev --remote` 時は 50 まで
+- Worker 数: Free 100 / Paid 500（超過時は Workers for Platforms を検討）
+- Static Assets: Worker version あたり Free 20,000 / Paid 100,000 ファイル、1ファイル 25 MiB
+- Cron / Queue Consumer / Durable Object Alarm の wall time は 15 分上限
+- ログサイズ: 1リクエスト 256 KB（超過分は記録されない）
+
+## 参考リンク
+- https://developers.cloudflare.com/workers/
+- https://developers.cloudflare.com/workers/platform/limits/
+- https://developers.cloudflare.com/workers/platform/pricing/
+
+---
+参照日: 2026-05-03

--- a/src/content/knowledge/web-development/cloudflare-docs/25-workers-ai.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/25-workers-ai.mdx
@@ -1,0 +1,149 @@
+---
+title: "Cloudflare Workers AI"
+description: "Cloudflareのグローバルネットワーク上のサーバーレスGPUで、Llama・Mistral・Whisper等のOSSモデルを推論実行できるAIプラットフォーム。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 25
+---
+# Workers AI
+
+## 一行サマリ
+Cloudflareのグローバルネットワーク上のサーバーレスGPUで、Llama・Mistral・Whisper等のOSSモデルを推論実行できるAIプラットフォーム。
+
+## 解決する課題（Why）
+自前GPUの調達・スケーリング・遊休コストといったAI推論基盤の運用負担を排除する。Workers/Pagesと同じエッジ拠点で推論が走るため、別クラウドのLLM APIを呼ぶ場合に発生する追加レイテンシとエグレス費用を回避できる。アイドル時の課金がない従量課金（Neurons）で、PoCから本番までインフラ設計を書き換えずにスケールできる。
+
+## 主要機能（What）
+- Text Generation：Llama 3/4、Mistral、Qwen、Gemma、DeepSeek、GPT-OSS、Kimi等のチャット/指示モデル
+- Text Embeddings：BGE系、Qwen3-Embedding、PLaMo Embedding等
+- Image Generation：FLUX 1/2、Leonardo Lucid Origin、Phoenix
+- Speech：Whisper（ASR）、MeloTTS、Deepgram Aura/Nova/Flux（TTS・STT、WebSocket対応）
+- Translation：m2m100、IndicTrans2
+- Classification / Object Detection / Reranker / Vision LLM
+- Function calling・Reasoning・Vision入力対応モデルあり
+- AI Gateway / Vectorize / Workers / Durable Objects との統合
+
+## 提供モデル抜粋
+カタログ総数97モデル（2026-05時点）。代表例:
+- Llama 3.1/3.2/3.3、Llama 4 Scout 17B（MoE）、Llama Guard 3
+- Mistral 7B、Mistral Small 3.1 24B
+- Qwen 2.5 Coder 32B、QwQ 32B、Qwen3 30B-A3B
+- DeepSeek-R1-Distill-Qwen-32B
+- GPT-OSS 20B/120B（OpenAIオープンウェイト）
+- Gemma 3 12B / Gemma 4 26B-A4B
+- Kimi K2.5 / K2.6（Moonshot、1Tパラメータ・262k context）
+- GLM-4.7-Flash（Zhipu）
+- Whisper / Whisper-large-v3-turbo
+- BGE Embeddings（small/base/large/m3）
+
+## アーキテクト視点：いつ選ぶか
+### 適しているシーン
+- OSSモデルで要件を満たせるユースケース（チャットボット、要約、RAG、埋め込み生成、画像生成、文字起こし）
+- Workers / Pages と同居させてエッジ近接で推論したい構成
+- アイドル時間が長く従量課金のメリットが大きい用途
+- データ主権の理由でCloudflareネットワーク内で完結させたい場合
+- Vectorize + Workers AI で完結するRAGパイプライン
+
+### 適していないシーン
+- GPT-5、Claude Sonnet 4.5、Gemini 3 Pro等のフロンティアモデルが必須の用途 → AI Gateway経由でOpenAI/Anthropic/Google直結が妥当
+- 大規模ファインチューニング（LoRA対応はあるが基盤学習は不可）
+- 1分あたり数千req超のText Generationを単一プランで張り付かせる用途（task type別レート制限あり）
+- リアルタイム性極端に厳しい音声対話（一部モデルはWebSocket対応だが選択肢は限定的）
+
+## 競合・代替
+
+| 観点 | Workers AI | OpenAI API | AWS Bedrock | Replicate | Together / Groq |
+|---|---|---|---|---|---|
+| モデル | OSS中心97種 | GPT-4o/5、o系 | Anthropic/Meta/Mistral等マルチ | OSS幅広い | OSS中心 |
+| デプロイ拠点 | Cloudflareエッジ | 米国中心 | AWSリージョン | 集約GPU | 集約GPU |
+| エッジ統合 | Workers同居で最強 | 別ネットワーク | AWS内なら強 | 弱 | 弱 |
+| 課金 | Neurons従量 | トークン従量 | トークン従量 | 秒課金 | トークン従量 |
+| フロンティアモデル | × | ◎ | ◎（Claude） | △ | △ |
+| OSS最新追従 | ○（gpt-oss・Kimi等迅速） | × | ○ | ◎ | ◎ |
+| 無料枠 | 10,000 Neurons/日 | なし | なし | 限定 | 限定 |
+
+## 料金モデルの要点
+- 単価：**$0.011 / 1,000 Neurons**（バックエンドはNeurons課金、UIは$/トークン換算で表示）
+- 無料枠：**全プランで10,000 Neurons/日**、UTC 0時リセット
+- Workers Free：無料枠超過分は不可、Paidへアップグレード必須
+- Workers Paid：無料枠超過分を $0.011/1k Neurons で従量課金
+- モデル例（M=百万トークン）:
+  - Llama 3.1 8B fp8-fast：input $0.045/M、output $0.384/M
+  - Llama 3.3 70B fp8-fast：input $0.293/M、output $2.253/M
+  - GPT-OSS 120B：input $0.350/M、output $0.750/M
+  - Kimi K2.6：input $0.95/M、cached input $0.16/M、output $4.00/M
+  - BGE-large-en-v1.5：$0.204/M input
+  - Whisper：$0.0005/audio min
+  - FLUX-1-schnell：$0.0000528/512x512タイル + $0.0001056/step
+
+## CLI / IaC 操作例
+**wrangler.jsonc**
+```jsonc
+{
+  "name": "my-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-05-01",
+  "ai": { "binding": "AI" }
+}
+```
+
+**Worker内呼び出し**
+```ts
+export default {
+  async fetch(req, env) {
+    const res = await env.AI.run("@cf/meta/llama-3.1-8b-instruct-fp8-fast", {
+      messages: [
+        { role: "system", content: "あなたは簡潔に答えるアシスタントです。" },
+        { role: "user", content: "Workers AIとは？" }
+      ]
+    });
+    return Response.json(res);
+  }
+} satisfies ExportedHandler<{ AI: Ai }>;
+```
+
+**Embeddings + Vectorize**
+```ts
+const { data } = await env.AI.run("@cf/baai/bge-m3", { text: ["RAG用テキスト"] });
+await env.VEC.insert([{ id: "1", values: data[0] }]);
+```
+
+**REST API（外部から）**
+```bash
+curl https://api.cloudflare.com/client/v4/accounts/$ACCOUNT/ai/run/@cf/meta/llama-3.1-8b-instruct \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"prompt":"Hello"}'
+```
+
+## 制限・注意点
+- **Rate Limit（task type別、デフォルト/分）**:
+  - Text Generation：300（モデル別に150〜1500の例外あり）
+  - Text Embeddings：3000（bge-large-en-v1.5は1500）
+  - Text-to-Image：720（SD v1.5 img2imgは1500）
+  - Automatic Speech Recognition / Translation / Image-to-Text：720
+  - Image Classification / Object Detection：3000
+  - Summarization：1500、Text Classification：2000
+- ローカル開発（`wrangler dev`）の推論もレート制限にカウントされる
+- Beta段階のモデルはレート制限が低い場合あり
+- 上限緩和・プライベートカスタムモデルはCustom Requirements Formで個別交渉
+- フロンティアモデル不在：高度な推論・長文context・最新ベンチ最強系は別系統が必要
+
+## AI Gateway との併用
+Workers AIだけでフロンティアモデル要件を満たせない場合、**AI Gateway** をフロントに置きOpenAI/Anthropic/Bedrock/Vertex/Workers AIへルーティングする構成が定石。
+- キャッシュ（同一プロンプトの再利用でコスト削減）
+- レート制限・リトライ・モデルフォールバック（OpenAI障害時にWorkers AIへ自動切替）
+- ログ・分析・コスト可視化を一元化
+- Workers AI自体もAI Gatewayの`run`オプションでgateway経由実行可能
+
+典型構成: Workers → AI Gateway → (Workers AI / OpenAI / Anthropic) → Vectorize で記憶。
+
+## 参考リンク
+- 公式トップ: https://developers.cloudflare.com/workers-ai/
+- モデルカタログ: https://developers.cloudflare.com/workers-ai/models/
+- Pricing: https://developers.cloudflare.com/workers-ai/platform/pricing/
+- Limits: https://developers.cloudflare.com/workers-ai/platform/limits/
+- 統合AIモデルカタログ: https://developers.cloudflare.com/ai/models/
+
+---
+参照日: 2026-05-03

--- a/src/content/knowledge/web-development/cloudflare-docs/26-workflows.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/26-workflows.mdx
@@ -1,0 +1,193 @@
+---
+title: "Cloudflare Workflows"
+description: "Cloudflare Workers上で動作する耐久性のある複数ステップ実行エンジン。AWS Step FunctionsやTemporalに相当し、ステップごとに状態を永続化しながら最大1年間にわたる長時間処理を確実に完遂する。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 26
+---
+# Workflows
+
+## 一行サマリ
+Cloudflare Workers上で動作する耐久性のある複数ステップ実行エンジン。AWS Step FunctionsやTemporalに相当し、ステップごとに状態を永続化しながら最大1年間にわたる長時間処理を確実に完遂する。
+
+## 解決する課題（Why）
+- 長時間にわたる処理を単一リクエストで完結できない（タイムアウト・接続切断）
+- API呼び出しや外部システム連携の失敗時に、途中から安全に再開したい
+- ユーザーオンボーディングや承認待ちなど、人間や外部イベントを挟む非同期フローを管理したい
+- 自前でジョブキュー・状態管理DB・リトライロジックを構築する運用負担を排除したい
+- 数日〜数週間にわたるスリープを必要とするビジネスプロセス（トライアル期限切れ、リマインダー等）を実装したい
+
+## 主要機能（What）
+- **`step.do(name, fn)`**: 任意の処理を耐久ステップとして実行。結果は永続化され、失敗時は自動リトライ。
+- **`step.sleep(name, duration)` / `step.sleepUntil(name, date)`**: 秒〜最大365日のスリープ。スリープ中はCPU課金されず、同時実行数にもカウントされない。
+- **`step.waitForEvent(name, opts)`**: 外部イベント（Webhook、承認、ユーザー入力）を待機。タイムアウト指定可。
+- **リトライ制御**: ステップ単位で `retries.limit / delay / backoff` と `timeout` を設定。
+- **`WorkflowEntrypoint` クラス**: Workersランタイム上で `run(event, step)` を実装する形でWorkflowを定義。
+- **インスタンス管理API**: 作成・取得・一時停止・再開・終了をプログラム的またはREST APIで制御。
+- **Python SDK**: TypeScriptに加えPythonでもWorkflow定義が可能。
+- **Observability**: 組み込みのダッシュボード／`wrangler tail` で各ステップの実行状況・リトライ履歴を可視化。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- すでにCloudflare Workers／R2／D1／Workers AIを採用しており、エコシステム内で完結させたい
+- 数分〜数日にわたる非同期処理（オンボーディング、決済後処理、データETL、AIパイプライン）
+- 人間の承認やWebhook受信を挟むhuman-in-the-loopフロー
+- グローバル分散・ゼロインフラ運用が要件
+- 小〜中規模で、専用クラスタ（Temporal等）を立てるオーバーヘッドを避けたい
+- AIエージェントの長時間タスク（複数LLM呼び出し＋外部API連携＋状態保持）
+
+### 適していないシーン
+- ステップあたり1MiBを超える大きな中間データを頻繁に扱う（R2等の外部ストレージ参照に切り替えれば回避可）
+- ミリ秒単位のリアルタイム性が要求される同期処理（通常のWorkerで十分）
+- 25,000ステップを超える超巨大DAG・複雑なfan-out/fan-in（Temporalの方が表現力で優位）
+- マルチクラウド／オンプレ環境とのハイブリッド要件
+- 既存のAWS資産が大きく、Step FunctionsとEventBridge等が密結合している
+
+## 競合・代替
+
+| 観点 | Cloudflare Workflows | AWS Step Functions | Temporal | Inngest | Trigger.dev |
+|---|---|---|---|---|---|
+| 実行モデル | コードファースト（TS/Python） | ASL（JSON/YAML DSL） | コードファースト（多言語SDK） | コードファースト（イベント駆動） | コードファースト（TS） |
+| ホスティング | フルマネージド（Cloudflare） | フルマネージド（AWS） | セルフホスト or Temporal Cloud | マネージド／セルフホスト | マネージド／セルフホスト |
+| 最大実行時間 | 1年（step.sleep） | 1年（Standard） | 無制限 | 数日〜（プラン依存） | 数日〜 |
+| 最小課金単位 | CPU時間（待機中ゼロ） | 状態遷移数 | アクション数（Cloud） | ステップ実行数 | 実行時間 |
+| グローバル分散 | 標準（エッジ） | リージョン単位 | クラスタ構成次第 | マネージド側で抽象化 | マネージド側で抽象化 |
+| 学習コスト | 低（Workers知見があれば） | 中（ASL習得が必要） | 中〜高（概念が豊富） | 低 | 低 |
+| 強み | エッジ統合・低コスト・待機無料 | AWSサービス統合の豊富さ | ワークフロー表現力・成熟度 | DX・イベント駆動 | DX・Vercel系との親和性 |
+
+## 料金モデルの要点
+- Workers Standardと同一課金体系。追加料金なし。
+- **CPU時間**: 月3,000万msまで無料、超過分100万msあたり$0.02。待機中（`step.sleep`、I/O待ち、`step.waitForEvent`中）はCPU課金されない。
+- **リクエスト（invocation）**: 月1,000万まで無料、超過100万あたり$0.30。Workflow内のサブリクエストは追加課金されない。
+- **ストレージ**: 1GBまで無料、超過分$0.20/GB-月。状態保持期間は無料3日／有料7日（デフォルト、短縮可）。
+- Freeプランでも利用可（CPU 10ms、日次10万実行、ストレージ1GB）。
+- **コスト最適化観点**: 長時間スリープを多用しても課金されないため、リマインダーやスケジュールジョブを大量に走らせる用途に強い。
+
+## CLI / IaC 操作例
+
+Workflow定義（`src/index.ts`）:
+
+```typescript
+import {
+  WorkflowEntrypoint,
+  WorkflowStep,
+  WorkflowEvent,
+} from "cloudflare:workers";
+
+type Env = {
+  MY_WORKFLOW: Workflow;
+  BUCKET: R2Bucket;
+  AI: Ai;
+};
+
+export class OnboardingWorkflow extends WorkflowEntrypoint<Env> {
+  async run(event: WorkflowEvent<{ userId: string }>, step: WorkflowStep) {
+    const profile = await step.do("fetch user profile", async () => {
+      const res = await fetch(`https://api.example.com/users/${event.payload.userId}`);
+      return await res.json();
+    });
+
+    await step.do(
+      "send welcome email",
+      {
+        retries: { limit: 5, delay: "10 seconds", backoff: "exponential" },
+        timeout: "2 minutes",
+      },
+      async () => {
+        await fetch("https://api.mailer.com/send", {
+          method: "POST",
+          body: JSON.stringify({ to: profile.email, template: "welcome" }),
+        });
+      },
+    );
+
+    await step.sleep("wait 7 days for trial", "7 days");
+
+    await step.waitForEvent("await upgrade", {
+      event: "user.upgraded",
+      timeout: "30 days",
+    });
+
+    await step.do("provision paid features", async () => {
+      // ...
+    });
+  }
+}
+```
+
+`wrangler.jsonc`:
+
+```jsonc
+{
+  "name": "onboarding-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-04-01",
+  "workflows": [
+    {
+      "name": "onboarding",
+      "binding": "MY_WORKFLOW",
+      "class_name": "OnboardingWorkflow"
+    }
+  ],
+  "limits": {
+    "cpu_ms": 300000,
+    "subrequests": 100000
+  }
+}
+```
+
+主要コマンド:
+
+```bash
+# デプロイ
+npx wrangler deploy
+
+# Workflow一覧
+npx wrangler workflows list
+
+# インスタンス起動
+npx wrangler workflows trigger onboarding '{"userId":"u_123"}'
+
+# インスタンス状態確認
+npx wrangler workflows instances describe onboarding <instance-id>
+
+# 一時停止／再開／終了
+npx wrangler workflows instances pause onboarding <instance-id>
+npx wrangler workflows instances resume onboarding <instance-id>
+npx wrangler workflows instances terminate onboarding <instance-id>
+
+# ログtail
+npx wrangler tail
+```
+
+## 制限・注意点
+- **最大ステップ数**: 有料プランデフォルト10,000、最大25,000（Wrangler設定で拡張）。Free 1,024。
+- **最大実行期間（wall time）**: 各ステップ無制限、`step.sleep` は最大365日。
+- **CPU時間**: ステップあたりデフォルト30秒、最大5分（`limits.cpu_ms`で設定）。
+- **ペイロード／ステップ結果**: イベントペイロード・各ステップ結果ともに最大1MiB。大容量データはR2に格納し参照を返す。`ReadableStream<Uint8Array>` で返却することでストリーム化も可能。
+- **状態保持容量**: 1インスタンスあたり最大1GB（有料）／100MB（Free）。
+- **同時実行**: 有料50,000、Free 100。待機中は同時実行数にカウントされない。
+- **インスタンス作成レート**: 有料 アカウントあたり300/秒、Workflowあたり100/秒。
+- **状態保持期間**: 完了済みインスタンスは有料30日／Free 3日で削除。
+- **サブリクエスト**: デフォルト10,000、最大1,000万まで拡張可。
+- **Workers for Platforms名前空間にはデプロイ不可。**
+- **冪等性の責務はユーザー側**: ステップ関数は再実行されうるため、外部副作用は冪等になるよう設計する必要がある。
+
+## ユースケース具体例
+- **ユーザーオンボーディング**: 登録 → ウェルカムメール → 7日後トライアル終了通知 → アップグレード待機 → 有料機能プロビジョニング
+- **決済処理**: 注文受付 → 在庫予約 → 決済API呼び出し（リトライ付） → 配送指示 → 通知。途中失敗時は補償ステップで自動ロールバック
+- **データETL**: R2の生データ取得 → AI推論で要約 → D1へ書き込み → Webhook通知。各段階を独立ステップ化し巨大データもストリームで扱う
+- **AIエージェント**: 複数LLM呼び出しと外部ツール実行を耐久実行。失敗時に途中ステップから再開
+- **承認フロー**: 申請受領 → 管理者へ通知 → `step.waitForEvent` で承認待機（最大30日） → 承認後アクション
+- **リマインダー／スケジュールジョブ**: ユーザーごとに長期スリープを大量並行実行（待機中は課金ゼロ・同時実行枠も消費しない）
+
+## 参考リンク
+- 公式ドキュメント: https://developers.cloudflare.com/workflows/
+- 制限: https://developers.cloudflare.com/workflows/reference/limits/
+- 料金: https://developers.cloudflare.com/workflows/reference/pricing/
+- Workers REST API: https://developers.cloudflare.com/api/
+
+---
+参照日: 2026-05-03

--- a/src/content/knowledge/web-development/cloudflare-docs/30-browser-isolation.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/30-browser-isolation.mdx
@@ -1,0 +1,157 @@
+---
+title: "Cloudflare Browser Isolation (Cloudflare One)"
+description: "Cloudflareのエッジ上で実行された「リモートブラウザ」が描画ベクター情報のみをユーザー端末に転送し、JavaScriptや能動コンテンツを端末に一切到達させずにWebを閲覧させる、Network Vector Rendering（NVR）方式のリモートブラウザ分離（Remote Browser Isolation, RBI）サービスである。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 30
+---
+# Browser Isolation (Cloudflare One)
+
+## 一行サマリ
+Cloudflareのエッジ上で実行された「リモートブラウザ」が描画ベクター情報のみをユーザー端末に転送し、JavaScriptや能動コンテンツを端末に一切到達させずにWebを閲覧させる、Network Vector Rendering（NVR）方式のリモートブラウザ分離（Remote Browser Isolation, RBI）サービスである。
+
+## 解決する課題（Why）
+従来のセキュアWebゲートウェイ（SWG）はURL/カテゴリでブロックする発想であり、未分類ドメインや正規サイトを踏み台にしたゼロデイ・水飲み場攻撃には無力である。一方で従来のRBIはピクセルストリーミングやDOMミラーリング方式が主流で、帯域・遅延・レンダリング崩れの問題からユーザー体験が著しく劣化していた。Cloudflare Browser Isolationは以下を解決する。
+
+- ブラウザ経由のゼロデイマルウェア・ドライブバイダウンロードの遮断（コードはエッジで実行され端末に届かない）。
+- フィッシングサイトでのキーボード入力禁止による認証情報窃取の抑止。
+- コピー＆ペースト・印刷・アップロード・ダウンロードを粒度を持って制御することによる情報持ち出しの抑止（DLPの代替・補完）。
+- BYOD・委託先・契約社員などの非管理端末に対し、エージェント不要で安全な業務Webアクセスを配布。
+- 既存ブラウザのまま使えるため、専用クライアントを配るタイプのRBI（Talon等）に比べ展開コストが極小。
+
+## 主要機能（What）
+
+- **Network Vector Rendering (NVR)**：Cloudflare独自方式。リモートブラウザがレンダリングした「描画ベクター」（描画コマンド列）のみをHTML5互換クライアントに転送する。ピクセルストリーミングのような帯域消費もDOMミラーリングのような互換性問題も避け、ローカルブラウザで描画したのと見分けがつかない体験を実現する。
+- **Clientless（プレフィックスURL方式）**：`https://<team>.cloudflareaccess.com/browser/<URL>` の形式でアクセスするだけで、WARPクライアント無しに任意の端末からRBIを利用できる。BYOD・社外協力者・短期契約者向け。
+- **In-line（WARP/Gateway経由）**：WARPクライアントを入れた管理端末に対しては、通常のURLを透過的にIsolate判定する。ユーザーは普段どおり閲覧し、危険サイトのみ自動的にエッジブラウザへ流れる。
+- **Access連携（Clientlessの認可レイヤ）**：Clientless Web Isolationの入口にCloudflare Accessポリシーを掛けられる。誰がリモートブラウザを使えるか、どのIdPで認証するかをAccessのDSLで制御する。社内Webアプリの保護に使う通常のAccessポリシー（Tier 1参照）と同じ仕組みを再利用する。
+- **Data protection controls（`bisoadmincontrols`）**：以下6項目を許可/禁止/限定の単位で設定する。
+  - **Copy（Remote → Client）**：リモート→ローカル方向のクリップボードコピー。
+  - **Paste（Client → Remote）**：ローカル→リモート方向の貼付け。
+  - **Download**：ファイルのローカル保存。`view in remote browser only`（プレビュー閲覧のみ）も選択可。
+  - **Upload**：ローカルからリモートへのファイルアップロード。
+  - **Keyboard**：キーボード入力。フィッシング疑惑サイトで入力だけ禁止する用途に有効。
+  - **Print**：ローカル印刷。
+- **Tunnel連携によるプライベートWebアプリの分離アクセス**：Tunnel配下の社内アプリ（例：`http://192.168.2.1:7148`）へClientless URL経由で到達できる。VPN無しに非管理端末から社内Webを安全に触らせたい場合の決定打。
+- **Local Domain Fallback / Do Not Isolate**：信頼済みドメインや銀行・社内SaaS等、分離するとUXが壊れるサイトを明示的に除外できる。Local Domain FallbackはGateway側のDNS逃がし機能と組合わせて使う。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- 未分類ドメインや短期間しか存在しないフィッシング・C2系ドメインを踏ませる前提で、SWGブロックでは取りこぼす攻撃面を物理的に切り離したい組織。
+- BYOD・業務委託・M&A直後で端末管理が混在しており、エージェント配布が現実的でないケースのSafe Browsing提供。
+- 開発者・SOCがマルウェアサンプルや疑わしいURLを業務として開く必要があり、検体実行を端末に持ち込みたくない。
+- 機密データ取扱い系SaaS（Salesforce / HRIS / 経理）について、ダウンロードと印刷だけ禁止して情報持ち出しを抑える「軽量DLP」用途。
+- 子会社・取引先に対し、Tunnel配下の社内Webアプリへのアクセスを「クライアントレスかつIsolated」で配布したい。
+
+### 適していないシーン
+- 動画会議・WebRTC・低遅延ゲーム等、リアルタイム双方向メディア前提のアプリ。NVRでも遅延・互換性が問題になりやすい。
+- 帯域が極端に細い回線（モバイル従量課金、海上・現場拠点）。NVRはピクセル方式より軽いが完全にローカルブラウザ並みではない。
+- 「すべてのWebを常にIsolate」の運用設計。コスト・体感・対応外サイトの観点で破綻するため、リスクベースで部分適用するのが定石。
+- エンドポイントDLPの全代替。クリップボード/印刷/DLは抑えられるが、スクリーンショットや写真撮影には無力で、エンドポイントEDR/DLPと併用する前提である。
+
+## 競合・代替
+
+| 観点 | Cloudflare RBI | Menlo Security | Zscaler Cloud Browser | Talon (Palo Alto Prisma Access Browser) |
+|---|---|---|---|---|
+| レンダリング方式 | Network Vector Rendering（描画コマンド転送） | DOM Mirroring / Adaptive Clientless Rendering | ピクセル/DOM混合 | 専用Chromiumフォーク（端末側で実行） |
+| クライアント | 不要（既存ブラウザのまま） | 不要 | 不要（Zscalerクライアント有でも可） | 専用ブラウザ配布が必要 |
+| Clientless URL | あり（`/browser/<URL>`） | あり | あり | 概念が異なる（ブラウザ自体が境界） |
+| Access/ZTNA統合 | Cloudflare Access / Tunnelとネイティブ連携 | 単体製品寄り、ZTNAは別連携 | Zscaler Private Access統合 | Prisma Access統合 |
+| DLPコントロール | clipboard / print / DL / UL / keyboard | 同等 | 同等 | ブラウザ内ポリシーで強力 |
+| 強み | エッジ網のレイテンシ優位・他Cloudflare One機能と一体・既存ブラウザ流用 | RBI専業の歴史と精度 | 大企業向けSWG/ZTNAスイート統合 | エンタープライズブラウザというカテゴリ自体の強さ |
+| 弱み | RBI単体としての成熟度では老舗に一歩譲る側面 | スイート全体の選択肢が狭い | アーキテクチャが重い・価格 | 端末側に専用ブラウザ配布の運用コスト |
+| 価格モデル | Zero Trust Pay-as-you-go / Enterpriseのアドオン | エンタープライズ商談 | エンタープライズ商談 | エンタープライズ商談（買収後Prisma配下） |
+
+Cloudflareの差別化要素は「Access / Gateway / Tunnel / WARPと同じコントロールプレーンに乗っていること」「NVRによるUXの近さ」であり、Zero Trust一式をCloudflareで揃える前提なら第一候補となる。
+
+## 料金
+- **Free / Pay-as-you-go ベース**：Browser IsolationはCloudflare Zero Trustの**アドオン**として提供される。
+- **Pay-as-you-go**：ユーザー単位の従量課金にBrowser Isolationアドオン料金が加算される（公開Webでは「Pay-as-you-goおよびEnterpriseプランへのアドオン」と明記）。
+- **Enterprise**：契約に組込み可能。SCIM・User Risk Score・SLAなどとセットで提案される。
+
+無料枠50ユーザーのZero Trust基本機能には**含まれない**点が、Tier 1で扱ったAccessとの大きな違いである。RBIを使う段階で課金プランへの移行が必要となる。
+
+## CLI / IaC 操作例
+
+### Terraform：Isolateアクション付きGatewayポリシー（HTTPルール）
+Browser Isolationは `cloudflare_zero_trust_gateway_policy` の `action = "isolate"` で発動し、`rule_settings.bisoadmincontrols` で粒度制御を行う。
+
+```hcl
+resource "cloudflare_zero_trust_gateway_policy" "isolate_uncategorized" {
+  account_id  = var.account_id
+  name        = "Isolate uncategorized & risky categories"
+  description = "未分類・新規ドメイン・セキュリティリスクをRBIへ"
+  precedence  = 100
+  enabled     = true
+  action      = "isolate"
+  filters     = ["http"]
+
+  # 未分類 + 新規ドメイン + Security Risksカテゴリ
+  traffic = "any(http.request.uri.content_category[*] in {1 2 3})"
+
+  rule_settings = {
+    biso_admin_controls = {
+      dcp = true   # disable copy   (Remote -> Client)
+      dp  = true   # disable paste  (Client -> Remote)
+      dd  = true   # disable download
+      du  = true   # disable upload
+      dk  = false  # keyboard許可（業務閲覧のため）
+      dpr = true   # disable print
+    }
+  }
+}
+```
+
+### Terraform：機密SaaSの「ダウンロード/印刷だけ禁止」軽量DLPパターン
+```hcl
+resource "cloudflare_zero_trust_gateway_policy" "isolate_hris" {
+  account_id = var.account_id
+  name       = "Isolate HRIS - block download/print only"
+  precedence = 50
+  enabled    = true
+  action     = "isolate"
+  filters    = ["http"]
+
+  traffic = "any(http.request.host in {\"hris.example.com\"})"
+
+  rule_settings = {
+    biso_admin_controls = {
+      dcp = false
+      dp  = false
+      dd  = true
+      du  = false
+      dk  = false
+      dpr = true
+    }
+  }
+}
+```
+
+### Clientless URL（運用例）
+```
+https://<team-name>.cloudflareaccess.com/browser/https://intranet.internal/
+```
+このURLの前段にAccess applicationを掛けることで、認証済みユーザーだけがClientless RBI経由で社内Tunnelアプリに到達できる構成を組める。
+
+## 制限・注意点
+- **HTTPポリシーの適用にはTLS復号が必須**。証明書ピン留めしているサイト・アプリではIsolate配下で動かない場合がある。
+- **WebRTC / 動画会議系**は遅延と互換性の問題で実用に耐えないことが多い。Do Not Isolateで明示除外する設計が前提。
+- **PDF・大容量メディア**はリモートブラウザ内ビューア（`view in remote browser only`）に閉じ込めると安全側に倒せるが、ローカル編集ワークフローとは衝突する。
+- **同時セッション数**：ブラウザ種別あたりの同時インスタンス数に上限がある（公式トラブルシュートで言及。「No Browsers Available」エラー）。重め業務での前提条件として把握しておくこと。
+- **Clientless URLの公開範囲**：Access policyを正しく組まないと、`/browser/<任意URL>` で社内Tunnelの全アプリに到達されうる。AccessのIncludeを必ず人/グループ単位に絞る。
+- **AccessのBypassポリシー併用時の注意**：Tier 1で触れたとおり、Bypassは制御を完全に外す。Clientless RBIの入口でBypassを多用するとRBIごと素通りされるため、原則Service Authで代替する。
+- **OS・GPU依存の描画問題**：Windowsで稀にWebGL関連エラー・空白描画が発生する。ソフトウェアラスタライゼーション設定で回避できるケースがあるが、業務利用前のパイロット検証必須。
+- **コスト跳ね**：「全URLをIsolate」設計は、ユーザー数 × トラフィックでアドオン費用が跳ねる。リスクカテゴリ・未分類・特定SaaSなど対象を絞った設計が定石である。
+
+## 参考リンク
+- Browser Isolation 概要：https://developers.cloudflare.com/cloudflare-one/policies/browser-isolation/
+- Isolation policies（bisoadmincontrols）：https://developers.cloudflare.com/cloudflare-one/policies/browser-isolation/isolation-policies/
+- Setup（In-line / Clientless）：https://developers.cloudflare.com/cloudflare-one/policies/browser-isolation/setup/
+- Clientless Web Isolation：https://developers.cloudflare.com/cloudflare-one/policies/browser-isolation/setup/clientless-browser-isolation/
+- Troubleshooting：https://developers.cloudflare.com/cloudflare-one/policies/browser-isolation/troubleshooting/
+- Terraform Provider（cloudflare_zero_trust_gateway_policy）：https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_gateway_policy
+
+---
+参照日: 2026-05-03

--- a/src/content/knowledge/web-development/cloudflare-docs/31-casb.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/31-casb.mdx
@@ -1,0 +1,158 @@
+---
+title: "Cloudflare CASB (Cloudflare One)"
+description: "SaaSやIaaSのAPIに直接接続し、設定ミス・過剰共有・不審なユーザー活動・データ露出を継続スキャンで検出するAPIベースのCloud Access Security Brokerである。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 31
+---
+# CASB (Cloudflare One)
+
+## 一行サマリ
+SaaSやIaaSのAPIに直接接続し、設定ミス・過剰共有・不審なユーザー活動・データ露出を継続スキャンで検出するAPIベースのCloud Access Security Brokerである。
+
+## 解決する課題（Why）
+SaaS時代のセキュリティ事故の多くは、攻撃者の侵入ではなくテナント側の「設定の歪み」と「共有の事故」から生じる。Public link付きのGoogle Drive、MFA未設定のOkta管理者、外部組織が招待されたままのSlackチャネル、退職者が残したGitHubトークン。こうした問題はネットワーク経路を通らないため、ファイアウォールでもSWGでも見えない。Cloudflare CASBはSaaSのAPIに直接接続し、テナント内部の状態を読み取って以下を解決する。
+
+- SaaSテナントの**設定ミス（misconfiguration）**の継続的な検出。
+- ファイル・ドキュメント・リポジトリの**過剰共有（over-sharing / public exposure）**の発見。
+- 未承認SaaSやAI利用といった**Shadow IT / Shadow AI**の可視化。
+- DLPと組合せたSaaS内コンテンツの**機密データ露出**検知。
+- 退職者・元従業員アカウントや権限肥大の検出。
+
+ネットワーク経路を通らない領域、すなわち「すでにSaaS内部で起きている事象」を捕まえるためのレイヤである。
+
+## 主要機能（What）
+
+### APIスキャン方式
+CASBは各SaaSのAPIにOAuthまたは管理者権限で接続し、**read-only**の最小権限で定期スキャンを実行する。スキャン間隔は概ね1時間〜24時間で、ネットワーク経路にプロキシとして割り込まないため、ユーザー体験やレイテンシには影響しない。Inlineの制御（DLPブロックなど）はGatewayが担当し、APIによるテナント可視化はCASBが担当する、という役割分担である。
+
+### 対応SaaS / IaaS
+2026年5月時点で以下に対応する（カテゴリ別）。
+
+- **生産性スイート**：Google Workspace（Gmail / Drive / Calendar / Admin）、Microsoft 365（Admin Center / Outlook / SharePoint / OneDrive）
+- **クラウドストレージ**：Box、Dropbox、Google Drive、OneDrive、SharePoint、AWS S3、GCP Cloud Storage
+- **コラボレーション**：Slack、Atlassian Confluence、Atlassian Jira
+- **CRM / ITSM**：Salesforce、ServiceNow
+- **開発基盤**：GitHub、Bitbucket Cloud
+- **AI**：Anthropic、OpenAI、Microsoft 365 Copilot、Gemini for Google Workspace
+
+AI系SaaSへの対応はShadow AI対策として近年強化されている領域であり、生成AIの業務利用が広がる組織での価値が高い。
+
+### Findings（検出種別）
+検出結果は二系統に分類される。
+
+- **Posture Findings**：テナント設定そのものに対する問題。MFA未強制、管理者権限の過剰付与、Public sharing有効、外部ユーザー招待、退職者アカウント残存、APIトークン露出など。
+- **Content Findings**：SaaS内のファイル・メッセージに含まれる機密データ。クレジットカード番号・マイナンバー・ソースコード上のシークレットなどがDLPプロファイルとマッチした際に生成される。
+
+各FindingにはSeverityが付与される。
+
+| Severity | 対応の目安 |
+|---|---|
+| Critical | 即日対応（公開状態のシークレット、特権アカウント乗っ取り疑い等） |
+| High | 同週中に対応（公開ドキュメント、MFA未強制管理者等） |
+| Medium | 同月中にレビュー |
+| Low | 情報提供・定期レビュー対象 |
+
+### DLP / Gateway との連携
+Content FindingsはCloudflare DLPのプロファイル（PCI / PII / カスタム正規表現等）と連動する。Posture Findingsの一部、特にGoogle Workspaceのファイル共有系Findingは、画面上から**Gateway HTTPポリシーをワンクリックで生成**できるよう接続されており、検出 → ブロックの動線が短い。Inline制御は常にGatewayが担い、CASBはトリガーと文脈を提供する役割となる。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- 既にCloudflare Zero Trust（Access / Gateway / DLP）を導入済みで、SaaS内部の監査レイヤを足したい組織。
+- Google Workspace / Microsoft 365 を全社で使い、外部共有の事故を継続的に発見したい中規模組織。
+- GitHub / Bitbucket でのシークレット露出・public化事故を早期に検出したい開発組織。
+- Shadow AI（ChatGPT / Claude / Copilotの個人利用）の可視化を始めたい組織。
+- 50ユーザー無料枠の中で「軽量CASB」を試したいスタートアップ。
+
+### 適していないシーン
+- **Inlineでの強制制御を主軸にしたい**ケース。CloudflareのCASBはAPI型に特化しており、Reverse proxy / Forward proxy型のセッション内介入を期待するならNetskopeやDefender for Cloud Appsの方が向く。
+- **長尾のSaaS**（業界特化アプリや国産SaaS）まで広く対応させたいケース。ロングテール対応はNetskope / McAfee MVISION の方が成熟している。
+- **オンプレSaaS（自社ホストGitLabなど）**の監査。CASB対象は基本的にクラウド版に限られる。
+- **コンプライアンス報告書を自動生成したい**といった重厚な監査機能を求めるケース。Cloudflare CASBは検出と是正動線にフォーカスしており、レポーティング機能は最小限である。
+
+## 競合・代替
+
+| 観点 | Cloudflare CASB | Netskope CASB | Microsoft Defender for Cloud Apps | McAfee（Trellix）MVISION Cloud | Palo Alto SaaS Security |
+|---|---|---|---|---|---|
+| 主モデル | API型に特化 | API + Inline（Forward / Reverse Proxy）両対応 | API + Conditional Access App Control（Reverse Proxy） | API + Inline | API + Inline |
+| 強み | Zero Trustスタック（Access / Gateway / DLP）と一体・無料枠あり | カバーSaaS数が最大級・UEBAが強力 | Microsoft 365との統合が圧倒的・Entra連動 | 老舗で大企業導入実績豊富 | Prisma SASEとの統合 |
+| 弱み | 対応SaaS数は競合より少なめ・Inline制御は別コンポーネント | 価格高め・運用がリッチで重い | M365以外のカバレッジは中庸 | UIが古め・SKU体系が複雑 | 単独利用しにくい |
+| Inline DLPブロック | Gatewayに委譲（連携あり） | 自前 | 自前（Conditional Access） | 自前 | 自前 |
+| 料金感 | Zero Trust Free〜・Standardから従量 | 個別見積（高単価帯） | M365 E5に内包またはアドオン | 個別見積 | Prismaバンドル |
+
+カバレッジとInline制御の総合力ではNetskope / Microsoftが上位だが、「Cloudflare One全体に1点足せばSaaS可視化が立つ」という統合性とコスト効率は他にない強みである。
+
+## 料金
+- **Free**：Zero Trust Freeに含まれ、最大2つのCASB integration まで設定可能。50ユーザーまで。Posture Findings は確認可能だが、Findingの詳細表示や全integration活用にはEnterpriseが必要。
+- **Pay-as-you-go / Standard**：Zero Trust有償プランの一部としてCASBが利用可能（ユーザー単価ベース）。
+- **Enterprise**：全対応SaaS integration、詳細Finding（影響範囲・関連ユーザー・修復導線）、DLPプロファイル連携、SCIM、サポートSLAが付帯する。
+
+要するに、PoCはFreeで2 integrationまで試し、本格運用時はZero Trust Enterpriseに揃えるのが現実的な導入パスである。
+
+## CLI / IaC 操作例
+
+CASB integration自体（OAuthでSaaSテナントに接続する操作）は管理画面ベースであり、Terraformの正式リソースは限定的である。一方、CASBから検出されたFindingに対する**Gatewayポリシー化**や、CASB前段の**Access統合**はTerraformで宣言できる。
+
+### Terraform：Findingsを起点にしたGateway HTTPポリシー
+```hcl
+# CASBが検出したGoogle Workspaceの公開ファイル共有を、Gatewayでブロック
+resource "cloudflare_zero_trust_gateway_policy" "block_public_drive" {
+  account_id  = var.account_id
+  name        = "Block public Google Drive shares flagged by CASB"
+  description = "CASB Posture Finding 経由で発見された公開リンクをDownload時にブロック"
+  precedence  = 100
+  action      = "block"
+  filters     = ["http"]
+  enabled     = true
+
+  traffic = "any(http.request.uri.content_category[*] in {\"file sharing\"})"
+  identity = "any(identity.email matches \".*@example.com\")"
+}
+```
+
+### Terraform：CASB対象SaaSをAccess SaaS Applicationとして前段に立てる
+```hcl
+resource "cloudflare_zero_trust_access_application" "salesforce" {
+  account_id       = var.account_id
+  name             = "Salesforce"
+  type             = "saas"
+  session_duration = "24h"
+
+  saas_app = {
+    auth_type = "saml"
+    sp_entity_id = "https://example.my.salesforce.com"
+    consumer_service_url = "https://example.my.salesforce.com?so=..."
+  }
+}
+```
+
+CASBはSaaSテナント内部を見るレイヤ、Access SaaS統合はSaaSへの入口を見るレイヤであり、両者を組合せると「入口でSSO制御 + 内部で設定監査」の二重防御になる。
+
+### API（参考）
+- `GET /accounts/{account_id}/zt_risk_scoring/integrations`
+- `GET /accounts/{account_id}/zt_risk_scoring/findings`
+
+Findings APIをCI / SOAR連携で叩き、Slack通知やJira起票につなぐ運用が現実的である。
+
+## 制限・注意点
+- **Inlineブロックは持たない**。リアルタイム遮断はGateway / DLP併用が前提である。CASB単体導入では「見える化」までに留まる。
+- **対応SaaSの幅は競合より狭い**。社内利用SaaSの棚卸しを先に行い、対応外であればNetskope等の併用も検討する。
+- **APIスキャン間隔は1〜24時間**。ゼロタイムでの検知ではなく、設定ミスを「事後最短」で見つける性質と理解する。
+- **Free枠は2 integration / Finding詳細制限あり**。本番運用ではEnterpriseが事実上の前提となる。
+- **OAuth認可スコープが広い**ものもあり、対象SaaS側の管理者と権限レビューを行ったうえで接続する必要がある。
+- **オンプレSaaS（自社GitLab等）は対象外**。
+- Findingの放置は「検出している＝管理している」という誤った安心を生む。SLA（Severity別の対応期限）を運用ルールとして定めるべきである。
+
+## 参考リンク
+- Cloudflare CASB 概要：https://developers.cloudflare.com/cloudflare-one/applications/casb/
+- CASB integrations 一覧：https://developers.cloudflare.com/cloudflare-one/applications/casb/casb-integrations/
+- Manage findings：https://developers.cloudflare.com/cloudflare-one/applications/casb/manage-findings/
+- Cloudflare DLP：https://developers.cloudflare.com/cloudflare-one/policies/data-loss-prevention/
+- Cloudflare Gateway：https://developers.cloudflare.com/cloudflare-one/policies/gateway/
+- Cloudflare One llms.txt：https://developers.cloudflare.com/cloudflare-one/llms.txt
+- Terraform Provider（cloudflare_zero_trust_gateway_policy / cloudflare_zero_trust_access_application）：https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs
+
+---
+参照日: 2026-05-03

--- a/src/content/knowledge/web-development/cloudflare-docs/32-dex.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/32-dex.mdx
@@ -1,0 +1,148 @@
+---
+title: "Cloudflare Digital Experience Monitoring (Cloudflare One)"
+description: "WARPデバイスから送出されるテレメトリと合成テスト（Synthetic Tests）を集約し、ユーザー端末からSaaS・社内アプリ・Tunnel配下のオリジンに至るまでのエンドツーエンドな到達性とパフォーマンスを可視化するDEX（Digital Experience Monitoring）サービスである。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 32
+---
+# Digital Experience Monitoring (Cloudflare One)
+
+## 一行サマリ
+WARPデバイスから送出されるテレメトリと合成テスト（Synthetic Tests）を集約し、ユーザー端末からSaaS・社内アプリ・Tunnel配下のオリジンに至るまでのエンドツーエンドな到達性とパフォーマンスを可視化するDEX（Digital Experience Monitoring）サービスである。
+
+## 解決する課題（Why）— リモートワーク時代の「ユーザー側起因の障害」可視化
+従来のAPMやサーバー側モニタリングは「オリジンからの応答」までしか見ておらず、ユーザー宅のWi-Fi品質・ISPの経路問題・端末のCPU/メモリ枯渇・WARPの接続不全など、サーバーサイドからは観測できない領域が完全な盲点となっていた。リモートワーク常態化により、ヘルプデスクへの「なんか遅い」という曖昧な問い合わせが急増しているが、これを再現・切り分けする手段が長年欠けていた。Cloudflare DEXはWARPクライアントが既に各端末に入っている前提を活かし、以下を解決する。
+
+- 端末ごとのCPU・メモリ・接続先colo・WARP接続状態を一覧で把握できる。
+- 任意のSaaS・社内エンドポイントへの合成HTTP/Traceroute試験を5〜60分間隔で全端末から自動実行し、地域・ISPごとの劣化を統計的に検知する。
+- ユーザーから「重い」と申告があった瞬間にリモートでPCAP・WARP診断ログを採取できる（端末を取り上げる必要がない）。
+- ヘルプデスクの「ログを送ってください」ワークフローを撤廃できる。
+
+## 主要機能（What）
+
+- **Fleet Status**：colo別の接続デバイス数、接続状態（Connected / Disconnected / Paused / Connecting）、クライアントモード分布、OS・WARPバージョン分布、CPU・メモリ使用率の時系列を一画面で提示する。
+- **Synthetic Application Monitoring (Tests)**：WARP配下の端末から定期的にHTTPまたはTracerouteを実行する合成監視。
+  - **HTTP Test**：5〜60分間隔。Resource fetch time / Server response time / DNS response time / HTTPステータスを測定。公開URL・プライベートホスト名（local domain fallback要登録）どちらも対象。
+  - **Traceroute Test**：5〜60分間隔。RTT・Packet loss・Hop数・Hop毎のIP/応答時間/ロス率・Availabilityを測定。
+- **DEX Rules**：どのユーザー・グループ・端末で各テストを実行するかをポリシーで指定する（全社一律ではなくセグメント単位の運用が可能）。
+- **Remote Captures**：管理者がダッシュボードから対象端末（最大10台同時）を指定し、リモートでPCAP・WARP診断ログを採取する機能。
+  - **PCAP**：WARPトンネル外（既定インターフェース）と内側の双方を取得。`capture-default.pcap` / `capture-tunnel.pcap` / `results.json` の3点をWiresharkで解析できる。最大600秒・50MB、Windowsは同時実行不可。
+  - **WARP Diagnostic Logs**：直近96時間の診断ログ。任意でSplit Tunnelの全ルートテストを併走可能（その間端末性能に影響あり）。100MB超は自動アップロード不可で手動共有となる。
+  - 対応OSは Windows / macOS / Linux（2024.12.492.0以降）。iOS / Android / ChromeOSは非対応。
+- **Test History**：合成テストの結果を時系列・端末別・地域別に蓄積。Logpush経由でR2・外部クラウドストレージ・SIEMへ転送可能。既定保持期間は7日。
+- **Notifications**：以下3種のアラートを email / webhook / 三者連携 に発報する。
+  - Device Connectivity Anomaly（WARP接続のスパイク・ドロップをZ-score ±3.5σで検知）
+  - DEX Test Latency（HTTP fetch時間・Traceroute RTTの異常）
+  - DEX Test Low Availability（成功率がSLO閾値（例: 98.0%）を割った場合）
+  - colo・OS・WARPバージョン・テスト名でフィルタ可能。
+- **DEX MCP Server**：DEXのデータをClaudeなどMCP対応エージェントから問い合わせ可能にする統合（最近追加）。
+- **EU Customer Metadata Boundary対応**：EUコンプライアンス要件下でも利用できる。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- WARPを既に全社展開している、または展開予定の組織。DEXは追加課金なしで「ついてくる」性格の機能であり、WARP導入の正当化材料にもなる。
+- リモートワーク主体・グローバル分散チームで、ヘルプデスクが「ユーザー宅のネットワーク問題」と「アプリ側問題」を切り分ける材料を欲しがっているケース。
+- Cloudflare Access / Gateway / Tunnelで既にZero Trustスタックを統一している環境。DEXはこの3者と同じ管理面（Cloudflare One）に乗るため、サイロが増えない。
+- SaaS（Microsoft 365、Salesforce等）の地域別劣化を「実ユーザー視点」で監視したいケース。Cloudflareのcolo網を利用するため、社外SaaSの可用性を社員のロケーション別に観測できる。
+- VIP端末（経営層・営業担当）の常時状態監視。
+
+### 適していないシーン
+- WARPを導入しない / できない組織。DEXはWARPデバイスから送られるテレメトリで成立しており、エージェントレスでは何も取れない。BYOD で WARP を強制できない場合は別系統（Catchpoint等の合成監視SaaS）を検討する。
+- アプリケーション内部のトランザクション・コードレベルのトレースを取りたいケース。これはDatadog APM / New Relic等のAPMの領域であり、DEXは「外形監視＋端末状態」に特化する。
+- iOS / Android主体のモバイルワーカー集団で詳細PCAPまで欲しいケース。Remote CapturesのPCAP取得はデスクトップ3OS限定である。
+- 1分未満の高頻度監視を要するクリティカル業務系。テスト最小間隔は5分である。
+
+## 競合・代替
+
+| 観点 | Cloudflare DEX | Catchpoint | ThousandEyes (Cisco) | Nexthink | Microsoft Intune Endpoint analytics |
+|---|---|---|---|---|---|
+| 観測点 | WARP端末＋Cloudflare colo | 専用ノード＋エンドポイントエージェント | 専用エンタープライズエージェント＋Cloud Agent | 端末常駐エージェント＋センサー | Intune配下のWindows/macOS端末 |
+| 強み | Zero Trustスタックと同管理面・追加課金軽い | 合成監視の老舗・ノード網が広範 | ネットワークパス可視化が圧倒的・BGPまで追える | 端末DEX全般（アプリ起動失敗・クラッシュまで）・ITSM連携 | Intune標準・Windowsとの親和性 |
+| 弱み | WARP前提・APMトレースは持たない | 価格高め・端末側DEXは弱い | 高価・運用が重い | 価格高め・ネットワーク深掘りはThousandEyesに劣る | macOS以外は弱い・Cloudflare系SaaS監視は不得手 |
+| 価格帯 | Zero Trustプラン内（Free 50ユーザーまで含む） | エンタープライズ商談 | エンタープライズ商談（高額帯） | エンタープライズ商談 | Intune Suite に同梱 |
+| 適合 | Cloudflare One採用組織 | グローバルSaaS事業者 | 大企業のネットワーク部門 | エンドユーザー体験を重視する大企業IT | Microsoft 365中心の中堅企業 |
+
+DEXは「WARPを入れてしまえばタダ同然で得られる端末＋経路の可視化」というポジショニングであり、専門合成監視（Catchpoint / ThousandEyes）の代替というより、Zero Trust導入の副産物として最初に手を伸ばすべき選択肢である。深掘りが必要になった段階で専門ツールを足す、という二段構えが現実的である。
+
+## 料金（Cloudflare Zero Trust 上で WARP デバイスが必要、プラン差）
+- **Free**：50ユーザーまでZero Trustの基本機能（Access / Gateway / WARP）が無料。DEXのFleet status・基本的なSynthetic Tests・Remote Capturesも利用可能で、検証・少人数組織であればコストゼロで一通り触れる。
+- **Pay-as-you-go (Standard)**：$7/ユーザー/月程度。ユーザー数の制約がなくなり、DEXのテスト本数・履歴量・通知も実運用レベルに広がる。
+- **Enterprise / SASE bundle**：DEX MCP・高度なLogpush連携・SLA・EU Customer Metadata Boundary・複数アカウント横断などが上位プランに紐づく。SASEバンドル（Cloudflare One Enterprise）に組み込むのが一般的である。
+
+DEX独立の課金体系は存在せず、「Zero Trustプラン＋WARPデバイスシート」のサブセットとして提供される点が運用上重要である。逆に言えばWARPユーザー数が課金単位そのものになる。
+
+## CLI / IaC 操作例
+
+### Terraform（cloudflare provider v5）
+```hcl
+resource "cloudflare_zero_trust_dex_test" "salesforce_http" {
+  account_id  = var.account_id
+  name        = "Salesforce HTTP"
+  description = "Salesforce login page reachability from all WARP devices"
+  enabled     = true
+  interval    = "0h5m0s"
+  target_policies = [{
+    id      = cloudflare_zero_trust_device_settings_policy.default.id
+    default = true
+  }]
+
+  data = {
+    host   = "https://login.salesforce.com"
+    kind   = "http"
+    method = "GET"
+  }
+}
+
+resource "cloudflare_zero_trust_dex_test" "internal_api_traceroute" {
+  account_id = var.account_id
+  name       = "Internal API Traceroute"
+  enabled    = true
+  interval   = "0h15m0s"
+
+  data = {
+    host = "10.20.30.40"
+    kind = "traceroute"
+  }
+}
+```
+
+### 通知（Notification policy）
+Notification policy はCloudflareダッシュボード（Notifications）で `DEX Test Latency` / `DEX Test Low Availability` / `Device Connectivity Anomaly` を選び、SLO閾値・対象テスト・配信先（email / webhook / PagerDuty 等）を設定する。Terraformでも `cloudflare_notification_policy` で管理できる。
+
+### Logpush（テスト結果の長期保管）
+```hcl
+resource "cloudflare_logpush_job" "dex_results" {
+  account_id      = var.account_id
+  name            = "dex-test-results-to-r2"
+  dataset         = "zero_trust_network_sessions"  # 該当データセット名は要確認
+  destination_conf = "r2://dex-logs/{DATE}?account-id=${var.account_id}&access-key-id=...&secret-access-key=..."
+  enabled         = true
+}
+```
+
+## 制限・注意点
+- **WARP 導入が前提**：DEXはWARPクライアントから送られるテレメトリと、WARP配下で実行される合成テストで成立する。WARP未導入の端末・BYODで非同意の端末は完全に観測対象外となる。
+- **テスト最小間隔は5分**：1分未満のリアルタイム監視は不可。クリティカル業務はAPM・外形監視SaaSと併用する。
+- **Remote Capturesの制約**：1キャプチャあたり最大600秒・50MB、対応OSはWindows / macOS / Linux（2024.12.492.0以降）のみ、iOS / Android / ChromeOS非対応、Windowsは同時実行不可、サードパーティのキャプチャツールが干渉する場合がある。
+- **WARP診断ログ**：直近96時間が対象、100MB超は自動アップロード不可で手動共有が必要。
+- **テスト結果の既定保持は7日**：それ以上の長期分析にはLogpush経由でR2・S3・SIEMへ送出する設計が必要となる。
+- **アラートのZ-scoreは「直近5分 vs 過去4時間」で計算される**：恒常的な低品質環境ではベースラインが低く張りつき、異常を検知しづらい。SLO型アラートを併用するのが定石である。
+- **テスト本数上限・並列度はプラン依存**：大量導入時はCloudflareアカウント担当に上限確認が必須である。
+- **プライベートエンドポイントへの試験**：Tunnel経由でCloudflareに引き込まれている、または local domain fallback に登録されているホスト名のみが対象となる。
+- **DEX単体ではアプリ内処理時間は測れない**：HTTP testは外形のresource fetch timeまでである。アプリ内のトランザクション分解はAPMで補完する。
+
+## 参考リンク
+- DEX 概要：https://developers.cloudflare.com/cloudflare-one/insights/dex/
+- Synthetic tests：https://developers.cloudflare.com/cloudflare-one/insights/dex/tests/
+- HTTP test：https://developers.cloudflare.com/cloudflare-one/insights/dex/tests/http/
+- Traceroute test：https://developers.cloudflare.com/cloudflare-one/insights/dex/tests/traceroute/
+- Fleet status：https://developers.cloudflare.com/cloudflare-one/insights/dex/fleet-status/
+- Remote captures：https://developers.cloudflare.com/cloudflare-one/insights/dex/remote-captures/
+- Notifications：https://developers.cloudflare.com/cloudflare-one/insights/dex/notifications/
+- Cloudflare One llms.txt：https://developers.cloudflare.com/cloudflare-one/llms.txt
+- Terraform `cloudflare_zero_trust_dex_test`：https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs
+
+---
+参照日: 2026-05-03

--- a/src/content/knowledge/web-development/cloudflare-docs/33-dlp.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/33-dlp.mdx
@@ -1,0 +1,150 @@
+---
+title: "Cloudflare Data Loss Prevention (Cloudflare One)"
+description: "Cloudflare DLPは、Gateway・CASB・Email Security・AI Gatewayという複数のトラフィック検査点に共通して差し込まれる検出エンジンであり、機密データの外部流出を「インライン（HTTP/メール）」と「データ保管時（SaaS API）」の両面で同時に制御するアドオンサービスである。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 33
+---
+# Data Loss Prevention (Cloudflare One)
+
+## 一行サマリ
+Cloudflare DLPは、Gateway・CASB・Email Security・AI Gatewayという複数のトラフィック検査点に共通して差し込まれる検出エンジンであり、機密データの外部流出を「インライン（HTTP/メール）」と「データ保管時（SaaS API）」の両面で同時に制御するアドオンサービスである。
+
+## 解決する課題（Why）
+クラウドとSaaS、生成AIの普及によって機密データの流出経路は劇的に増えており、エンドポイントDLPやメール単体のDLPでは「ChatGPTにソースコードを貼られる」「Google Driveから個人共有される」「退職者が顧客リストをダウンロードする」といった経路を網羅できない。Cloudflare DLPは、ZTNAと同じConnectivity Cloud上に検査エンジンを置くことで以下を解決する。
+
+- インライン経路（Web/SaaS/AI）と静止データ経路（SaaS API）の検査ポリシーを単一プロファイルで共有できる。
+- TLSインスペクション済みのGatewayトラフィックに直接適用できるため、追加プロキシを挟まずにDLPを有効化できる。
+- 既知のサンプル文書・実データを基にしたファジー検出（Document Fingerprinting / EDM）が可能で、正規表現だけのDLPに比べて誤検知を抑えられる。
+- 生成AIプロンプトの検査（AI Gateway連携）にも同じプロファイルを再利用できる。
+
+## 主要機能（What）
+DLPはそれ自体が独立したプロキシではなく、**検出ロジック（Detection entries）→ プロファイル → ポリシー** の3層で構成され、Gateway / CASB / Email Security / AI Gateway から呼び出される。
+
+- **Predefined profiles**：Cloudflareがメンテする組み込みプロファイル。Financial Information、Social Security / Insurance / Tax / Identifier Numbers、Health Information、Credentials and Secrets など多数を提供する。Free / Pay-as-you-goプランでもこのうち2種は利用可能で、評価導入のハードルが低い。
+- **Custom profiles（regex）**：RE2構文の正規表現で独自パターンを定義する。1パターンあたり1024バイト、UTF-8最大4バイト/文字までという上限がある。社員番号・案件IDなど社内固有の識別子に使う。
+- **Exact Data Match (EDM)**：顧客マスタや従業員名簿などの実データを `.csv` / `.txt`（LF改行）でアップロードし、Cloudflare到達前にクライアント側でハッシュ化する。トラフィック側もハッシュ化して照合するため、機密データそのものはCloudflareに渡らず、ログでも自動マスクされる。各エントリは最低6文字必要。
+- **Document Fingerprinting**：契約書テンプレートや設計書のサンプル `.docx` / `.txt`（10MBまで）をアップロードすると、Cloudflareがフィンガープリントを生成し、類似度しきい値（0-100%）で「派生したコピー」を検出する。完全一致ではないため、抜粋・改変されたコピーにも反応する。
+- **Optical Character Recognition (OCR)**：画像・PDF内のテキストをスキャンして上記プロファイルにかける機能。スクリーンショット経由の流出に対応する。
+- **Custom Wordlists / AI prompt topics**：機密用語リスト、および生成AIプロンプトのトピック分類（ソースコード共有、個人情報送信など）にも対応する。
+- **対応ファイル種別**：テキスト・CSV、Microsoft Office 2007+ (`.docx` / `.xlsx` / `.pptx`) およびMicrosoft 365、PDF、ZIP（再帰圧縮10階層まで）。
+
+### Gateway / CASB / Email との統合（DLPは検出側）
+Gateway・CASB・Email Securityは別記事で詳述するが、DLPはこれらに「呼び出される側」として動作する。統合点を整理すると以下になる。
+
+| 統合先 | 検査対象 | 前提条件 |
+|---|---|---|
+| Cloudflare Gateway（HTTP policy） | インラインHTTP/HTTPSトラフィック | TLSインスペクション必須・WARP / PACでクライアントを誘導 |
+| Cloudflare CASB | Google Workspace / Microsoft 365 / Salesforce / GitHub等のSaaSに保管中のファイル | API経由のテナント連携（OAuth） |
+| Cloudflare Email Security | Outboundメール本文・添付 | Email Security導入済みドメイン |
+| Cloudflare AI Gateway | 生成AIへのプロンプト・レスポンス | TLSインスペクション不要（AI Gateway自体が中継するため） |
+
+このため「DLPだけ」を導入しても効果はなく、最低でもGatewayまたはCASB / Email Securityのいずれかと組み合わせる前提となる。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- すでにCloudflare GatewayでSWGを運用しており、TLSインスペクションが有効な組織。最小コストでインラインDLPを足せる。
+- Microsoft 365 / Google WorkspaceをCASB対象として持ち、保管中ファイルに対する継続スキャンが必要なケース。
+- 生成AI利用ガバナンスの整備で、ChatGPT・Claude等への機密データ投入をブロックしたい組織（AI Gateway連携）。
+- 顧客マスタなど「実データ」を既に保有しており、EDMでハッシュ照合したいケース。サンプル契約書のコピー検出にDocument Fingerprintingが要るケース。
+- Predefined profilesで足りる、PCI / PII / マイナンバー的な汎用検出から始めたい組織。
+
+### 適していないシーン
+- エンドポイント側でのコピー＆ペースト・USB転送・印刷を制御したいケース。CloudflareのDLPはネットワーク・SaaS APIの検査が主眼であり、ホストエージェント由来の制御はできない（Symantec DLP / Forcepoint DLPの領域）。
+- TLSインスペクションを組織ポリシーや法規制で許容できない環境。インラインDLPは事実上機能しない。
+- ニッチなビジネスアプリ（独自プロトコル・SaaS未対応のもの）に対する保管中スキャン。CASBコネクタが提供されないSaaSは対象外となる。
+- DLP単体で買いたい組織。AdvanceedなDLPはZero Trust Enterpriseプランのアドオンであり、DLPだけ切り出した契約形態は存在しない。
+
+## 競合・代替
+
+| 観点 | Cloudflare DLP | Symantec DLP | Microsoft Purview DLP | Netskope DLP | Forcepoint DLP |
+|---|---|---|---|---|---|
+| 提供形態 | SASE/SSE一体型のアドオン | エージェント＋オンプレ＋クラウドの複合 | Microsoft 365に組み込み | SASE一体型 | エンドポイント＋ネットワーク＋クラウド |
+| インライン検査 | Gateway経由（TLS必須） | プロキシ製品と組合せ | Edge / Defender for Cloud Apps | 内蔵プロキシ | 専用ネットワークDLP |
+| SaaS API連携 | CASB（M365 / Workspace / Salesforce / GitHub等） | CloudSOC | M365内は強い・他SaaSはDefender for Cloud Apps | 100以上のSaaS | CASB別ライセンス |
+| 検出技術 | Predefined / regex / EDM / Fingerprinting / OCR / AI prompt | EDM / Fingerprinting / VML / OCR | Sensitive info types / EDM / Fingerprinting / Trainable classifiers | EDM / Fingerprinting / ML | Fingerprinting / 機械学習 / OCR |
+| エンドポイント制御 | なし | あり（強み） | Endpoint DLP（M365 E5） | あり | あり（強み） |
+| 生成AI対応 | AI Gateway連携でネイティブ | 個別ポリシーで対応 | Purview AI Hub | SkopeAI | 個別対応 |
+| 価格モデル | Zero Trust Enterpriseアドオン | エンタープライズライセンス | M365 E5に同梱 / 別ライセンス | サブスクリプション | サブスクリプション |
+| 強み | SASEと同一ファブリック・AI連携・EDMが既定で利用可 | 検出エンジンの成熟・エンドポイント | M365との一体感・コスト効率 | SaaSカバレッジ | エンドポイント検査 |
+| 弱み | エンドポイント制御がない・Enterprise必須 | 運用コスト高・別物のアーキ | M365外のカバレッジ | Cloudflare比でアーキが分散 | クラウドネイティブ感は薄い |
+
+CloudflareのDLPは「検出器の網羅度」では老舗3社（Symantec / Forcepoint / Microsoft Purview）に並び始めた段階であり、強みは検出器単体ではなくSASE一体での運用容易性とAI Gatewayとの統合にある。
+
+## 料金
+- **Free / Pay-as-you-go**：Predefined profilesのうち2種（Financial Information / Social Security 等の識別子系）、ペイロードロギング、誤検知レポートのみ利用可能。評価・PoC用途の位置付け。
+- **Zero Trust Enterprise**：DLPはこのプランの**アドオン**として提供される。すべてのPredefined profile、Custom regex、EDM、Document Fingerprinting、OCR、AI promptトピック検出、CASB / Email Security連携、API経由のプロファイル管理、SIEM連携などが解放される。
+- DLPは**ユーザー単位の追加課金**であり、対象ユーザー数とCASBコネクタ数で見積りが膨らみやすい。Enterprise契約時にCloudflare営業との個別見積りが前提となる。
+
+## CLI / IaC 操作例
+DLPプロファイルとデータセット（EDM・Fingerprinting）はTerraform Provider v5以降で `cloudflare_zero_trust_dlp_*` リソースとして管理できる。
+
+```hcl
+# Custom DLP profile（regexベース）
+resource "cloudflare_zero_trust_dlp_custom_profile" "employee_id" {
+  account_id  = var.account_id
+  name        = "Employee ID Pattern"
+  description = "EMP-12345 形式の社員番号を検出"
+
+  entry {
+    name    = "Employee ID"
+    enabled = true
+    pattern = {
+      regex      = "EMP-[0-9]{5}"
+      validation = "luhn" # 任意。クレジットカード形式の場合
+    }
+  }
+
+  context_awareness = {
+    enabled = true
+    skip = {
+      files = false # ファイル本文もスキャン
+    }
+  }
+}
+
+# EDM データセット（実データのハッシュ照合）
+resource "cloudflare_zero_trust_dlp_dataset" "customers_edm" {
+  account_id        = var.account_id
+  name              = "Customer Master EDM"
+  description       = "顧客マスタからのEDMデータセット"
+  encoding_version  = 2
+  upload {
+    type = "exact_data_match"
+  }
+}
+
+# Gateway HTTP policy にDLPプロファイルを適用
+resource "cloudflare_zero_trust_gateway_policy" "block_employee_id_upload" {
+  account_id = var.account_id
+  name       = "Block Employee ID upload"
+  precedence = 100
+  action     = "block"
+  filters    = ["http"]
+
+  traffic = "any(dlp.profiles[*] in {\"${cloudflare_zero_trust_dlp_custom_profile.employee_id.id}\"})"
+}
+```
+
+EDMデータセットは `cloudflare_zero_trust_dlp_dataset` を作成した後、CLIまたは管理画面から `.csv` / `.txt` を**クライアント側でハッシュ化してアップロード**するフローになる。実データそのものはTerraform stateには載らないため、stateの暗号化と分離は不要だが、生CSVの保管場所は別途設計する必要がある。
+
+## 制限・注意点
+- **TLSインスペクション必須**：インラインHTTPでのDLPはTLS復号を前提とする。証明書ピンニングを行うアプリ（金融系SDK等）はBypass設定が必要で、その経路のDLPは効かなくなる。
+- **誤検知**：regexベースの検出は誤検知が出やすい。Document FingerprintingとEDMで補完するか、Context awareness（前後のキーワードで絞り込む機能）を併用する設計が望ましい。
+- **スキャン上限**：Document Fingerprintingのサンプル文書は1ファイル10MBまで、regexパターンは1024バイトまで、EDMの各エントリは最低6文字必要、ZIPは再帰10階層まで。これを超える対象は検出から漏れる。
+- **暗号化済みファイル**：パスワード付きZIP、暗号化PDFなどは復号できないため、Gatewayポリシー側で「暗号化ファイル全般をブロック」する別ルールと組合せるのが定石である。
+- **ペイロードロギングの取り扱い**：マッチしたペイロードを画像付きで保存する機能は、それ自体が機密データの新たな保管点になる。閲覧権限を持つロールを最小化し、アクセスログを別ストレージに集約する運用が必要である。
+- **アドオン契約**：Zero Trust Enterpriseのアドオンであり、Pay-as-you-goから単独でアップグレードできない。導入には商談ベースの契約変更が必要である。
+- **エンドポイント制御の不在**：USBコピー・ローカル印刷・スクリーンショット転送は対象外。エンドポイントDLPと併用する場合は責務分界を明確にしておく。
+
+## 参考リンク
+- Data Loss Prevention：https://developers.cloudflare.com/cloudflare-one/policies/data-loss-prevention/
+- DLP profiles：https://developers.cloudflare.com/cloudflare-one/policies/data-loss-prevention/dlp-profiles/
+- Detection entries（EDM / Fingerprinting / Wordlists）：https://developers.cloudflare.com/cloudflare-one/policies/data-loss-prevention/detection-entries/configure-detection-entries/
+- Cloudflare One llms.txt：https://developers.cloudflare.com/cloudflare-one/llms.txt
+- Terraform Provider（cloudflare_zero_trust_dlp_*）：https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs
+
+---
+参照日: 2026-05-03

--- a/src/content/knowledge/web-development/cloudflare-docs/34-email-security.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/34-email-security.mdx
@@ -1,0 +1,152 @@
+---
+title: "Cloudflare Email Security (Cloudflare One)"
+description: "Microsoft 365 / Google Workspace を中心とした既存メール環境の前段または並走として動作し、AI とグローバル脅威インテリジェンスでフィッシング・BEC・マルウェア・添付ファイル攻撃を配信前または配信後に検出・隔離するクラウド型メールセキュリティサービスである。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 34
+---
+# Email Security (Cloudflare One)
+
+> 注：本記事の Email Security はクラウド型のメールセキュリティ製品（旧 Area 1 Security）であり、独自ドメインのメール転送サービスである **Cloudflare Email Routing**（Tier 4 で扱う予定）とは別物である。前者はフィッシング・BEC・マルウェアからメール受信箱を守るセキュリティ製品、後者はゾーン宛メールを任意の宛先に転送するルーティング機能である。
+
+## 一行サマリ
+Microsoft 365 / Google Workspace を中心とした既存メール環境の前段または並走として動作し、AI とグローバル脅威インテリジェンスでフィッシング・BEC・マルウェア・添付ファイル攻撃を配信前または配信後に検出・隔離するクラウド型メールセキュリティサービスである。
+
+## 解決する課題（Why）
+従来型のセキュアメールゲートウェイ（SEG）は MX を切り替える前段プロキシとして機能してきたが、近年は Microsoft 365 / Google Workspace 標準のフィルタを通り抜ける高度なフィッシング・BEC が増え、SEG だけでは取り切れない領域が広がっている。Cloudflare Email Security は次の課題を解く。
+
+- **BEC（Business Email Compromise）**：実在する取引先・経営層を装った請求書すり替え・偽送金指示など、添付もリンクもない純粋な「文面詐欺」を、文脈解析と送信者の通信パターン学習で検知する。
+- **フィッシング**：URL レピュテーション・ドメイン類似度・ペイロードのレンダリング解析を組合せ、配信前にリンクを評価する。検知率は公称 99.99% を謳う。
+- **添付マルウェア**：サンドボックスで添付を実行・解析し、ゼロデイ／回避型マルウェアも検知する。
+- **配信前検出と配信後修復の両立**：MX 切替で配信前にブロックするだけでなく、API 連携で配信後の受信箱からも遡って隔離（Auto Move）できる。
+- **DMARC 運用負荷**：DMARC レポートの集計・可視化・なりすまし送信の調査をダッシュボードで行える。
+
+## 主要機能（What）
+
+### Pre-delivery vs Post-delivery
+- **Pre-delivery（MX/Inline デプロイ）**：MX レコードを Cloudflare に向け、すべての受信メールが Cloudflare 経由で受信箱に届くようにする。スコア判定によりブロック・隔離・タグ付け・本文書き換え（リンク書き換え、警告バナー追加）まで配信前に行える。リアルタイム保護が可能で、悪性メールはユーザーの目に触れない。
+- **Post-delivery（API デプロイ）**：MX は変更せず、Microsoft Graph API または Google Workspace API 経由で受信箱を監視し、配信済みメールをスキャンする。誤検知時の影響が少なく、導入時の MX 変更による事故リスクがない一方、ユーザーが受信箱で一瞬目にする可能性がある（後述の Auto Move で隔離）。
+
+実運用では「**MX で前段ブロック + API で並走チェックして遅延検知分も後追い隔離**」というハイブリッド構成が推奨される。
+
+### MX デプロイ
+他社 SEG と同じ「MX 切替型」の動作モード。すべてのメールを Cloudflare のエッジで受け、判定後にダウンストリームの Microsoft 365 / Google Workspace / Exchange Online / オンプレ Exchange / 他社メール基盤に転送する。Microsoft 365・Google Workspace に限らず任意のメール基盤に対応する。
+
+### API デプロイ
+- **Microsoft 365**：Microsoft Graph API 経由でテナントに接続し、受信箱を直接監視・操作する。MX 変更は不要。
+- **Google Workspace**：Google Workspace API（および BCC / Journaling）でメッセージコピーを取得しスキャンする。
+- ディレクトリ同期（ユーザー・グループ）が API 連携で行え、ポリシーの宛先指定がしやすい。
+
+### Auto Move
+API デプロイの中核機能。Cloudflare の判定結果（disposition：MALICIOUS / SUSPICIOUS / SPAM / SPOOF / BULK 等）に基づき、受信箱に配信されたメールを自動的に隔離フォルダ・迷惑メール・ゴミ箱へ移動する。判定が後から変わった場合（脅威インテリジェンス更新による再評価）にも遡って受信箱から取り下げる。Microsoft 365 / Google Workspace の双方で利用できる。
+
+### Link Isolation（RBI 連携）
+Email Security はメール内の URL を書き換え、クリック時にもう一度 URL レピュテーションを評価する（Time-of-click protection）。さらに **Cloudflare Browser Isolation** と統合し、疑わしいリンクをユーザーのブラウザに直接届けず、リモートブラウザ内で隔離して描画できる。資格情報窃取ページに対する入力ブロックなどもここで効く。詳細は Browser Isolation 記事を参照。
+
+### DMARC Management
+DMARC / SPF / DKIM のレポート集約とドメインなりすましの可視化、設定不備の検出を提供する。SEG と DMARC 管理ツールを別々に契約していた組織は統合できる。
+
+### マルチチャネル拡張
+メール以外に Slack / Microsoft Teams / SMS / QR コード経由のフィッシングまで対象を広げる方向に進化している（プランによる）。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- Microsoft 365 / Google Workspace を採用しており、標準フィルタ（EOP / Defender P1）を通り抜けるフィッシング・BEC を取りこぼしている組織。
+- 既存 SEG（Proofpoint / Mimecast）からのリプレース。とくに価格と運用負荷の観点で見直したいケース。
+- Cloudflare One 全体（Access / Gateway / CASB / Browser Isolation）を採用しており、URL のクリック後挙動まで含めて統一ポリシーで守りたいケース。
+- 配信後修復（Auto Move）を即日入れたい場合。MX 変更を伴わないため導入が早い。
+- DMARC 運用を内製で抱えており、ツール統合したい組織。
+
+### 適していないシーン
+- メール基盤がオンプレ Exchange のみで、API 連携機構が弱い古い環境。MX デプロイは可能だが、Auto Move 等の旨みは API 連携前提である。
+- 高度な DLP・暗号化メール（S/MIME 強制、PGP 鍵管理）まで含む包括的なメッセージング基盤の置き換えを目的とする場合。Email Security はインバウンド保護に重心がある。
+- 既に Microsoft Defender for Office 365 P2 でほぼ満足しており、追加コストの正当化が難しい組織。
+- Cloudflare アカウントを持たない・Cloudflare 全体への投資意向がない組織（単独製品としても買えるが、エコシステム統合が最大の差別化要因のため）。
+
+## 競合・代替
+
+| 観点 | Cloudflare Email Security | Proofpoint | Abnormal Security | Microsoft Defender for Office 365 | Mimecast |
+|---|---|---|---|---|---|
+| デプロイ形態 | MX / API（M365・Google） | MX 中心、API も対応 | API 専業（M365・Google） | M365 ネイティブ | MX 中心 |
+| Pre-delivery 検出 | 強い（MX/Inline） | 強い（老舗 SEG） | なし（API のみ） | M365 内で動く | 強い |
+| Post-delivery 修復 | Auto Move | あり | 中核機能 | あり（ZAP） | 限定的 |
+| BEC 検出アプローチ | AI＋脅威インテリ＋通信パターン | ルール＋AI | 行動分析特化（ML） | Defender ML | ルール＋AI |
+| Cloudflare One 統合 | 完全統合（Browser Isolation・Gateway） | なし | なし | Microsoft 365 内統合 | なし |
+| 強み | 価格・統合・99.99% を謳う検知率 | 機能網羅性・大企業導入実績 | BEC の検知精度に定評 | M365 とのネイティブ統合・追加コスト最小 | アーカイブ・継続性に強い |
+| 弱み | DLP・アーカイブは別領域 | 価格・UI の重さ | Pre-delivery を持たない | Microsoft 単一ベンダーリスク | UI と AI 検知精度で後発に押される |
+
+Abnormal Security は API 専業の比較対象としてよく挙がる。Cloudflare Email Security は「MX も API も両方できる」点と「Browser Isolation との時刻クリック保護統合」が独自性となる。
+
+## 料金
+旧 Area 1 ライセンスを引き継ぎ、現在は **Cloudflare Zero Trust（Cloudflare One）の Enterprise プラン**として提供される。
+
+- 単独製品としての契約と、Cloudflare One スイートにバンドルした契約の双方が可能である。
+- 公開料金表は提供されておらず、ユーザー数・受信メールボリューム・追加オプション（PhishGuard マネージドサービス、Browser Isolation 統合、DLP）に応じた個別見積もりとなる。
+- 参考価格帯：1 ユーザーあたり月額数ドル〜 USD 二桁前半が一般的なレンジ（公式公表値ではなく、競合 SEG と同等帯）。
+- **PhishGuard**：Cloudflare のセキュリティアナリストが顧客テナントを監視・脅威ハンティングを代行するマネージドアドオン。中堅企業で SOC 機能が薄い場合の選択肢。
+- Free / Pay-as-you-go プランは存在しない。Access や Gateway と異なり「無料 50 ユーザー」のような枠はない点に注意。
+
+## CLI / IaC 操作例
+本機能は Cloudflare ダッシュボード（Zero Trust → Email Security）からの操作が中心であり、Terraform Provider にもまだ専用の `cloudflare_email_security_*` リソースは整備されていない（v5 時点）。API 連携と直接 REST API 呼び出しが現実解である。
+
+### 管理コンソールフロー（Microsoft 365 / API デプロイ）
+```
+1. Zero Trust ダッシュボード → Email Security → Settings → Domains
+2. 「Add domain」で保護対象ドメインを登録
+3. 「Connect Microsoft 365」を選び、グローバル管理者アカウントで OAuth 認可
+   - Microsoft Graph に対するメールスキャン権限を付与
+4. ディレクトリ同期（ユーザー・グループ）が自動で開始される
+5. Detection settings で disposition ごとの自動アクション（Auto Move 先）を設定
+   - MALICIOUS → Junk Email
+   - SUSPICIOUS → Quarantine フォルダ
+   - SPOOF → タグ付けのみ など
+6. Impersonation Registry に保護対象の役員・取引先ドメインを登録
+7. 数日のラーニング期間後にエンフォースモードへ切替
+```
+
+### Google Workspace（API デプロイ）
+```
+1. Google Workspace 管理コンソールでサービスアカウントとドメイン全体委任を設定
+2. Cloudflare 側に JSON キーをアップロード、または OAuth 連携を実施
+3. Gmail API のスコープ（gmail.modify 相当）を委任
+4. 以降の運用は M365 と同様
+```
+
+### MX デプロイ（共通）
+```
+1. Cloudflare 側で受信用ホスト名（mailstream-*.cloudflare.net 系）を発行
+2. 自社ドメインの MX レコードを Cloudflare 提供ホストに変更
+3. ダウンストリーム（M365 / Google Workspace）の受信制限で
+   Cloudflare 由来の IP レンジのみ許可するようインバウンドコネクタを設定
+4. SPF に Cloudflare のインクルードを追加
+```
+
+### REST API 例（Detection settings 取得）
+```bash
+curl -H "Authorization: Bearer $CF_API_TOKEN" \
+  "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/email-security/settings/detections"
+```
+
+将来的に Terraform リソースが追加された場合は IaC 化を再検討するとよい。当面はテナント設定をスクリプト化（API 経由）して GitOps 的に管理するのが現実解である。
+
+## 制限・注意点
+- **Terraform 対応が薄い**：Access や Tunnel と異なり、IaC 化の選択肢が限定的である。設定はダッシュボード／API での管理が前提となる。
+- **Auto Move は API デプロイ前提**：MX デプロイ単独では「配信前ブロック」しかできない。配信後の遡及隔離が欲しいなら API 連携を併設する必要がある。
+- **ディレクトリ同期の権限**：Microsoft Graph や Google Workspace API への強い権限を Cloudflare に渡す。最小権限で済むかをセキュリティチームと事前にレビューすること。
+- **MX デプロイ時のフェイルオープン挙動**：上流障害の波及を避ける設計だが、可用性 SLO はメール基盤本体（M365 / Google）と Cloudflare の双方を見て評価する必要がある。
+- **誤検知運用**：BEC 系の AI 判定は文面文脈に依存するため、初期は学習期間として monitor モードで運用し、業務メール（社内通称、略語、外部協力会社の独特な署名）に合わせてチューニングが必要である。
+- **DLP・暗号化送信**：本製品は受信側保護が中心であり、送信メールの DLP・暗号化（PGP / S/MIME）は別領域である。Cloudflare Data Loss Prevention や他社製品との組合せが必要となる。
+- **Cloudflare Email Routing と混同しない**：契約・課金・管理画面が別系統である。
+- **Free 枠なし**：Cloudflare One の他コンポーネントと違い、本機能は商用契約前提で評価期間（PoC）以外で無料利用はできない。
+
+## 参考リンク
+- Email Security 概要：https://developers.cloudflare.com/cloudflare-one/email-security/
+- 製品ページ（マーケティング）：https://www.cloudflare.com/zero-trust/products/email-security/
+- 旧 Area 1 ドキュメント：https://developers.cloudflare.com/email-security/
+- Cloudflare One llms.txt：https://developers.cloudflare.com/cloudflare-one/llms.txt
+- Browser Isolation（リンク隔離連携の文脈）：https://developers.cloudflare.com/cloudflare-one/policies/browser-isolation/
+
+---
+参照日: 2026-05-03

--- a/src/content/knowledge/web-development/cloudflare-docs/35-gateway.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/35-gateway.mdx
@@ -1,0 +1,172 @@
+---
+title: "Cloudflare Gateway (Cloudflare One)"
+description: "ユーザー・デバイスから出るDNS / HTTP / L3-L4トラフィックをCloudflareエッジに集約し、宛先・コンテンツ・アイデンティティ・デバイスポスチャを軸に評価して通す／止める／書き換えるSWG（Secure Web Gateway）兼DNSフィルタである。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 35
+---
+# Gateway (Cloudflare One)
+
+## 一行サマリ
+ユーザー・デバイスから出るDNS / HTTP / L3-L4トラフィックをCloudflareエッジに集約し、宛先・コンテンツ・アイデンティティ・デバイスポスチャを軸に評価して通す／止める／書き換えるSWG（Secure Web Gateway）兼DNSフィルタである。
+
+## 解決する課題（Why）
+社内端末を境界の中に閉じ込めるレガシープロキシは、リモートワーク・SaaS中心の業務形態とは相性が悪い。ローカルブレイクアウト後のトラフィックを誰もログしていない、悪性ドメインへのDNS解決を止められない、退職者の端末から社外ネットワークへ機密ファイルが流れても気づけない、といった盲点が常態化している。Cloudflare Gatewayはこれをエッジ集約型のSASEモデルで置き換え、以下を解決する。
+
+- 全社のDNS / HTTP / L4トラフィックを単一の制御点で監視・制御。
+- マルウェア配布ドメイン・フィッシングサイト・カテゴリ違反サイトの遮断。
+- TLSを復号した上でのアンチウイルス・DLP・テナント制御・ブラウザ分離。
+- WARP配下デバイスからインターネット／プライベートネットワーク双方への通信ポリシー統一。
+- 監査・インシデント調査に耐えるリクエスト単位のログ保持。
+
+## 主要機能（What）
+
+### DNS フィルタ
+Cloudflare Resolver（1.1.1.1）を経由するDNSクエリをポリシー判定して解決をブロック・上書きする層である。WARPなしでも、DNS Locations（拠点IP登録）やルーターのDNS設定だけで導入できるため、Gatewayのなかで最も導入障壁が低い。
+
+- **Action**：Allow / Block / Override / Safe Search / YouTube Restricted Mode。
+- **Selector**：Domain / Host / Content Categories / Security Categories / Resolved IP / Source IP / Location / Query Record Type / User Email / User Group / Country。
+- **Content Categories / Security Categories**：CloudflareのIntelligenceフィードに基づく分類（成人向け / ギャンブル / マルウェア / フィッシング / 新規登録ドメイン 等）でドメイン群を一括制御。
+- **DNS Locations**：固定IPの拠点はそのIPからのクエリにポリシーを紐付け、ローミング端末はWARPで識別する。
+
+### HTTP インスペクション
+WARP経由でTLSを復号し、HTTP/HTTPSペイロード単位の制御を行う層である。Cloudflareルート証明書、または企業所有の証明書を端末に配布することが前提となる。
+
+- 主要機能：URL / Host / File Type ブロック、Anti-Virus（アップロード・ダウンロードのスキャン）、DLP（クレジットカード番号・社内識別子等の流出検知）、Tenant Control（自社M365テナントのみ許可など）、Browser Isolation（リモートブラウザ隔離）、Quarantine、カスタムBlock Page。
+- Selector：URL / Domain / Host / HTTP Method / File Type / Application / Content Categories / Country / Source IP / User / Group / Device Posture。
+- Browser Isolation（RBI）と組合せると、未分類サイトを「読めるが貼り付け・ダウンロード不可」のRead-onlyモードで開く運用が可能。
+
+### Network ポリシー（L3-L4）
+HTTPに収まらないトラフィック（SSH / RDP / SMTP / 任意のTCP・UDP）を制御する層である。Magic WAN / GRE / IPSec / WARPで集約したパケットをIP・ポート・プロトコル・SNI単位で評価する。
+
+- Action：Allow / Block / Network Override（宛先IP・ポートの書き換え）。Audit SSHはDeprecatedで、SSH監査はAccess for Infrastructureに移行している。
+- Selector：Source/Destination IP・Port、Protocol、SNI、Application、Content Categories、Virtual Network、User、Group、Device Posture。
+- Cloudflare Tunnelで公開した社内ネットワーク（Private Network）への到達制御も同じレイヤで書ける。
+
+### WARP クライアント
+Gatewayのフル機能（HTTP復号・Device Posture・User identity）を引き出す前提となるエンドポイントエージェントである。MDM配布（Intune / Jamf / Kandji）でデバイス登録し、Splitトンネルで「会社が見たいトラフィック」だけをCloudflareに送る運用が現実的である。
+
+- Device Postureチェック：OSバージョン / ディスク暗号化 / EDR稼働 / 証明書存在 / シリアルナンバーリスト など。
+- User identity：Cloudflare Accessで認証したIdPユーザーをそのままGatewayポリシーのSelectorに利用できる。
+- Split Tunnel：Include / Excludeモードで、業務SaaSのみ流す／プライベート帯域は除外、といった設計が可能。
+
+### Logs
+すべてのDNS / Network / HTTPリクエストはGateway Activity Logに記録される。Logpushを使えばS3 / R2 / Splunk / Datadog / Sentinelに継続転送でき、SIEM連携が成立する。Free / Standardはダッシュボード上での保持期間が短く、長期保管はLogpush（Enterprise）が前提となる。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- VPN撤廃・SASE移行の文脈で、SWG / DNSフィルタを単一ベンダーで揃えたい中小〜中堅企業。
+- 「悪性ドメインを止めたい」だけが先に欲しいケース（DNS Locations + Content Categoriesで即日導入）。
+- 全社員にWARPを配り、Tunnelで社内アプリも公開している組織。Access（誰が）+ Tunnel（どこへ）+ Gateway（何を）が一気通貫で書ける。
+- Cloudflareエッジを既にCDN / WAFで使っている組織にとって、ログ・アイデンティティ・証明書配布の運用基盤を流用できる。
+- 50ユーザー以下のスタートアップで、コストゼロでSWGを導入したいケース。
+
+### 適していないシーン
+- ZscalerやNetskopeに既に大規模投資済みで、CASB / SSPM / Advanced DLP / UEBAなどフル機能を業務要件として使い倒している組織。CloudflareのDLP・CASB相当機能はEnterprise領域では追従途上である。
+- オンプレミスのレガシーWindowsアプリ群が、TLS復号と相性の悪い独自プロトコルで通信しているケース。HTTPインスペクションは個別にBypass設計が必要。
+- WARPを配布する運用体制（MDM・端末ポリシー）がない組織。DNSフィルタ単独運用で止めるのが現実解。
+- 政府・防衛系で「特定国の事業者にトラフィックを集約してはならない」という制約がある場合。
+
+## 競合・代替
+
+| 観点 | Cloudflare Gateway | Zscaler ZIA | Netskope SWG | Cisco Umbrella |
+|---|---|---|---|---|
+| 出自 | CDN / Anycastネットワーク | 純血SASE / SWG専業 | CASBから拡張したSSE | DNSフィルタ（旧OpenDNS）から拡張 |
+| DNSフィルタ | 標準（無料枠あり） | 別モジュール | 別モジュール | 本職 |
+| HTTPインスペクション | 標準・TLS復号対応 | 高機能・成熟 | 高機能・成熟 | SIG add-on |
+| L4 / Network | 統合（Magic WAN連携） | 専用ZPA / Cloud Connector | NewEdgeで対応 | SIG / Tunnel |
+| CASB / Advanced DLP | 追従途上 | 強力 | 最強クラス | 中位 |
+| Browser Isolation | 標準同梱（CloudflareのRBI） | 別ライセンス | 別ライセンス | 別ライセンス |
+| 価格 | 50ユーザー無料 / $7〜 | 高価（要見積もり） | 高価（要見積もり） | $2.20〜（DNS Essentials） |
+| 強み | エッジ統合・Access/Tunnelとの結合・無料枠 | エンタープライズでの成熟・運用ノウハウ | データ中心SSE・CASB成熟度 | DNSフィルタの精度・既存Cisco資産との相性 |
+| 弱み | 大規模CASB / UEBA要件は弱い | 高コスト・複雑 | 高コスト・PoP網はCloudflareに劣る | DNS主体でHTTP / L4は後発 |
+
+CloudflareはAccess / Tunnel / Gateway / Browser Isolation / DLPを単一プレーンで束ねるアーキテクチャ的なシンプルさが最大の差別化要因である。逆にZscaler / Netskope水準の成熟したCASB・SSPMが業務要件の中核なら、現時点では併用または代替が妥当である。
+
+## 料金
+
+- **Free（Zero Trust Free）**：50ユーザーまで。DNSフィルタ・HTTPインスペクション・Network ポリシー・WARP・基本Browser Isolation（限定的）が含まれる。Activity Logのダッシュボード保持期間は短い。
+- **Standard（Pay-as-you-go）**：$7/ユーザー/月程度から、ユーザー数に応じた従量課金。51ユーザー目以降が課金対象、Free機能の上限拡張・SLA向上が中心。
+- **Enterprise**：年間契約。Logpush、Advanced DLP、CASB、SCIM強制再評価、User Risk Score、Magic WAN統合、専用PoP・専用IP、サポートSLAなど。SaaS全社展開や監査要件のある組織はここを前提に設計する。
+
+Gateway / Access / Tunnelは同じZero Trustライセンスにバンドルされており、「Gatewayだけ」「Accessだけ」を別契約する形にはならない。50ユーザー無料枠を最大限活かし、必要になった機能（Logpush・DLP）でEnterpriseに上がる、という段階導入が現実的である。
+
+## CLI / IaC 操作例
+
+### Terraform（cloudflare provider v5）
+```hcl
+# DNS: マルウェア・フィッシングカテゴリをブロック
+resource "cloudflare_zero_trust_gateway_policy" "block_malware_dns" {
+  account_id  = var.account_id
+  name        = "Block malware/phishing (DNS)"
+  description = "Security categories block at DNS layer"
+  precedence  = 1000
+  enabled     = true
+  action      = "block"
+  filters     = ["dns"]
+  traffic     = "any(dns.security_category[*] in {68 80 178 83})"
+}
+
+# HTTP: 業務時間外にSNS系をBrowser Isolationへ
+resource "cloudflare_zero_trust_gateway_policy" "isolate_social" {
+  account_id  = var.account_id
+  name        = "Isolate social media"
+  precedence  = 2000
+  enabled     = true
+  action      = "isolate"
+  filters     = ["http"]
+  traffic     = "any(http.request.uri.content_category[*] in {5})"
+  identity    = "any(identity.groups.name[*] in {\"general-staff\"})"
+}
+
+# Network: 社外SSHを原則ブロック、踏み台のみ許可
+resource "cloudflare_zero_trust_gateway_policy" "block_egress_ssh" {
+  account_id = var.account_id
+  name       = "Block egress SSH"
+  precedence = 3000
+  enabled    = true
+  action     = "block"
+  filters    = ["l4"]
+  traffic    = "net.dst.port == 22 and not(net.dst.ip in {203.0.113.10})"
+}
+```
+
+### WARP デバイス登録（MDM経由の例）
+```bash
+# macOS（Jamf / Kandjiでconfig profile配布が本筋。手動検証用）
+sudo warp-cli registration new --team-name acme
+
+# 接続・ステータス確認
+warp-cli connect
+warp-cli status
+
+# Gateway DoH接続のみ使う場合（HTTP/L4は流さない）
+warp-cli mode doh
+```
+
+### DNS Location（拠点IPベース）の登録
+オフィス固定IPからのDNSクエリにポリシーを当てる場合は、Zero Trustダッシュボード「Gateway → DNS Locations」で拠点IPv4/IPv6を登録するか、APIで`POST /accounts/{id}/gateway/locations`を叩く。
+
+## 制限・注意点
+- HTTPインスペクションはCloudflareルート証明書（または持ち込み証明書）の端末配布が前提である。BYOD・非管理端末ではDNS / Networkまでに留めるのが現実解。
+- 一部アプリ（Apple Push、銀行系、証明書ピン留めSDK）はTLS復号と相性が悪く、ホスト単位でDo Not Inspect（バイパス）設定が必要。
+- Logpushによる長期ログ転送はEnterprise機能であり、Free / Standardはダッシュボード保持に依存する。コンプライアンス要件があるなら最初からEnterprise前提で設計する。
+- Network ポリシーのprecedence管理はTerraform provider v4にハッシュ計算起因の制約があり、v5への移行が推奨される。
+- Cloudflare AccessやTunnelは前提として別記事を参照。Gatewayは「外向きトラフィックの制御」、Accessは「内向きアプリへの認可」、Tunnelは「内部の到達経路」と役割が分かれている。
+- 50ユーザーFreeはAccess / Gateway / Tunnel合算の制限であり、Gateway単独の枠ではない点に注意。
+- WARPのSplit Tunnelを誤設定すると業務SaaSがCloudflareを経由しない（＝ポリシーが効かない）状態になる。Includeモード運用とテストが必須。
+
+## 参考リンク
+- Cloudflare Gateway Policies：https://developers.cloudflare.com/cloudflare-one/policies/gateway/
+- DNS Policies：https://developers.cloudflare.com/cloudflare-one/policies/gateway/dns-policies/
+- HTTP Policies：https://developers.cloudflare.com/cloudflare-one/policies/gateway/http-policies/
+- Network Policies：https://developers.cloudflare.com/cloudflare-one/policies/gateway/network-policies/
+- WARP client：https://developers.cloudflare.com/cloudflare-one/connections/connect-devices/warp/
+- Zero Trust Plans：https://www.cloudflare.com/plans/zero-trust-services/
+- Terraform `cloudflare_zero_trust_gateway_policy`：https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_gateway_policy
+- Cloudflare One llms.txt：https://developers.cloudflare.com/cloudflare-one/llms.txt
+
+---
+参照日: 2026-05-03

--- a/src/content/knowledge/web-development/cloudflare-docs/40-api-shield.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/40-api-shield.mdx
@@ -1,0 +1,189 @@
+---
+title: "Cloudflare API Shield"
+description: "OpenAPIスキーマ・学習済みスキーマ・mTLS・JWT検証・シーケンス分析を組み合わせ、Web全般を見るWAFでは捉えきれない「APIに固有の脆弱性と濫用」をエッジで止めるAPI専用のセキュリティレイヤである。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 40
+---
+# API Shield
+
+## 一行サマリ
+OpenAPIスキーマ・学習済みスキーマ・mTLS・JWT検証・シーケンス分析を組み合わせ、Web全般を見るWAFでは捉えきれない「APIに固有の脆弱性と濫用」をエッジで止めるAPI専用のセキュリティレイヤである。
+
+## 解決する課題（Why）
+APIエンドポイントは「正規ユーザーが正しい認証情報で、ただし想定外の使い方をする」攻撃に晒される。OWASP API Top 10が挙げるBOLA（Broken Object Level Authorization）、認証不備、過剰なデータ露出、リソース消費の濫用などは、シグネチャベースのWAFが得意とする「明らかに悪意あるペイロード」とは性質が異なる。さらに、開発チームが把握していないShadow APIや、廃止したはずのZombie APIが本番に残り続けるガバナンス問題も常態化している。API Shieldはこれをエッジで以下のように解く。
+
+- 通過する全リクエストを観測してShadow / Zombie APIを自動検出し、棚卸しを継続的に維持する。
+- OpenAPIスキーマ（持ち込みまたは学習）に違反するリクエストをエッジで遮断する。
+- mTLSとJWT検証で「呼び出し元の正当性」をオリジン到達前に保証する。
+- BOLA / Volumetric Abuse / Sequence Mitigationでビジネスロジックを悪用する濫用を検出・抑制する。
+- GraphQLの深さ・複雑度を制御し、単一クエリでのリソース枯渇攻撃を防ぐ。
+
+WAFは「Webアプリ全般のシグネチャ防御」、API ShieldはAPIに特化した「振る舞い・契約・アイデンティティ防御」と役割が分かれており、両者は併用が前提である。
+
+## 主要機能（What）
+
+### API Discovery
+通過トラフィックからAPIエンドポイントを自動抽出し、Endpoint Managementに登録する機能である。検出方法は2系統あり、ヒューリスティック検出（パスパターン・コンテンツタイプから推定）と、Session Identifierベースの検出（Cookieやヘッダで識別したセッションを軸にエンドポイントを集計）が併用される。Session Identifierを設定するほうが精度が高く、認証後にしか露出しない管理API・内部APIまで拾える。Shadow API / Zombie APIの可視化はAPI Shield導入の最初のROIになる。
+
+### Schema Validation
+OpenAPI v3.0/v3.1のスキーマに基づいてリクエストを検証し、違反したものをLog / Block / Override Status Codeで処理する。スキーマの入手経路は2つ。
+
+- **Uploaded Schema**：開発チームが管理しているOpenAPIファイルをそのままアップロードする。CIから差し替えれば「契約=防御ルール」が一致する。
+- **Learned Schema**：API Shieldが通過トラフィックから自動生成するスキーマ。OpenAPI管理が追いついていない既存APIに対して、まずLearnedで叩き台を作り、エクスポートして開発チームに正本化させる運用が現実解。
+
+検証対象はパス・メソッド・クエリパラメータ・ヘッダ・リクエストボディ・型・必須項目まで広く、未知のパラメータや型不一致を弾く。
+
+### mTLS（Mutual TLS）
+Cloudflareが管理するCA、または持ち込みCAでクライアント証明書を発行し、エッジで検証する機能である。B2B API、IoTデバイス、モバイルアプリのバックエンドAPIなど、「呼び出し元が限定された機械」に対する正当性検証として使う。Endpoint Management上で「mTLS必須エンドポイント」を指定し、Cloudflare Rulesと組み合わせて未提示・無効証明書のリクエストをブロックする。mTLS機能自体はEnterprise以外の顧客にも開放されている例外領域である。
+
+### JWT Validation
+リクエストに付与されたJWTをエッジで検証し、署名・有効期限・iss / aud / sub等のクレームを評価する。Token Configurationsで複数のIdP（Auth0 / Cognito / Okta / Firebase Auth等のJWKS）を登録し、エンドポイントごとに「どの発行者を許容するか」を縛れる。さらにJWTのclaim値をTransform RulesやRulesetでヘッダに伝搬させ、オリジン側で再検証せずにユーザーIDを取り出す構成が可能。Authentication Postureと併用すると「JWT必須エンドポイントなのに無認証で叩かれている」異常を検知できる。
+
+### Sequence Mitigation / Sequence Analytics
+APIエンドポイントの「呼ばれる順序」をシーケンスとして観測する機能である。たとえば「/login → /transfer」のように特定の順序でしか呼ばれないはずのエンドポイントが、ボットによる総当たり的呼び出しでスキップされた場合に検出・遮断できる。Sequence Analyticsで観測パターンを可視化し、Sequence Mitigationでルール化する流れになる。OWASP API Top 10のうち「ビジネスロジックの濫用」を狙い撃ちする数少ない実装である。
+
+### BOLA Protection
+Broken Object Level Authorization（他ユーザーのリソースID指定で他人のデータを取得する古典的脆弱性）の兆候を検出する。エンドポイント別に「同一ユーザーが多様なオブジェクトIDを連続で叩いている」「通常分布を外れたID走査が起きている」といったパターンを統計的に拾い、Endpoint Insightsとして提示する。Block化はSequence MitigationやRate Limiting Rulesと組み合わせて実装する。
+
+### Volumetric Abuse Detection
+エンドポイントごとに「セッション単位 / IP単位 / JWT sub単位」で正常リクエストレートを学習し、外れ値を検出する機能である。WAFのRate Limiting Rulesが「閾値を人間が決める」のに対し、こちらは「正常分布をエッジが自動学習する」。クレデンシャルスタッフィング、在庫買い占めボット、価格スクレイピングなどの検出に向く。検出結果から推奨Rate Limit Ruleを生成できる。
+
+### GraphQL Malicious Query Protection
+単一GraphQLクエリでリソースを枯渇させる攻撃（深いネスト、巨大エイリアス、循環フラグメント）を、クエリの深さ（depth）とサイズ（size）の上限で制限する機能である。GraphQLはRESTと違って単一エンドポイントで任意のクエリを受け付けるため、従来のURL単位レート制限が効かない。API ShieldはGraphQL固有の構造解析でこのギャップを埋める。
+
+### Endpoint Management / Labels / Routing
+検出・登録された全エンドポイントに対し、Label（PII含む / 認証必須 / 内部用 等のメタ情報）を付与し、それを軸にポリシー・分析・アラートを束ねる。Routingでオリジンの振り分け、Developer Portal機能で社内向けAPIカタログの公開も可能。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- 既にCloudflare WAF / CDNを使っており、API向けに別ベンダーの専用ツールを新規導入する前に、同一プレーンで一段上げたい組織。
+- OpenAPIスキーマを開発チームが管理しているが、本番に「契約として」適用する仕組みがない組織。Schema ValidationでCI連携が一気に成立する。
+- B2B API、フィンテック、医療情報API、IoTバックエンドなどmTLSが業務要件に入る組織。
+- 「Shadow API / Zombie APIがどれだけあるか分からない」状態のレガシーAPI資産を抱える組織。Discovery単独でもROIが出る。
+- GraphQL APIを本番で公開しており、深さ・複雑度起因のDoSが懸念される組織。
+
+### 適していないシーン
+- Salt Security / Noname / Traceableなど純血API Securityベンダーを既に導入し、ML異常検知・E2Eトレーシング・OWASP API Top 10ダッシュボードを業務として使い倒している組織。API Shieldの分析深度はまだ追従途上である。
+- API流量がCloudflareエッジを通っていない（オンプレ / 別CDN / プライベート閉域）組織。Magic Transit / Tunnel経由で集約しない限り効かない。
+- Enterprise契約を持たないPro / Business顧客。Endpoint ManagementとmTLSを除く中核機能は事実上Enterprise add-onである。
+- 単純なREST APIにRate Limitingを足したいだけのケース。WAF Rate Limiting Rulesで足りる。
+
+## 競合・代替
+
+| 観点 | Cloudflare API Shield | Salt Security | Noname Security | 42Crunch | Traceable | AWS WAF + API Gateway | Kong | Apigee |
+|---|---|---|---|---|---|---|---|---|
+| 出自 | CDN / WAFエッジ統合 | 純血API Security（ML中心） | 純血API Security（Discovery中心） | OpenAPI契約セキュリティ専業 | API分散トレース起点 | クラウドWAF + マネージドAPI GW | OSS APIゲートウェイ | エンタープライズAPI管理 |
+| 配置 | エッジ（インライン） | アウトオブバンド + インライン | アウトオブバンド + インライン | CIシフトレフト + ランタイム | エージェント / アウトオブバンド | クラウド内インライン | インライン（自社ホスト可） | インライン |
+| Discovery | ヒューリスティック + Session ID | 高精度ML | 高精度・Discoveryが本職 | スキーマ起点 | 分散トレース起点 | 限定的 | 限定的 | 限定的 |
+| Schema Validation | OpenAPI Upload + Learned | 学習中心 | 学習中心 | 最強クラス（OpenAPI契約専業） | あり | 限定的 | あり | あり |
+| BOLA / Logic Abuse | あり（エッジ統計） | 強み（MLベース） | あり | 限定的 | 強み（トレース解析） | 弱い | 弱い | 弱い |
+| mTLS / JWT | 標準 | 検出のみ | 検出のみ | 検出のみ | 検出のみ | 別構成 | 標準 | 標準 |
+| GraphQL保護 | depth / size制限 | あり | あり | OpenAPIスコープ外 | あり | 弱い | プラグイン | プラグイン |
+| 価格 | Enterprise add-on | 高価（要見積） | 高価（要見積） | OpenAPI規模に応じた中位 | 高価（要見積） | AWS従量 | OSS無料〜Enterprise | 高価 |
+| 強み | エッジ統合・WAF/Bot/CDNと同一プレーン | 業界最先端の検出深度 | Discoveryと棚卸しの完成度 | OpenAPIガバナンスのCI統合 | 分散環境の可視化 | AWS資産との相性 | 自社運用の自由度 | エンタープライズ管理機能 |
+| 弱み | 検出深度は専業に劣る | 高コスト・運用負荷 | 高コスト・新興ベンダー | ランタイム検出は弱い | 高コスト・導入重い | API特化機能は弱い | セキュリティは後付け | 重厚・高価 |
+
+API Shieldの差別化はWAF / Bot Management / Cache / Workers / mTLSが同一プレーンで束なる点に尽きる。逆にOWASP API Top 10をフルカバーするML検出・E2Eトレース・SOC運用ノウハウまで業務要件にあるなら、Salt / Noname / Traceableの併用または代替が妥当である。
+
+## 料金
+
+- **Endpoint Management / Schema Validation / mTLS**：全プランの顧客が利用可能（mTLSはCloudflare管理CAで証明書発行可）。Pro / Businessでも一部機能には触れる。
+- **API Discovery（Session ID版）/ JWT Validation / Sequence Mitigation / Sequence Analytics / BOLA Protection / Volumetric Abuse Detection / GraphQL Protection / Schema Learning**：Enterprise add-on。Application Security Advanced / API Shieldライセンスのいずれかが必要。
+- **非契約Preview**：Enterprise顧客向けに、API Shield機能の一部を従量課金なしで試用できる枠が提供される。本番採用前のPoCはここで行うのが定石。
+- **JDCloud顧客には提供されない**地理的制約がある。
+
+WAF / Bot Management / DDoSとは別ラインで課金されるため、見積もりはApplication Security全体のバンドル価格として営業に出させるのが現実的である。
+
+## CLI / API 例
+
+### OpenAPIスキーマのアップロード（Schema Validation）
+```bash
+# ZONE_ID とAPI Tokenを準備し、OpenAPI v3スキーマを登録
+curl -X POST \
+  "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/schema_validation/schemas" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: multipart/form-data" \
+  -F "file=@./openapi.yaml" \
+  -F "kind=openapi_v3" \
+  -F "name=payments-api-v1" \
+  -F "validation_enabled=true"
+
+# Schema Validation設定（違反時のデフォルト動作をBlockに）
+curl -X PUT \
+  "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/schema_validation/settings" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"validation_default_mitigation_action":"block","validation_override_mitigation_action":null}'
+```
+
+### mTLSクライアント証明書の発行（Cloudflare管理CA）
+```bash
+# Cloudflare管理CAからクライアント証明書を発行
+curl -X POST \
+  "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/client_certificates" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "csr": "'"$(cat client.csr | sed ':a;N;$!ba;s/\n/\\n/g')"'",
+    "validity_days": 365
+  }'
+
+# mTLS Hostname設定（特定ホスト名でクライアント証明書を必須化）
+curl -X POST \
+  "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/access/certificates/settings" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"settings":[{"hostname":"api.example.com","client_certificate_forwarding":true,"china_network":false}]}'
+```
+
+### JWT Token Configurationの登録
+```bash
+# JWKSエンドポイントを指定してToken Configを作成
+curl -X POST \
+  "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/api_gateway/token_configurations" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "auth0-prod",
+    "credential_location": "authorization_header_bearer",
+    "token_sources": [{"jwks_uri":"https://acme.auth0.com/.well-known/jwks.json"}]
+  }'
+```
+
+### 検出済みエンドポイント一覧の取得（Discovery結果）
+```bash
+curl -X GET \
+  "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/api_gateway/discovery/operations?state=review" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}"
+```
+
+## 制限・注意点
+- 中核機能（Discovery Session ID / JWT / Sequence / BOLA / Volumetric / GraphQL / Schema Learning）はEnterprise add-onである。Pro / BusinessではEndpoint Management・mTLS・Uploaded Schema Validationまでに限定される。
+- Schema Validationの精度はOpenAPIスキーマの品質に依存する。型定義が雑なスキーマをアップロードすると誤遮断が起きるため、最初はLog Onlyで運用ログを観測し、段階的にBlockへ昇格する手順が必須。
+- Learned Schemaは観測トラフィックに依存するため、低頻度エンドポイントや認証後にしか呼ばれないエンドポイントは学習が遅い。Session Identifier設定とセットでないと精度が出ない。
+- mTLSはエッジ-クライアント間の検証であり、エッジ-オリジン間（Authenticated Origin Pulls）とは別機能。両方を要件として整理すること。
+- JWT Validationは署名・期限・claim一致までで、認可ロジック（このユーザーがこのリソースを操作してよいか）はオリジン側責務。BOLAはこの認可漏れを統計的に検出するに過ぎず、根本対策はオリジン側の修正である。
+- Sequence MitigationはAPI Shieldが「正常な順序」を観測できているエンドポイント群でのみ有効。新規ローンチAPIには学習期間が必要。
+- GraphQL保護はdepth / sizeまでで、クエリコストベース（フィールドごとの重み付け）の制限は本機能では未対応。重い実装はApolloレベルでのcomplexity制御も併用する。
+- API Shieldの分析画面はWAF / Bot Managementと別UIに分かれており、APIに関するシグナルだけを見るには複数ダッシュボードを行き来する必要がある。
+- Cloudflareエッジを通らないAPIには一切効かない。マルチCDN・直接到達経路がある場合は、API Shield配下に統一する設計が前提となる。
+
+## 参考リンク
+- API Shield Overview：https://developers.cloudflare.com/api-shield/
+- Security Features：https://developers.cloudflare.com/api-shield/security/
+- Management and Monitoring：https://developers.cloudflare.com/api-shield/management-and-monitoring/
+- Schema Validation：https://developers.cloudflare.com/api-shield/security/schema-validation/
+- mTLS：https://developers.cloudflare.com/api-shield/security/mtls/
+- JWT Validation：https://developers.cloudflare.com/api-shield/security/jwt-validation/
+- Sequence Mitigation：https://developers.cloudflare.com/api-shield/security/sequence-mitigation/
+- BOLA Protection：https://developers.cloudflare.com/api-shield/security/bola-protection/
+- Volumetric Abuse Detection：https://developers.cloudflare.com/api-shield/security/volumetric-abuse-detection/
+- GraphQL Malicious Query Protection：https://developers.cloudflare.com/api-shield/security/graphql-protection/
+- API Shield API（Cloudflare API Reference）：https://developers.cloudflare.com/api/operations/api-shield-api-discovery-retrieve-discovered-operations-on-a-zone
+- API Shield llms.txt：https://developers.cloudflare.com/api-shield/llms.txt
+
+---
+参照日: 2026-05-04

--- a/src/content/knowledge/web-development/cloudflare-docs/41-argo-smart-routing.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/41-argo-smart-routing.mdx
@@ -1,0 +1,141 @@
+---
+title: "Cloudflare Argo Smart Routing"
+description: "オリジンへ向かうトラフィックを、Cloudflareが自社網内で観測しているリアルタイムの遅延・パケットロス・輻輳情報に基づいて経路選定し、BGPの「最短ホップ」よりも体感的に速い経路でオリジンに届けるエッジ層のオーバーレイルーティングサービスである。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 41
+---
+# Argo Smart Routing
+
+## 一行サマリ
+オリジンへ向かうトラフィックを、Cloudflareが自社網内で観測しているリアルタイムの遅延・パケットロス・輻輳情報に基づいて経路選定し、BGPの「最短ホップ」よりも体感的に速い経路でオリジンに届けるエッジ層のオーバーレイルーティングサービスである。
+
+## 解決する課題（Why）
+インターネットの基本ルーティングプロトコルであるBGPは、AS間の到達性と経路ポリシーを成立させることが目的であり、遅延・ジッタ・パケットロスといった「実効的な速さ」を最適化する仕組みを持たない。結果として、AS数が少ない（ホップ数が短い）経路が選ばれても、そのASがピーク時間帯に輻輳していればRTTは悪化する。さらに以下のような構造的な問題が常態化している。
+
+- ピアリング先のトランジットが混雑し、特定リージョン⇔オリジン間だけ夜間に遅くなる。
+- 海底ケーブル障害でルートが切り替わった際、BGP収束まで数十秒〜数分のロスが発生する。
+- DSR（直接サーバ応答）的なIP Anycastだけでは、最寄りエッジから先（エッジ→オリジン区間）のラストマイルを最適化できない。
+- 動的コンテンツ（API・パーソナライズページ）はキャッシュできず、オリジン往復のRTTがそのまま体感速度になる。
+
+Argo Smart Routingはこれを「Cloudflareが自社で計測しているエッジ間・エッジ→オリジン間の実遅延データ」を使って解決する。Cloudflareは1秒あたり数千万〜億単位のリクエストを世界中のPoPで処理しており、その実測値からアグリゲートされたヒートマップを使って、利用者ごとに最適な中継PoP経由の経路を選ぶ。
+
+## 主要機能（What）
+
+### Smart Routing（経路選定）
+クライアント↔最寄りエッジは通常のAnycastで処理し、エッジ↔オリジンの区間をCloudflareバックボーンとPoP網を介して中継する。具体的には、リクエストを受けたPoPがオリジン直接へ抜けるのではなく、別の混雑していない中継PoPを経由してオリジン側ASに最も近いPoPから抜ける、という「Cloudflare網内での迂回」を選択する。
+
+- 経路選定の単位はオリジンASおよび宛先プレフィックス。
+- 中継PoPは数十ms単位で更新されるレイテンシテーブルから選ばれる。
+- TCP / TLSセッションはCloudflare網内では再利用され、コネクション確立コストが圧縮される。
+
+### リアルタイム遅延計測
+Cloudflareは公称で1秒あたり9300万HTTPリクエスト規模を世界中のエッジで処理しており、その全体から得られるTTFB（Time to First Byte）・RTT・再送率をリアルタイムに集計し、PoP↔オリジンの実効レイテンシマトリクスを維持している。Argoはこのマトリクスを参照し、宛先ASに対して「いま最も速いPoP出口」を選ぶ。
+
+- 計測は通常トラフィックそのものを使うパッシブ計測が主体。能動プローブも補助的に使われる。
+- 障害（特定区間のパケロス急増・RTT急増）を検知すると、BGPの収束を待たずに迂回経路へ切り替わる。
+
+### Tiered Cache との連動
+Argo Smart Routingはオリジン到達のためのオーバーレイであり、Tiered Cacheはキャッシュ階層を組むことで上位PoPにキャッシュを集約し、オリジンへのリクエスト数自体を減らす機能である。両者は別契約・別目的だが、Tiered Cacheの「上位PoP→オリジン」の区間にArgo Smart Routingが効くため組合せると効果が乗る。
+
+- Tiered Cacheは下位PoP→上位PoP→オリジンの三段構成でキャッシュヒット率を底上げする。
+- 上位PoPからオリジンへ抜ける区間でArgoが最速経路を選ぶことで、キャッシュミス時のTTFBが短縮される。
+- 静的コンテンツ中心ならまずTiered Cache、APIや動的コンテンツが多いならArgoから先に効く、という使い分けになる。
+
+### RTT 削減効果
+Cloudflareの公称ベンチマークでは、Argo Smart Routing有効時にWebアプリのパフォーマンスが平均30%改善する。実測ダッシュボードでは「Argo経由 vs Argo未経由」のTTFBヒストグラムと、PoPごとの遅延改善ヒートマップ（負値＝Argoを通さない方が速いリージョン）が確認できる。詳細メトリクスは過去48時間に500リクエスト以上Argo経由で処理されている場合に表示される。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- グローバル展開しているSaaSのAPIゲートウェイ。動的コンテンツでキャッシュが効かず、世界中からのRTTがそのままUXに直結する。
+- 動画配信・SNS・チャットなどリアルタイム性の高いアプリケーション（Discord事例で平均33msの短縮実績）。
+- オリジンが少数リージョンに集中しており、遠隔地ユーザーのRTTが国内ユーザーの数倍になっているケース。マルチリージョンで再構築するよりArgoの方が圧倒的に安く速い。
+- 既にCloudflareプロキシ配下（オレンジクラウド）で運用しているサービスで、追加投資なしにラストマイル最適化を入れたい。
+- 海底ケーブル障害・トランジット切替の影響を受けやすい地域（南米・アフリカ・東南アジア）への配信。
+
+### 適していないシーン
+- 静的アセットがほぼ100%でキャッシュヒット率が極めて高いサイト。Argoが効くのはキャッシュミスでオリジン往復する局面に限られるため、まずTiered Cache / Cache Reserveを優先する。
+- オリジンが単一リージョンかつユーザーも同地域に集中しているケース。BGP最短経路と実効最速経路の差が小さいので投資対効果が薄い。
+- Cloudflareプロキシを通さない構成（DNS Onlyのグレークラウド）。Argoはプロキシ前提なので有効化しても通らない。
+- 大量の攻撃トラフィックを受けているサイト。WAF / DDoSで遮断されたトラフィックはArgoの課金対象外だが、正当トラフィックの帯域が大きい場合は従量コストが想定外に膨らむことがある。
+
+## 競合・代替
+
+| 観点 | Cloudflare Argo Smart Routing | AWS Global Accelerator | Fastly Network Services | Akamai SureRoute | GCP Premium Tier |
+|---|---|---|---|---|---|
+| 出自 | CDN網のオーバーレイルーティング | AWS Anycast + Global Network | Fastly POP網内最適化 | CDN動的サイトアクセラレーション | GCP Premium Networkバックボーン |
+| 経路選定の根拠 | 実トラフィックのレイテンシ実測 | AWSグローバルバックボーンのSLA | Fastly内部メトリクス | 複数代替経路を並列試行（race） | GCPバックボーン優先 |
+| 適用対象 | エッジ↔オリジン区間 | クライアント↔ALB / NLB / EC2 | エッジ↔オリジン区間 | エッジ↔オリジン区間 | クライアント↔GCPリソース |
+| キャッシュ統合 | Tiered Cacheと連携 | 該当なし（CloudFrontは別） | Fastly CDNと統合 | Akamai CDNと統合 | Cloud CDNと統合 |
+| 料金 | $5/月 + リクエスト・帯域従量 | $0.025/時間 + データ転送 | プラン込み・要見積もり | 要見積もり（高額） | データ転送に上乗せ |
+| 強み | 実測ベース・無設定で効く | AWSサービスとの統合・固定IP | 細かい設定が可能 | 大企業向け実績 | GCP内通信が高速 |
+| 弱み | Cloudflareプロキシ前提 | AWSロックイン・コスト高 | Fastly利用前提 | 高コスト・契約プロセス重い | GCP外への効果は限定的 |
+
+Argoの差別化はシンプルさにある。1クリックで有効化し、コードもインフラも変更せずにグローバルRTTが平均30%改善する、という「他に選択肢がないレベルの低い導入摩擦」が最大の価値である。AWS Global Acceleratorはクライアント側のAnycast IP取得が主目的なので、性質が異なる比較対象になる。
+
+## 料金
+
+- **基本料金**：$5/月の固定料金。
+- **従量課金**：Argo経由で処理されたリクエスト数および帯域に応じた従量。WAF / DDoS / Bot Managementで軽減された攻撃トラフィックは課金対象外。
+- **Enterprise**：年間契約に含まれるプレビュー・割引枠あり。商談ベース。
+- **請求プロファイル必須**：有効化前にBillingプロファイルを登録する必要がある。
+
+Cloudflareダッシュボードの「Notifications → Usage Based Billing」で閾値超過アラートを設定するのが運用上の必須項目。動的トラフィックが急増したサービスでは月額が想定の数倍に振れることがあるため、最初からアラート前提で組む。
+
+## CLI / API 例
+
+### REST API（Zone Setting）
+```bash
+# Argo Smart Routingを有効化
+curl -X PATCH \
+  "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/argo/smart_routing" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data '{"value":"on"}'
+
+# 現在の状態確認
+curl -X GET \
+  "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/argo/smart_routing" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}"
+
+# 無効化
+curl -X PATCH \
+  "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/argo/smart_routing" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data '{"value":"off"}'
+```
+
+### Terraform（cloudflare provider v5）
+```hcl
+resource "cloudflare_argo_smart_routing" "this" {
+  zone_id = var.zone_id
+  value   = "on"
+}
+```
+
+### 効果計測
+有効化後48時間以上経過し、Argo経由のリクエストが500件を超えると、ダッシュボードの`Analytics → Performance`にTTFBヒストグラムとPoPごとの遅延改善ヒートマップが表示される。負値（青）は「Argoを通さない方が速い」リージョンを意味するため、定期的に確認して期待効果を検証する。
+
+## 制限・注意点
+- **Cloudflareプロキシ配下が前提**：DNS Only（グレークラウド）レコードには効かない。プロキシ済み（オレンジクラウド）であることを必ず確認する。
+- **キャッシュヒットには寄与しない**：Argoはオリジン到達経路の最適化であり、エッジでキャッシュヒットしているリクエストには関与しない。キャッシュ可能なコンテンツはまずCache Rules / Tiered Cache / Cache Reserveで詰める。
+- **WebSocket / 長時間コネクション**：基本的に効くが、コネクション確立後の経路は固定される。経路変動の恩恵を受けるのは新規接続。
+- **従量コストの予見性が低い**：トラフィックバーストでコストが跳ねるため、Usage Based Billing通知の設定は必須。
+- **Argo Tunnelは別物・廃止済み**：かつて`argo-smart-routing/argo-tunnel/`配下に存在した「Argo Tunnel」は、2021年にCloudflare Tunnelへ統合・名称変更され、無料化された。現在`cloudflared`デーモンで動かしているTunnelの実体がそれであり、Argo Smart Routing（本記事）とは別契約・別課金。混同が多いので設計レビューでは必ず分離して説明する。
+- **オリジン側の対応は不要**：Cloudflareから見えるオリジンIPが変わるわけではないため、オリジン側のFWルール変更は不要。ただしCloudflare IPレンジの許可リストは最新版を参照。
+- **Enterprise契約での無料プレビュー**：Enterpriseプランには一定期間の無料プレビュー枠が用意されることがある。営業経由で確認する。
+
+## 参考リンク
+- Argo Smart Routing 公式：https://developers.cloudflare.com/argo-smart-routing/
+- Get Started：https://developers.cloudflare.com/argo-smart-routing/get-started/
+- Analytics：https://developers.cloudflare.com/argo-smart-routing/analytics/
+- 製品ページ：https://www.cloudflare.com/application-services/products/argo-smart-routing/
+- Tiered Cache：https://developers.cloudflare.com/cache/how-to/tiered-cache/
+- Cloudflare Tunnel（旧Argo Tunnel）：https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/
+- API Reference（Argo Smart Routing）：https://developers.cloudflare.com/api/operations/argo-smart-routing-patch-smart-routing-setting
+
+---
+参照日: 2026-05-04

--- a/src/content/knowledge/web-development/cloudflare-docs/42-bot-management.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/42-bot-management.mdx
@@ -1,0 +1,219 @@
+---
+title: "Cloudflare Bot Management"
+description: "ZoneのHTTPリクエスト1本ごとに「人間らしさ」を1〜99のスコアで評価し、スコア・カテゴリ・Verified Bots判定・JA3/JA4フィンガープリント・AIクローラ識別子を変数化してWAFやWorkerから参照させる、Cloudflareエッジ上のボット制御プレーンである。「悪いボットを止める」だけでなく「良いボットは正しく通す」「AIクローラを意図的に管理する」までを同じレイヤで扱う。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 42
+---
+# Bot Management
+
+## 一行サマリ
+ZoneのHTTPリクエスト1本ごとに「人間らしさ」を1〜99のスコアで評価し、スコア・カテゴリ・Verified Bots判定・JA3/JA4フィンガープリント・AIクローラ識別子を変数化してWAFやWorkerから参照させる、Cloudflareエッジ上のボット制御プレーンである。「悪いボットを止める」だけでなく「良いボットは正しく通す」「AIクローラを意図的に管理する」までを同じレイヤで扱う。
+
+## 解決する課題（Why）
+Webサイトに到達するトラフィックの相当部分は人間ではない。クレデンシャルスタッフィング、在庫枯渇攻撃（スニーカーボット）、コンテンツスクレイピング、価格情報の自動収集、AI学習用クロール、不正アカウント作成、コメントスパム、決済不正の試行、これらは従来「IPブロック」「User-Agent判定」「CAPTCHA表示」で凌いできたが、いずれも実用限界に達している。
+
+- 住宅プロキシ・モバイルキャリアIP経由の分散ボットはIP評価では止まらない。
+- ヘッドレスChromeやPlaywrightは普通のUser-Agentを名乗る。
+- CAPTCHAは正規ユーザーのCVRを落とす一方、解読サービスで突破される。
+- AI学習クローラ（GPTBot, ClaudeBot, PerplexityBot等）の急増で「サーバ負荷」「コンテンツ無断学習」「自社UXの代替」という新たな論点が生まれた。
+- 一方で検索エンジン・監視SaaS・正規連携ボットは通さなければ事業が成立しない。
+
+Cloudflare Bot Managementは、これらをエッジ側でリクエスト単位にスコアリングし、WAF Custom Rule・Rate Limiting・Workersのいずれからも同じ変数として参照できる形に正規化する。
+
+## 主要機能（What）
+
+### Bot Score（cf.bot_management.score）
+1〜99の整数で「自動化らしさ」を表現する変数である。1に近いほどボット確実、99に近いほど人間確実。Bot Management（Enterprise）では1〜99の生スコアが、Pro/Business（Super Bot Fight Mode）ではAutomated / Likely Automated / Likely Human / Verified Botのカテゴリ単位で利用できる。
+
+- 1：自動化が確実（既知のヘッドレス・既知の悪性シグネチャ）。
+- 2〜29：Likely Automated。スクレイピング・自動化ツールが多い帯。
+- 30〜99：Likely Human。日常的なブラウザトラフィック。
+- Verified Bot：別フラグ（後述）で表現される正規ボット。
+
+WAFのfilter式で `cf.bot_management.score < 30` のように直接参照でき、Workers KVやLogpushにそのまま流せる。
+
+### 機械学習検出（ML Detection）
+1日あたり数千億リクエスト規模の学習データをもとにした主検出エンジンである。HTTPヘッダ構成、TLSハンドシェイクの特徴、セッションを跨いだ挙動、リクエスト間の時間的分布などをまとめてモデルに食わせ、2〜99のスコアを出力する。Cloudflareのネットワーク全体を学習基盤に使えるため、単一ドメインでは見えない攻撃パターンを横断的に学べる点がアーキテクチャ上の最大の強みである。
+
+### ヒューリスティック検出
+既知の悪性パターン（古典的なスクレイパーのシグネチャ、明らかに偽装されたUser-Agent、矛盾したヘッダ組み合わせ）を即座に弾くルールベース検出。スコア1の判定は概ねこの層から出る。
+
+### JS Detections
+軽量なJavaScriptを応答に注入し、ブラウザ側の挙動・APIサポート状況・自動化フラグ（navigator.webdriver等）を検査する仕組みである。ヘッドレスChrome・Puppeteer・Playwrightといった自動化ブラウザの検出精度を底上げする。プライバシーに配慮した最小限のシグナルのみを収集する設計。
+
+### 異常検出（Anomaly Detection）
+Enterpriseで利用できる教師なし学習エンジン。当該ゾーンの過去のトラフィックをベースラインとし、そこからの外れ値を検出する。「業界平均から見たボット」ではなく「あなたのサイトにとって不自然なリクエスト」を識別するレイヤである。
+
+### Super Bot Fight Mode（Pro/Business）
+Pro / Businessプラン向けの中間グレード。カテゴリ単位（Definitely Automated / Likely Automated / Verified Bot）でAction（Allow / Block / Managed Challenge）を設定する。WAF Custom Ruleからも参照可能だが、生スコアは取れない。Businessではより細かい設定とJS Detectionsが利用できる。
+
+### Bot Fight Mode（Free）
+Freeプラン向けの単一トグル。検知されたボットトラフィックに対してチャレンジを発動する。設定の粒度はなく、特定パスの除外などはできない。導入コストはゼロだが、誤検知が起きた場合の調整余地が乏しいのが現実。
+
+### Verified Bots
+Cloudflareが「正規」と認定したボットのリスト。Googlebot, Bingbot, Applebot, Slack Linkチェッカー, Stripe Webhook, Datadog Synthetics, UptimeRobot等を含む。`cf.client.bot` 変数や `cf.verified_bot_category` で識別できる。「全ボットを止めたいが、検索インデックスと監視は通したい」という現実解はこのリストに依存する。新規ボットの登録申請も受け付けている。
+
+### AI Crawl Control / AI Audit
+GPTBot, ClaudeBot, PerplexityBot, Google-Extended, CCBot等の「AI学習・推論用クローラ」を独立カテゴリとして可視化・制御する機能。ダッシュボードからワンクリックで「AIクローラを全部ブロック」「特定のクローラのみ許可」が設定でき、robots.txtの管理UIや、サイト所有者向けのToS雛形（AI学習禁止の文言）も同梱される。Bot Managementの中でも近年最も投資されている領域である。
+
+### AI Labyrinth
+不正なAIクローラを「無限に生成されるダミーページの迷路」に誘い込み、リソースを浪費させる対抗策。robots.txtを無視するクローラに対する積極的な防御として位置付けられている。検出されたクローラには本物のコンテンツではなく、AI生成のもっともらしい無意味なページが返される。
+
+### JA3 / JA4 フィンガープリント
+TLS ClientHelloの構成（バージョン、Cipher Suites、拡張、Elliptic Curves等）から導出される指紋。`cf.bot_management.ja3_hash` / `cf.bot_management.ja4` として変数化されており、特定のボットツールが残す固有のJA4を直接WAFルールでブロックできる。User-Agentが偽装されてもTLSスタックの実装は容易には変えられないため、JA4は「偽装に強い識別子」として実務上極めて有効である。
+
+### Turnstile連携
+CAPTCHAの代替プロダクト。ユーザーにパズルを解かせず、ブラウザのテレメトリのみで人間性を判定する。Bot ManagementとTurnstileを組み合わせると、「スコアが微妙な帯（例：20〜40）はTurnstileに通す」「決済・ログイン・登録だけはTurnstile強制」といったCVRに優しい運用が組める。Apple端末向けには Private Access Token (PAT) によるパスワードレスな人間性証明にも対応。
+
+### Bot Analytics
+Bot Managementを有効化したゾーンには専用のAnalyticsダッシュボードが付き、リクエストをBot Score別・カテゴリ別・User-Agent別・JA4別に内訳表示できる。WAFルール作成前のチューニング、誤検知調査、AIクローラのトラフィック把握に使う。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- ECサイト・チケッティング・予約系で在庫枯渇攻撃やスニーカーボットに恒常的に晒されている事業。生スコア＋JA4でターゲットを絞れる。
+- 銀行・証券・SaaSログインでクレデンシャルスタッフィングが観測されているサービス。スコアとTurnstile併用で正規ユーザーの摩擦を最小化できる。
+- 自社コンテンツの無断AI学習を抑止したいメディア・出版・EdTech・ナレッジSaaS。AI Crawl Control + AI Labyrinthが直接刺さる領域。
+- 既にCloudflare WAF / CDNを使っており、ルール記述のために `cf.bot_management.*` 変数が使える状態にしたい組織。
+- Bot対策に独自の専用ベンダー（DataDome / HUMAN等）を入れる前に、エッジ標準の機能で十分な打率が出せるかを試したい組織。
+
+### 適していないシーン
+- そもそもCloudflare以外のCDN（Akamai / Fastly / CloudFront）が前段で終端しており、Cloudflareにトラフィックが通らない構成。Bot Managementはエッジ通過が前提である。
+- 検出後のレスポンスをアプリ側で精緻に分岐させたいが、Workersを使う設計を許容できない場合。WAFのAction（Block / Challenge / Log）だけでは表現力が足りないシーンが必ず出る。
+- アプリ自身がBot前提で動く（公開API・RSS・Webhook配信元等）ため「ほぼ全リクエストが自動化」の正常状態にあるサービス。Verified Botリストとカスタムルールの設計コストが先に立つ。
+- 「AI学習クローラに対しては自社で課金して通す」といった商業的なボット流量取引（Pay per Crawl的なモデル）を主目的に置くケースは、Cloudflareの新領域プロダクト群（Pay per Crawl等）も含めて別途検討が必要。
+
+## 競合・代替
+
+| 観点 | Cloudflare Bot Management | Akamai Bot Manager Premier | DataDome | HUMAN (旧PerimeterX) | Imperva Advanced Bot Protection | Kasada |
+|---|---|---|---|---|---|---|
+| デプロイモデル | エッジ統合（CDN/WAFと同居） | エッジ統合（Akamai上） | リバースプロキシ / SDK / コネクタ | リバースプロキシ / SDK | リバースプロキシ / SDK | リバースプロキシ / SDK |
+| 検出主軸 | ML + ヒューリスティック + JA4 + JS Detections | ML + Behavioral + デバイス指紋 | ML + サーバ側シグナル中心 | クライアント側JS / SDKの濃いテレメトリ | ML + クライアント側 | クライアントチャレンジ（独自暗号） |
+| AIクローラ制御 | AI Crawl Control / AI Labyrinth標準 | 個別ルール対応 | AI bot対応進行中 | 対応中 | 対応中 | 対応中 |
+| Verified Bots | 公式リスト + 申請制 | 同等 | 内部リスト | 内部リスト | 内部リスト | 内部リスト |
+| CAPTCHA代替 | Turnstile / PAT | 独自Challenge | 独自Challenge | Human Challenge | Imperva Challenge | Cryptographic Challenge |
+| ログ / 分析 | Bot Analytics + Logpush | Akamai Analytics | DataDomeダッシュボード | HUMANダッシュボード | Imperva Analytics | Kasadaダッシュボード |
+| 価格帯 | Free〜Enterprise（段階あり） | エンタープライズのみ | エンタープライズのみ | エンタープライズのみ | エンタープライズのみ | エンタープライズのみ |
+| 強み | エッジ統合・段階導入・AI領域への先行投資 | 大規模ECでの実績・成熟度 | 純血ボット専業の精度 | クライアント側テレメトリの厚み | WAF/DDoSとの統合 | 独自暗号チャレンジの突破困難性 |
+| 弱み | 専業ベンダーのSOC運用支援は弱い | 高コスト・Akamai前提 | Cloudflare前段の場合は二重統合 | 同左 | 同左 | 同左 |
+
+専業ベンダーは「ボット対策のSOCサービス」「対攻撃チューニングコンサル」を込みで提供してくる点が差別化になる。Cloudflareは「既にCDN/WAFが入っているなら追加コストと運用が最小」という構造的優位を持つが、専業レベルのアドバイザリは期待しないほうがよい。
+
+## 料金
+
+- **Free（Bot Fight Mode）**：単一トグルでボットチャレンジ。Zoneの全リクエストに一律適用、除外設定はほぼ不可。検証・個人ブログ用途。
+- **Pro（Super Bot Fight Mode）**：Definitely Automated / Verified Botに対するAction設定（Allow / Block / Managed Challenge）。WAF Custom Ruleから限定的にカテゴリ参照可。
+- **Business（Super Bot Fight Mode + JS Detections）**：Likely Automatedも独立カテゴリで扱える。JS Detectionsが利用可能。WAF Custom Ruleでより柔軟な分岐が書ける。
+- **Enterprise（Bot Management for Enterprise）**：1〜99の生スコア、JA3/JA4フィンガープリント、Anomaly Detection、AI Crawl Control / AI Labyrinthのフル機能、Bot Analytics、Logpush、専用サポート。年間契約・要見積もり。
+
+「カテゴリベースで十分か、生スコアと指紋まで必要か」が最大の分岐点である。EC・金融・大規模メディアは原則Enterprise前提、中小Bizサイト・SaaSの初期防衛はSuper Bot Fight Modeで足りるケースが多い。AI Crawl Controlの一部機能はFreeでも提供されているが、フルコントロールはEnterpriseに集約されつつある。
+
+## CLI / API 例
+
+### WAF Custom Rule（Bot Scoreでのブロック例）
+ログインエンドポイントで「Bot Score < 30 かつ Verified Botでない」リクエストをManaged Challengeに回す。
+
+```bash
+curl -X POST "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/rulesets/phases/http_request_firewall_custom/entrypoint" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "rules": [
+      {
+        "action": "managed_challenge",
+        "expression": "(http.request.uri.path eq \"/login\" and cf.bot_management.score lt 30 and not cf.client.bot)",
+        "description": "Challenge low-score non-verified bots on login"
+      },
+      {
+        "action": "block",
+        "expression": "(cf.bot_management.score eq 1 or cf.bot_management.ja4 in {\"t13d1516h2_8daaf6152771_b186095e22b6\"})",
+        "description": "Hard-block definite bots and known-bad JA4"
+      }
+    ]
+  }'
+```
+
+### AIクローラの一括ブロック
+`cf.bot_management.verified_bot_category` や `cf.verified_bot_category` で `"AI Crawler"` を判定する、もしくはダッシュボードのAI Crawl Controlのトグルで一括設定する。
+
+```
+(cf.verified_bot_category eq "AI Crawler") -> block
+```
+
+### Terraform（cloudflare provider v5）
+```hcl
+resource "cloudflare_ruleset" "bot_protection" {
+  zone_id     = var.zone_id
+  name        = "Bot protection"
+  description = "Bot Management driven WAF rules"
+  kind        = "zone"
+  phase       = "http_request_firewall_custom"
+
+  rules = [
+    {
+      action      = "managed_challenge"
+      expression  = "(http.request.uri.path eq \"/login\" and cf.bot_management.score lt 30 and not cf.client.bot)"
+      description = "Challenge low-score non-verified bots on login"
+      enabled     = true
+    },
+    {
+      action      = "block"
+      expression  = "(cf.bot_management.score eq 1)"
+      description = "Block definitely automated traffic"
+      enabled     = true
+    },
+    {
+      action      = "block"
+      expression  = "(cf.verified_bot_category eq \"AI Crawler\")"
+      description = "Block all AI crawlers"
+      enabled     = true
+    }
+  ]
+}
+```
+
+### Workersでのスコア参照
+```js
+export default {
+  async fetch(request) {
+    const score = request.cf?.botManagement?.score ?? 99;
+    const ja4   = request.cf?.botManagement?.ja4;
+    if (score < 10) {
+      return new Response("forbidden", { status: 403 });
+    }
+    // 中間スコアはTurnstileのトークン検証を要求
+    if (score < 30 && !request.headers.get("cf-turnstile-token")) {
+      return Response.redirect("https://example.com/verify", 302);
+    }
+    return fetch(request);
+  }
+};
+```
+
+## 制限・注意点
+- 1〜99の生スコア、JA3/JA4、Anomaly Detection、AI Labyrinthのフル機能はEnterprise（Bot Management for Enterprise）限定。Pro/Businessはカテゴリ判定どまりである点を最初に握っておく。
+- Bot ScoreはCloudflareをトラフィックが通過する前提で算出される。Cloudflareがオリジン直前のリバースプロキシではなく、別CDNが前段にある構成では多くのシグナルが取れない。
+- JS Detectionsはレスポンスへのスクリプト注入を伴う。SPA・厳格なCSP・PWAでのCSPホワイトリスト調整が必要なケースがある。
+- Verified Botリストへの追加は申請制で即時ではない。自社の連携ボットがブロックされる事故を避けるため、内部・取引先のBotは事前にIPリストでAllowする運用と併用するのが安全である。
+- Turnstileを多用しすぎると正規ユーザーのCVRに悪影響が出る。「スコア低帯のみ」「機微エンドポイントのみ」に絞る設計が原則。
+- Bot ScoreベースのブロックはWAFログには残るが、原因調査にはBot AnalyticsとLogpush（Enterprise）の両方が必要になる。Standard以下のログ保持では事後検証が厳しい。
+- AI Labyrinthはクローラのリソースを浪費させる対抗策である一方、自社のCDN転送量・Workers実行コストにも跳ねる可能性がある。導入時はコストモデルを確認する。
+- robots.txt遵守の善意のクローラと、無視する悪意のクローラを同列に扱わない設計が必要。AI Crawl Controlのカテゴリ別設定で分岐を明示する。
+- WAF / Rate Limiting / Bot Management / Turnstile / Workersは同じ `cf.*` 変数で連携できるが、評価順序（Phase）を理解せずにルールを足すと意図と異なる順で発火する。Rulesetのphaseとprecedenceは設計時に明文化する。
+
+## 参考リンク
+- Cloudflare Bot Management 公式ドキュメント：https://developers.cloudflare.com/bots/
+- Bot Score の概念：https://developers.cloudflare.com/bots/concepts/bot-score/
+- Super Bot Fight Mode：https://developers.cloudflare.com/bots/get-started/super-bot-fight-mode/
+- Bot Management for Enterprise：https://developers.cloudflare.com/bots/get-started/bot-management/
+- AI Crawl Control / AI bots：https://developers.cloudflare.com/bots/concepts/bot/#ai-bots
+- AI Labyrinth：https://blog.cloudflare.com/ai-labyrinth/
+- Verified Bots：https://developers.cloudflare.com/bots/concepts/bot/verified-bots/
+- JA3/JA4 フィンガープリント：https://developers.cloudflare.com/bots/concepts/ja3-ja4-fingerprint/
+- Turnstile：https://developers.cloudflare.com/turnstile/
+- Bot Management 製品ページ：https://www.cloudflare.com/application-services/products/bot-management/
+
+---
+参照日: 2026-05-04

--- a/src/content/knowledge/web-development/cloudflare-docs/43-cache.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/43-cache.mdx
@@ -1,0 +1,255 @@
+---
+title: "Cloudflare Cache (Cache Rules / Cache Reserve / Tiered Cache)"
+description: "Cloudflareエッジで静的・準静的リソースを各PoPに保持し、Cache Rulesでキャッシュ条件とTTLを宣言、Tiered Cacheで上位ティアに集約してオリジン負荷を削り、Cache ReserveでR2上に長期退避させる、エッジキャッシュ層の総体である。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 43
+---
+# Cache (Cache Rules / Cache Reserve / Tiered Cache)
+
+## 一行サマリ
+Cloudflareエッジで静的・準静的リソースを各PoPに保持し、Cache Rulesでキャッシュ条件とTTLを宣言、Tiered Cacheで上位ティアに集約してオリジン負荷を削り、Cache ReserveでR2上に長期退避させる、エッジキャッシュ層の総体である。
+
+## 解決する課題（Why）
+オリジンサーバーは「同じレスポンスを世界中のユーザーに何度も返す」ために計算リソース・帯域・コストを浪費し、トラフィック急増時には真っ先にスケール限界に当たる。さらに、各PoPが個別にオリジンへフェッチする素朴なCDNでは、エッジが200拠点以上に分散しているほどキャッシュミス率が悪化し、オリジンへの「広く浅い負荷」が消えない。Cloudflare Cacheはこれをエッジ・上位ティア・永続ストアの三段構えで解決する。
+
+- グローバルに分散したPoPでの応答による初回TTFB短縮とオリジン負荷削減。
+- Tiered Cacheによる上位ティア集約で、オリジンへの重複フェッチを構造的に削る。
+- Cache ReserveでLRU退避を回避し、長尾コンテンツも常時エッジ近傍から配信。
+- Cache RulesでURL・Cookie・デバイス・ステータスコード等の条件で宣言的にキャッシュ戦略を分岐。
+- Always Onlineでオリジン障害時もキャッシュ済みコンテンツを継続配信。
+- Purge API・Cache Tag・Stale-While-Revalidateで「鮮度」と「可用性」のトレードオフを運用可能に。
+
+## 主要機能（What）
+
+### Cache Rules
+URL・ホスト・リクエストヘッダ・Cookie・デバイスタイプ等のマッチャに対して、キャッシュ可否・TTL・キャッシュキー・Origin Cache Controlの優先順位を宣言する仕組みである。旧Page Rulesの後継で、評価順序（precedence）と複数条件のAND/ORを明示できる。
+
+- **設定可能アクション**：Eligible for cache（キャッシュ対象化）、Edge TTL、Browser TTL、Custom Cache Key、Cache Reserve eligibility、Bypass Cache on Cookie、Origin Cache Controlの尊重可否、Serve Stale Content、Respect Strong ETags など。
+- **マッチャ**：`http.host`、`http.request.uri.path`、`http.request.uri.query`、`http.cookie`、`http.user_agent`、`ip.geoip.country`、`http.request.headers["x-foo"]` などRulesetエンジンの全式が利用可能。
+- **ルール上限**：Free 10 / Pro 25 / Business 50 / Enterprise 300（プラン依存）。
+- **API / Terraform**：Rulesets API（phase: `http_request_cache_settings`）で操作する。Terraformは `cloudflare_ruleset` リソースで宣言。
+
+### Cache Keys & TTL
+Cloudflareは既定で「URL（クエリ含む）+ ホスト + スキーム」をキャッシュキーとし、デバイスや言語ヘッダは含めない。Custom Cache Keyを使うと、特定クエリパラメータのみを含める／除外する、Cookie値で分岐する、ヘッダで分岐する、といった粒度設計が可能になる。
+
+- **Edge Cache TTL**：CloudflareのPoPに保持する時間。Cache Rulesで明示するか、`Cache-Control: s-maxage` / `max-age` をオリジンが返すと尊重される。
+- **Browser Cache TTL**：ブラウザ側 `Cache-Control: max-age` を上書きする。
+- **Cache TTL by status code**：200/301は長め、404/5xxは短めなど、ステータス別TTLを宣言できる。
+- **デフォルトTTL**（オリジンがCache-Control未指定の場合）：200/206/301は120分、302/303は20分、404/410は3分。
+- **既定キャッシュ対象拡張子**：画像（GIF/PNG/JPEG/WEBP）、動画（MP4/WEBM）、CSS/JS、PDF/DOC等60種類以上。HTML / JSONは既定では非キャッシュ（動的・個別化想定のため）。HTMLをキャッシュする場合はCache Rulesで明示的に「Eligible for cache」を有効化する。
+- **Origin Cache Controlとの優先順位**：Cache Rulesで明示したTTLが最優先。次にオリジン `Cache-Control` / `Expires`、最後にCloudflareデフォルト。
+
+### Tiered Cache
+全PoPが直接オリジンを叩くのではなく、上位ティアPoPに集約してからオリジンにフェッチする構造である。下位ティアのキャッシュミスは上位ティアでヒットする確率が高く、オリジンRPSを構造的に削減できる。
+
+- **Smart Tiered Cache Topology**：レイテンシデータから動的に最適な単一の上位ティアを選択する。Cloudflareが推奨する構成で、設定はトグル一つ。Pro以上で利用可能（Freeは対象外、後述）。
+- **Generic Global Tiered Cache**：複数の上位ティアをグローバルに配置し、遠距離訪問者のレイテンシ削減を優先する。Enterprise向け。
+- **Custom Topology**：Enterprise顧客がアカウントチームと協議の上で個別構築する専用トポロジ。
+- **リージョンヒント**：オリジンがクラウド（AWS/GCP/Azure）の場合、リージョン指定で上位ティアを地理的に近接させてオリジンRTTを最小化できる。
+
+### Cache Reserve
+R2上に構築された永続ストアにキャッシュアセットを退避させ、PoPからのLRU退避を実質的に回避する仕組みである。長尾コンテンツや滅多に呼ばれない大ファイルでも「ほぼ常にキャッシュヒット」状態を維持できる。
+
+- **対象条件**：Cache-Eligibleであること、Edge TTLが10時間以上、`Content-Length` ヘッダ付き、画像変換時はオリジナルのみ。
+- **保持期間**：30日間アクセスがなければ削除候補。
+- **課金モデル**（R2と類似）：
+  - ストレージ：$0.015 / GB-month
+  - Class A操作（書き込み、Cache Reserveへの保存）：$4.50 / 100万リクエスト
+  - Class B操作（読み出し、エッジミス時の取得）：$0.36 / 100万リクエスト
+- **有効化**：ダッシュボードからの単純トグルだが、有料Cache Reserveプランの契約が前提。
+
+### Always Online
+オリジンサーバーがダウンした際に、エッジキャッシュ済みのコンテンツを継続配信する機能である。完全に静的なページであれば、オリジン障害中もユーザーには通常運用に見える。Internet Archive連携版（過去にあった機能）は廃止され、現在はCloudflare自身のキャッシュからのみ配信される。Free含む全プランで利用可能だが、効果はキャッシュヒット率に依存する。HTMLをキャッシュ対象にしていない場合、オリジン障害時にAlways Onlineは無力なので、Cache Rulesで主要ページのHTMLキャッシュを明示しておくのが実装上の必須条件である。
+
+### Purge
+キャッシュを即時無効化する手段である。粒度別に複数の方式が用意されている。
+
+- **Single-File (URL) Purge**：個別URL指定。最も推奨される細粒度パージ。
+- **Purge by Tag**：オリジンが返す `Cache-Tag` ヘッダで束ねたグループ単位。Enterprise機能。
+- **Purge by Hostname**：ホスト単位。Enterprise機能。
+- **Purge by Prefix**：URLプレフィックス単位。Enterprise機能。
+- **Purge Everything**：ゾーン全体。最終手段。
+- **レート制限**（プラン別）：
+  - Single-File：Free 800 URL/秒、Pro/Business 1,500 URL/秒、Enterprise 3,000 URL/秒。
+  - Hostname/Tag/Prefix/Everything：Free 5 req/分、Pro 5 req/秒、Business 10 req/秒、Enterprise 50 req/秒。
+- **API**：`POST /zones/{zone_id}/purge_cache` 一本で、ボディに `files` / `tags` / `hosts` / `prefixes` / `purge_everything` を指定。
+
+### Stale-While-Revalidate (SWR)
+オリジンが `Cache-Control: stale-while-revalidate=N` を返すと、TTL切れ直後のN秒間は「古いキャッシュを返しつつ、バックグラウンドでオリジン再検証」を行う。ユーザー体験は古いコンテンツでも即時応答、オリジンには再検証リクエスト1本のみ、というキャッシュ理論上の理想状態を作れる。Cache Rulesの `Serve Stale Content` と組み合わせ、オリジンが応答失敗した際に古いキャッシュをフォールバック配信する設計も可能。
+
+### Crawler Hints
+コンテンツ更新タイミングを検索エンジンクローラに通知する機能（IndexNow準拠）。クローラが「変更がない時に巡回しない」ことで、オリジンへの不要なクロールトラフィックを削減できる。SEO的なペナルティはなく、有効化トグルのみ。
+
+### Vary for Images
+`Accept` ヘッダ（ブラウザのフォーマットサポート情報）を見て、同一URLからWebP / AVIF / JPEGなどブラウザ最適なフォーマットを返す機能である。Cache KeyにAcceptを含める必要があるが、Cloudflare側がVary対応キャッシュキーを自動構築する。Polish / Image Resizing / Imagesと組み合わせて使う前提の機能。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- 既にCloudflareをDNS / プロキシとして使っており、追加コストゼロでCDN効果を得たいケース。
+- 静的サイト・JAMstack・メディアサイトなど、キャッシュ可能率が高いワークロード。
+- オリジンがクラウドの単一リージョンにあり、グローバル配信のレイテンシとコストを下げたいケース（Tiered Cache + Smart Topology）。
+- 大量の長尾コンテンツ（過去記事・滅多に再生されない動画・地域限定アセット）を抱え、LRU退避でオリジンに戻されると困るケース（Cache Reserve）。
+- リリース時の即時無効化が業務要件で、Cache Tagでアトミックに無効化したいCMS / EC（Purge by Tag、Enterprise）。
+- オリジンが脆弱（小規模VPS、サーバレスのコールドスタート）で、Always Online + 長めのEdge TTLで耐障害性を補いたいケース。
+
+### 適していないシーン
+- すべてのレスポンスがログイン後の個別化コンテンツで、キャッシュキーを設計しても共有キャッシュが成立しない（純粋なSaaS管理画面など）。
+- 厳格なリアルタイム性が求められ、SWRや短TTLでも許容できないユースケース（株価ティッカー、ライブスコア。これはWebSocket / SSEで設計すべき）。
+- オリジンが既にCDN（CloudFront / Fastly）でフロントされ、Cloudflareをセキュリティ層のみで使う構成。Tiered Cache / Cache Reserveの恩恵が二重CDNで打ち消される。
+- 5GB超の単一ファイルを扱う（Enterpriseでも上限5GB、Free/Pro/Businessは512MB）。Stream / R2直配信が現実解。
+- HIPAA / 金融など、エッジに個人データを置けない規制要件がある領域。Cache RulesでBypass Cache on Cookieを徹底するか、キャッシュ自体を諦める。
+
+## 競合・代替
+
+| 観点 | Cloudflare Cache | Fastly | Akamai | AWS CloudFront | Bunny.net | Fly.io |
+|---|---|---|---|---|---|---|
+| 出自 | フルスタックCDN / セキュリティ統合 | プログラマブルCDN（VCL/Compute@Edge） | 老舗エンタープライズCDN | AWSバンドルCDN | 低価格特化CDN | エッジコンピュート（CDN特化ではない） |
+| 設定モデル | Cache Rules（宣言的）+ Workers | VCL / Compute@Edge（手続き的） | プロパティマネージャ（GUI主体） | Behaviors / Functions | シンプルGUI | アプリ実行 + キャッシュは副次的 |
+| 永続キャッシュ層 | Cache Reserve（R2） | Origin Shield（単一上位ティア） | Tiered Distribution | Origin Shield（リージョン単位） | Perma-Cache | なし |
+| 上位ティア | Smart / Generic / Custom | Origin Shield POP指定 | 多層階層キャッシュ | Origin Shield | Geo-Replication | なし |
+| Tag Purge | Enterprise | 標準（強み） | 標準 | Invalidation Path（Tag非対応） | 標準 | なし |
+| 即時Purge | 数秒〜 | 〜150ms（業界最速級） | 数秒〜 | 数十秒〜分 | 数秒〜 | アプリ次第 |
+| 価格 | Free含む4段階・帯域無制限 | 帯域従量・高め | 要見積もり・高価 | 帯域従量・リージョン別 | 帯域$0.005〜と最安級 | Compute従量 |
+| 強み | 統合・無料枠・Cache Reserve・帯域無料 | プログラマビリティ・即時Purge | 大規模配信実績・SLA | AWS連携・S3直結 | 価格 | アプリ近接配置 |
+| 弱み | プログラマビリティはWorkers前提 | コスト・学習コスト | 高価・運用重厚 | Tag Purge非対応・キャッシュキー柔軟性低 | エンタープライズ機能薄い | CDN特化機能なし |
+
+CloudflareはCache Rulesの宣言的シンプルさ、無料枠と帯域無料、Cache ReserveによるR2連携、Workersでの拡張、の組合せで「中堅まではこれ一枚で完結する」のが最大の強みである。即時Tag Purgeの一点突破ならFastly、AWS純正で揃えるならCloudFront、純粋な帯域単価ならBunny.netが候補に上がる。
+
+## 料金
+
+- **Cache 本体**：すべてのプランで標準提供。Free含めて帯域無制限・追加課金なし。
+- **Tiered Cache**：
+  - Smart Tiered Cache Topology：Pro以上（Freeは対象外）。追加課金なし。
+  - Generic Global / Custom Topology：Enterprise専用。
+- **Cache Reserve**：有料Cache Reserveプランの契約が前提。R2類似の従量課金：
+  - ストレージ：$0.015 / GB-month
+  - Class A（書き込み）：$4.50 / 100万リクエスト
+  - Class B（読み出し）：$0.36 / 100万リクエスト
+- **Always Online**：Free含む全プランで標準。
+- **Purge**：API / Dashboardで標準。Tag / Hostname / Prefix PurgeはEnterprise機能。
+- **Cache Rules上限**：Free 10 / Pro 25 / Business 50 / Enterprise 300。
+
+オリジン側エグレス料金とCDN帯域料金が事実上ゼロ（Cloudflareは帯域課金なし）であり、AWS S3 + CloudFrontと比較すると大規模配信ほどコスト差が大きく開く。逆にCache Reserveは「使った分だけ」モデルであり、長尾コンテンツのヒット率向上と読み出し課金のバランス設計が必要になる。
+
+## CLI / API 例
+
+### Cache Rule作成（curl、Rulesets API）
+```bash
+# HTMLを5分キャッシュし、ログインCookieがあるときはバイパス
+curl -X POST "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/rulesets" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "name": "Cache HTML with cookie bypass",
+    "kind": "zone",
+    "phase": "http_request_cache_settings",
+    "rules": [{
+      "expression": "(http.request.uri.path matches \"^/blog/\")",
+      "action": "set_cache_settings",
+      "action_parameters": {
+        "cache": true,
+        "edge_ttl": { "mode": "override_origin", "default": 300 },
+        "browser_ttl": { "mode": "override_origin", "default": 60 },
+        "cache_reserve": { "eligible": true, "minimum_file_size": 0 },
+        "serve_stale": { "disable_stale_while_updating": false }
+      }
+    }]
+  }'
+```
+
+### Purge by URL
+```bash
+curl -X POST "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/purge_cache" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "files": [
+      "https://example.com/index.html",
+      "https://example.com/assets/app.css"
+    ]
+  }'
+```
+
+### Purge by Tag（Enterprise）
+```bash
+curl -X POST "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/purge_cache" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data '{ "tags": ["product-1234", "category-shoes"] }'
+```
+
+### Terraform（cloudflare provider v5）
+```hcl
+# Cache Rule: 画像系を1日キャッシュ + Cache Reserve対象化
+resource "cloudflare_ruleset" "cache_images" {
+  zone_id = var.zone_id
+  name    = "Cache images aggressively"
+  kind    = "zone"
+  phase   = "http_request_cache_settings"
+
+  rules {
+    expression  = "(http.request.uri.path.extension in {\"jpg\" \"jpeg\" \"png\" \"webp\" \"avif\"})"
+    action      = "set_cache_settings"
+    description = "Long TTL for images, eligible for Cache Reserve"
+
+    action_parameters {
+      cache = true
+      edge_ttl {
+        mode    = "override_origin"
+        default = 86400
+      }
+      browser_ttl {
+        mode    = "override_origin"
+        default = 86400
+      }
+      cache_reserve {
+        eligible          = true
+        minimum_file_size = 0
+      }
+    }
+  }
+}
+
+# Tiered Cache: Smart Topologyを有効化
+resource "cloudflare_tiered_cache" "smart" {
+  zone_id    = var.zone_id
+  cache_type = "smart"
+}
+
+# Cache Reserve（ゾーン単位の有効化）
+resource "cloudflare_zone_cache_reserve" "this" {
+  zone_id = var.zone_id
+  enabled = true
+}
+```
+
+## 制限・注意点
+- 単一ファイルの最大キャッシュサイズはFree/Pro/Business 512MB、Enterpriseはデフォルト5GB。これを超えるアセットはStream / R2直配信が現実解。
+- HTML / JSONはデフォルトで非キャッシュ。Cache Rulesで明示的に「Eligible for cache」を有効化しないと、Always Onlineも効かない。
+- Cache Reserveは最低Edge TTL 10時間が条件。短TTLのアセットは退避対象外。
+- Cache Reserve は `Content-Length` ヘッダがないレスポンス（Chunked TransferのみのオリジンやWorkersのstreaming response）も対象外になる。
+- Tag / Hostname / Prefix PurgeはEnterprise限定。Pro / Businessでは Single-File と Purge Everything のみ。
+- Purge Everythingはエッジ全PoPからの追い出しなので、直後はオリジン負荷が一時的に跳ねる。リリース時はSWR + Cache Tag（Enterprise）で局所的に剥がす設計が望ましい。
+- Bypass Cache on Cookieは正規表現マッチで設定するが、ログインCookie名がアプリ依存なので、Cookie命名規則をフロントエンドと事前合意しておく必要がある。
+- Custom Cache Keyに含めるパラメータが多いほどキャッシュフラグメンテーションが進み、ヒット率が低下する。クエリパラメータの正規化（不要パラメータの除外、ソート）を併用する。
+- Workers経由のレスポンスは別途 `cf.cacheEverything` / `cacheTtl` の明示が必要で、Cache Rulesと挙動が一部異なる。Workers + Cache APIを使う場合はキャッシュ責務がアプリ側に移る点に注意。
+- Smart Tiered Cache Topologyの「対応プラン」は時期によって表記揺れがある（Pro以上が標準、Free対応はEnterpriseアカウント傘下のFreeなど条件付き）。導入時はダッシュボードのトグル可否を確認するのが確実。
+- Vary for Imagesを有効化するとキャッシュキーが分岐するため、ヒット率が落ちる可能性がある。Polish / Cloudflare Imagesと併用する前提で考える。
+
+## 参考リンク
+- Cloudflare Cache 概要：https://developers.cloudflare.com/cache/
+- Cache Rules：https://developers.cloudflare.com/cache/how-to/cache-rules/
+- Default Cache Behavior：https://developers.cloudflare.com/cache/concepts/default-cache-behavior/
+- Tiered Cache：https://developers.cloudflare.com/cache/how-to/tiered-cache/
+- Cache Reserve：https://developers.cloudflare.com/cache/advanced-configuration/cache-reserve/
+- Purge Cache：https://developers.cloudflare.com/cache/how-to/purge-cache/
+- Crawler Hints：https://developers.cloudflare.com/cache/advanced-configuration/crawler-hints/
+- Vary for Images：https://developers.cloudflare.com/cache/advanced-configuration/vary-for-images/
+- Cache llms.txt：https://developers.cloudflare.com/cache/llms.txt
+- Terraform `cloudflare_ruleset`：https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/ruleset
+
+---
+参照日: 2026-05-04

--- a/src/content/knowledge/web-development/cloudflare-docs/44-ddos.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/44-ddos.mdx
@@ -1,0 +1,238 @@
+---
+title: "Cloudflare DDoS Protection"
+description: "Cloudflareの全エッジ（330都市超・100カ国超、数百Tbps級のAnycastネットワーク）をそのまま吸収帯域として使い、L3/4からL7までのDDoSをManaged Rulesetで自動緩和する常時稼働型サービスである。Free含む全プランで無制限・無従量課金で提供される点が業界内で突出している。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 44
+---
+# DDoS Protection
+
+## 一行サマリ
+Cloudflareの全エッジ（330都市超・100カ国超、数百Tbps級のAnycastネットワーク）をそのまま吸収帯域として使い、L3/4からL7までのDDoSをManaged Rulesetで自動緩和する常時稼働型サービスである。Free含む全プランで無制限・無従量課金で提供される点が業界内で突出している。
+
+## 解決する課題（Why）
+DDoSは「攻撃者が用意できる帯域 vs 防御側が用意できる吸収帯域」の単純な算数で勝負が決まる。自前のオリジン回線・専用アプライアンス・キャリア提供のクリーンパイプでは、Tbps級のVolumetric攻撃や数億rpsのHTTPフラッドを正面で受けることは現実的でなく、攻撃中に追加帯域を契約する時間的余裕もない。CloudflareのDDoS Protectionは以下を解決する。
+
+- Anycastで全世界のエッジにトラフィックを分散吸収し、攻撃元に近いPoPで落とす（オリジン回線への到達を防ぐ）。
+- L3/4 SYN/ACK/UDP/DNSフラッド、L7 HTTPフラッドをManaged Rulesetで自動検知・自動緩和（人手介入なし）。
+- 攻撃の規模・継続時間に依存しない定額課金（Free含む全プラン）で、契約直後から数百Tbpsの吸収余力にアクセスできる。
+- BGP Anycast / GRE / IPSec / CNI経由でWebに限らない任意のIPプロトコルを保護（Magic Transit / Spectrum）。
+- Adaptive DDoS Protectionで、サービス固有のトラフィック形状（地域分布・User Agent比率・クエリパターン）から逸脱するフラッドを検知。
+
+## 主要機能（What）
+
+### HTTP DDoS Protection
+HTTP/HTTPS上のL7フラッド（GET/POSTフラッド、Cache Bypass攻撃、ランダムURL攻撃、ボットネット由来のリクエストフラッド）を緩和するManaged Rulesetである。Cloudflareプロキシ配下（オレンジクラウド有効）のゾーンに自動適用される。
+
+- Ruleset Engineで管理され、各ルールは独自の検知ロジックとアクション（Block / Managed Challenge / JS Challenge / Log）を持つ。
+- 全プランで有効。Free / Pro / Businessでも上限・従量課金なしで稼働する。
+- Override Rulesでルール単位のSensitivity（Default / Low / High）とAction上書きが可能（プランにより上書き本数が異なる）。
+- アクセプタンスは秒単位で、Cloudflare Radar / DDoS Reportで世界中の攻撃トレンドが公開されている。
+
+### Network-layer DDoS Protection (L3/4)
+SYNフラッド、ACKフラッド、UDPフラッド、DNSフラッド、SYN-ACK Reflection、TCPフラグメント攻撃などL3/4のVolumetric攻撃を緩和するManaged Rulesetである。プロキシ配下のIP（Cloudflare CDN / Spectrum / Magic Transit）に対して自動適用される。
+
+- Spectrumを使えば任意のTCP/UDPサービス（ゲーム・SSH・SMTP・カスタムプロトコル）を同層で保護できる。
+- Magic Transitを使えばBGP Anycast / GRE / IPSec / CNIで自社ASのIPプレフィックス全体をCloudflareに引き込み、Webに限らないオンプレ・クラウドを保護できる。
+- 全プランで有効、ただし「プロキシまたはMagic Transitでトラフィックを引き込んでいる」ことが前提。素のオリジンIPがDNSに残ったままだとバイパスされる。
+
+### Advanced DDoS Protection (Magic Transit / Spectrum向け)
+Magic Transit / Spectrum契約者向けの上位機能群である。汎用Managed Rulesetでは検知しにくい、状態を持つ高度な攻撃に対応する。
+
+- **Advanced TCP Protection**：スプーフィングされたACKフラッド、Out-of-state TCP、最適化されたSYNフラッドなど、ステートフル解析が必要な攻撃をフィンガープリントで識別。
+- **Advanced DNS Protection**：ランダム化サブドメイン攻撃（NXDOMAIN水責め）、DNS Amplification、権威DNS向けの細粒度フラッド対策。
+- **Advanced alerts**：フィルタ付きの粒度の高いアラート（プレフィックス単位・攻撃種別単位）。
+- Advanced DDoS Protectionアドオン契約が前提。標準のMagic Transit / Spectrumには含まれない。
+
+### Adaptive DDoS Protection
+サイト固有のトラフィックプロファイルを学習し、そのベースラインから逸脱する攻撃を検知する適応型ルールセットである。汎用シグネチャでは見抜けない「合法に見えるが当該サイトの平常時とは明らかに違う」フラッドに効く。
+
+- **エラー率プロファイリング**：通常時の5xx / 4xx比率を学習し、急増を攻撃シグナルとして扱う。Free / Pro / Businessでも基本機能が利用可能。
+- **トラフィック形状プロファイリング**（Enterprise + Advanced DDoS Protection）：Client Country、User Agent分布、クエリ文字列、Bot Score / ML Scoreまで含めた多次元プロファイル。
+- **Proactive false positive detection**（Business / Enterprise）：新規ルールを本番投入前にライブトラフィックでDry-runし誤検知を抑制。
+
+### Override Rules
+Managed Rulesetは原則そのまま使う前提だが、サービス特性で誤検知が起きる場合はOverride Rulesでルール単位の挙動を上書きできる。
+
+- 上書き対象：Action（Block / Challenge / Log / Disable）、Sensitivity Level（High / Default / Low / Essentially Off）。
+- プラン別の上書き上限：Free / Pro / Business / Standard Enterpriseは概ね1ルール、Enterprise + Advanced DDoS Protectionは10ルール上書き＋Expression fields＋Multi-rule対応。
+- Sensitivityを下げる運用は緊急時のみとし、平常時はDefaultで運用するのが原則。
+
+### Alerts & Analytics
+攻撃検知・緩和の可視化はDashboard / API / Logpushで取得できる。
+
+- **DDoS Attack Alerts**：HTTP / L3-4双方の攻撃検知時にメール・Webhook・PagerDuty通知（全プラン基本対応）。
+- **Network Analytics v2**：Magic Transit / Spectrum向けのパケット単位の統計（送信元国・プロトコル・アタックベクター）。
+- **HTTP DDoS Attack Analytics**：Securityダッシュボードに攻撃イベント単位で集約表示。
+- **Logpush（Enterprise）**：攻撃イベントログをS3 / R2 / Splunk / Datadog / Sentinelに継続転送。
+- **Cloudflare Radar**：自社攻撃ではなく業界全体の攻撃トレンドを参照する公開ダッシュボード。
+
+### Always-On vs On-Demand（Magic Transit）
+Magic Transitの引き込みモードは2種類あり、設計時にどちらを選ぶか明示する必要がある。
+
+- **Always-On**：常時CloudflareがBGPでプレフィックスを広告し、平常時から全トラフィックがエッジを経由する。最も検知が早く緩和遅延がほぼゼロ。レイテンシ要件が許容できるなら推奨。
+- **On-Demand**：平常時は自社ASでBGP広告し、攻撃検知時のみCloudflare側に切り替える。レイテンシを最優先するが、切り替え遅延（数十秒〜分単位）の間はオリジンが攻撃を受ける。
+- 一般論として、Eコマース・SaaS・APIゲートウェイなどダウンタイム許容度が低いワークロードはAlways-On、自前バックボーンを持つキャリアやレイテンシ厳格なゲーム配信はOn-Demandを選ぶ判断軸となる。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- すでにCloudflare CDN / WAFをプロキシ配下で使っているWebサービス。HTTP DDoSは追加コスト・追加設定なしで自動有効。
+- 自社ASのIPプレフィックスを保護したいキャリア・ホスティング・ゲーム配信事業者（Magic Transit Always-On）。
+- 過去にDDoSで実害があり「次は数Tbps級でも耐える」吸収帯域を即時に欲しい組織。Cloudflareの公称ネットワーク容量はマルチTbps級で、過去にも数Tbps〜数億rpsの攻撃を緩和した実績が公表されている。
+- 攻撃規模に応じた従量課金を避け、年度予算を固定したい組織。AWS Shield Advanced / Akamai Prolexicは攻撃中の超過帯域に従量課金的要素が絡むことがあるが、CloudflareはFree含めて無制限・定額。
+- Webだけでなく任意プロトコル（SSH / SMTP / ゲーム / 独自TCP/UDP）を同じ防御層で保護したいケース（Spectrum / Magic Transit）。
+
+### 適していないシーン
+- Cloudflare以外のCDN / プロキシで運用が完結しており、オリジンIPがDNS公開されたまま隠蔽できないケース。L3/4はバイパスされるため意味をなさない。
+- オンプレ回線の上流ISPが既にスクラビングサービスを提供しており、社内SLAでそれを使う前提になっている組織（重複投資になる）。
+- レイテンシが極端に厳しい金融トレーディング・低遅延ゲーム配信で、Always-On導入が許容できず、かつOn-Demand切り替え時間も許容できないケース（このときはISPスクラビング併用）。
+- 規制上、特定国の事業者にトラフィックを集約してはならない政府・防衛系。
+
+## 競合・代替
+
+| 観点 | Cloudflare DDoS Protection | AWS Shield Advanced | Akamai Prolexic | Imperva DDoS Protection | Radware DefensePro |
+|---|---|---|---|---|---|
+| 出自 | Anycast CDN（全プロダクト統合） | AWS WAF / CloudFront連動 | スクラビングセンター（純血DDoS） | WAF / CDN統合 | オンプレアプライアンス＋クラウド |
+| ネットワーク容量 | 数百Tbps級・330都市超 | AWS Globalバックボーン | 数十Tbps級・グローバルスクラビング | マルチTbps級 | パートナー網に依存 |
+| L3/4対策 | Magic Transit / Spectrumで全プロトコル | Shield Advanced（CloudFront / NLB / EIP） | BGP / GRE / Tunnel | BGP / Proxy | BGP / GRE |
+| L7対策 | HTTP DDoS Managed Ruleset（全プラン） | AWS WAF併用が前提 | Kona / App Protector | 標準同梱 | AppWall併用 |
+| Always-On / On-Demand | 両対応（Magic Transit） | Always-On（AWSリソースに対して） | 両対応 | 両対応 | 両対応 |
+| 価格モデル | 全プラン無制限・無従量。Magic Transit / Spectrumは別途有償 | $3,000/月＋データ転送、コスト保護あり | 6〜7桁ドル/年（要見積もり） | 要見積もり | アプライアンス＋年額 |
+| 強み | 全プラン無制限・エッジ統合・運用シンプル | AWS資産との結合・WAF / Firewall Managerと一体運用 | 大手金融・キャリア導入実績・専任SOC | DDoS / WAF / Botの統合 | オンプレ＋クラウドのハイブリッド |
+| 弱み | Cloudflareエッジに引き込めない構成は対象外 | AWS外のリソース保護不可・高コスト | 高コスト・契約までの時間 | PoP網はCloudflareに劣る | クラウド単独運用には冗長 |
+
+Cloudflareの最大の差別化は **「Free含む全プランでHTTP / L3-4 DDoS対策が無制限・無従量で標準提供される」** という料金モデルそのものである。AWS Shield Advancedは月額$3,000＋データ転送、Akamai Prolexicは年額契約で6〜7桁ドル規模が一般的という業界相場の中で、Cloudflareは「契約しなくても無料アカウントですぐ使える」位置に立っている。これは攻撃を受けてから防御を契約しても遅い、というDDoS特有の時間制約に対する強い解である。
+
+## 料金
+
+- **Free / Pro / Business**：HTTP DDoS / L3-4 DDoS Managed Ruleset、基本Adaptive Protection（エラー率ベース）、基本アラート、Override 1ルールが無制限・無従量で利用可能。Volumetric攻撃を受けても従量課金は発生しない。
+- **Enterprise（標準）**：上記に加え、誤検知抑制の強化（エラー率＋ヒストリカル）、SLA、専任サポート。
+- **Enterprise + Advanced DDoS Protection（アドオン）**：Adaptive Protectionのフルプロファイル（Country / UA / Query / ML Score）、Override 10ルール＋Expression fields＋Multi-rule、Advanced alerts。
+- **Magic Transit**：自社ASのIPプレフィックスをBGPでCloudflareに引き込む。年額契約・帯域とプレフィックス数で見積もり。Always-On / On-Demandはここで選択。
+- **Spectrum**：任意のTCP/UDPポートをプロキシ。Enterprise契約のアプリケーション単位課金が中心。
+
+「Web保護目的ならFreeで十分、自社ASやプロトコル丸ごと保護はMagic Transit / Spectrumで有償」という二段構成が基本設計となる。
+
+## CLI / API 例
+
+### HTTP DDoS Managed Rulesetの状態確認
+```bash
+# ゾーン配下に適用されているDDoS Managed Rulesetを取得
+curl -X GET \
+  "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/rulesets" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  | jq '.result[] | select(.kind=="managed" and (.name|test("DDoS")))'
+```
+
+### Override Rule（特定ルールのSensitivityをLowに、ActionをLogへ）
+```bash
+# ゾーンのhttp_ddos_managed_rulesetエントリーポイントにオーバーライドを書く
+curl -X PUT \
+  "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/rulesets/phases/http_ddos_l7/entrypoint" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "rules": [{
+      "action": "execute",
+      "expression": "true",
+      "action_parameters": {
+        "id": "4d21379b4f9f4bb5fbaa75a8ccba7f5c",
+        "overrides": {
+          "rules": [{
+            "id": "<rule_id_to_override>",
+            "action": "log",
+            "sensitivity_level": "low"
+          }]
+        }
+      }
+    }]
+  }'
+```
+
+### Terraform（cloudflare provider v5）
+```hcl
+# HTTP DDoS Managed RulesetのOverride（ルール単位でSensitivity緩和）
+resource "cloudflare_ruleset" "http_ddos_override" {
+  zone_id     = var.zone_id
+  name        = "HTTP DDoS override"
+  description = "Lower sensitivity for legitimate burst traffic"
+  kind        = "zone"
+  phase       = "ddos_l7"
+
+  rules = [{
+    action      = "execute"
+    expression  = "true"
+    description = "Execute managed DDoS ruleset with overrides"
+    action_parameters = {
+      id = "4d21379b4f9f4bb5fbaa75a8ccba7f5c"  # HTTP DDoS Managed Ruleset
+      overrides = {
+        rules = [{
+          id                = "<rule_id>"
+          sensitivity_level = "low"
+          action            = "log"
+        }]
+      }
+    }
+  }]
+}
+
+# Network-layer DDoS Managed Rulesetも同様、phase = "ddos_l4"
+resource "cloudflare_ruleset" "network_ddos_override" {
+  account_id  = var.account_id
+  name        = "Network DDoS override"
+  kind        = "root"
+  phase       = "ddos_l4"
+
+  rules = [{
+    action     = "execute"
+    expression = "true"
+    action_parameters = {
+      id = "3b64149bfa6e4220bbbc2bd6db589552"  # Network-layer DDoS Managed Ruleset
+    }
+  }]
+}
+```
+
+### DDoS Attack Alertの登録（Notification Policy API）
+```bash
+curl -X POST \
+  "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/alerting/v3/policies" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "name": "DDoS Attack Alert",
+    "alert_type": "dos_attack_l7",
+    "enabled": true,
+    "mechanisms": {
+      "email": [{"id": "ops@example.com"}],
+      "webhooks": [{"id": "<webhook_id>"}]
+    }
+  }'
+```
+
+## 制限・注意点
+- **Free / Pro / BusinessのHTTP DDoSは無制限だが、L3/4対策はあくまで「Cloudflareプロキシ配下のIP宛トラフィック」が対象**である。オレンジクラウドOFF（DNS only）にしているレコード、または直接オリジンIPがDNS公開されている場合は素通りで届く。Magic Transitなしの構成では、オリジンIPの隠蔽（Authenticated Origin Pulls / IP Allow List）が必須。
+- **任意プロトコル（SSH / SMTP / ゲームサーバー / 独自TCP/UDP）を守るならSpectrumまたはMagic Transitが必須**。Free / Pro / BusinessではWeb（HTTP/HTTPS）以外の引き込みができない。
+- **Adaptive DDoS Protectionのフル機能はEnterprise + Advanced DDoS Protectionアドオン限定**。Free / Pro / Businessはエラー率ベースの基本プロファイルのみ。
+- **Override Rulesは緊急対応の道具**であり、常時Sensitivityを下げて運用するのはアンチパターン。緩和ルールは時限的に入れて、原因が解消したらDefaultに戻す運用ルールを定義する。
+- **Always-On Magic Transitはレイテンシが増える**（Cloudflareエッジ経由の分）。低遅延ゲーム配信や金融系は事前にPoP距離・RTTを計測すべき。
+- **DNSが攻撃面のときはCloudflare DNS（権威）またはAdvanced DNS Protectionへの移行が前提**。自社で権威DNSを運用したままだと、DNS層のフラッドでサービス全体が落ちる。
+- **検知後の自動緩和はManaged Rulesetが行うため、運用側で「攻撃が来たらこのルールを有効化する」操作は不要**。逆にいうと、自分で見たい攻撃まで自動でChallenge / Blockされるため、検証時はLogアクションのオーバーライドを明示的に入れる。
+- **コスト保護の有無**：AWS Shield Advancedの「DDoS Cost Protection（攻撃中のスケールアウト料金返金）」のような明示的な仕組みはCloudflareにはない。代わりに **そもそも攻撃トラフィックがオリジンに届かない／従量課金が発生しない** という構造でコストを守る。
+
+## 参考リンク
+- Cloudflare DDoS Protection（公式ドキュメント）：https://developers.cloudflare.com/ddos-protection/
+- HTTP DDoS Managed Ruleset：https://developers.cloudflare.com/ddos-protection/managed-rulesets/http/
+- Network-layer DDoS Managed Ruleset：https://developers.cloudflare.com/ddos-protection/managed-rulesets/network/
+- Advanced DDoS Protection (Magic Transit)：https://developers.cloudflare.com/ddos-protection/advanced-ddos-systems/
+- Adaptive DDoS Protection：https://developers.cloudflare.com/ddos-protection/managed-rulesets/adaptive-protection/
+- Magic Transit：https://developers.cloudflare.com/magic-transit/
+- Spectrum：https://developers.cloudflare.com/spectrum/
+- Cloudflare Network（容量・PoP数）：https://www.cloudflare.com/network/
+- Cloudflare Radar（攻撃トレンド）：https://radar.cloudflare.com/
+- Terraform `cloudflare_ruleset`：https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/ruleset
+
+---
+参照日: 2026-05-04

--- a/src/content/knowledge/web-development/cloudflare-docs/45-load-balancing.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/45-load-balancing.mdx
@@ -1,0 +1,295 @@
+---
+title: "Cloudflare Load Balancing"
+description: "複数のオリジン（マルチクラウド・マルチリージョン・マルチデータセンター）を Pool 単位で束ね、Cloudflare のグローバルエッジ網からヘルスチェック・地理・レイテンシ・接続数を軸にトラフィックを振り分ける GSLB（Global Server Load Balancer）兼アプリケーション LB である。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 45
+---
+# Load Balancing
+
+## 一行サマリ
+複数のオリジン（マルチクラウド・マルチリージョン・マルチデータセンター）を Pool 単位で束ね、Cloudflare のグローバルエッジ網からヘルスチェック・地理・レイテンシ・接続数を軸にトラフィックを振り分ける GSLB（Global Server Load Balancer）兼アプリケーション LB である。
+
+## 解決する課題（Why）
+クラウド・データセンターを跨いだ可用性設計を、自前の DNS や IaaS LB だけで成立させるのは年々苦しくなっている。Route 53 や Azure Traffic Manager は GSLB として機能するが、エッジでのヘルス検知の鮮度・グローバルプロキシ統合・WAF / Bot との一体運用は別問題として残る。Cloudflare Load Balancing は同社のエッジ網（330+ PoP）に統合された GSLB として、以下の課題を一枚岩で扱う。
+
+- マルチクラウド active-active 構成（AWS + GCP / オンプレ + クラウド）の宛先振り分けと自動フェイルオーバー。
+- リージョン障害・オリジン障害発生時の DNS TTL に縛られないフェイルオーバー（Proxied モードでは TTL 概念が消える）。
+- 地理・レイテンシに基づく最寄りリージョンへのルーティング（GSLB / GeoDNS 相当）。
+- ヘルスチェックを世界各地の Cloudflare PoP から多点で実施し、単一 Probing PoP の偏りを排除。
+- WAF / CDN / Bot Management / Rate Limiting と同一プレーンでのトラフィック制御。
+- L7（HTTP/HTTPS）に加え、Spectrum 連携で L4（TCP/UDP）の GSLB も同様に扱える。
+
+## 主要機能（What）
+
+### Pools & Endpoints
+**Pool** は複数 **Endpoint**（旧称 Origin。実体は IP / ホスト名で表されるオリジンサーバー）をひとまとめにした論理グループである。Pool 単位に Health Monitor を貼り、Pool 単位にステータス（Healthy / Degraded / Critical）が決まり、Load Balancer から Pool への振り分けと、Pool 内の Endpoint への振り分けが二段で行われる。
+
+- **Pool = リージョン or クラウド単位**（例：`pool-aws-tokyo`, `pool-gcp-osaka`, `pool-onprem-dc1`）が定石。
+- 各 Endpoint には Weight・Virtual Network ID（Tunnel 経由の場合）・Header Override 等を付与できる。
+- Pool は Account 単位で再利用可能（複数 Load Balancer から共通 Pool を参照できる）。
+- Pool 内の Endpoint 健全数が Minimum Origins を下回ると Pool 自体が Unhealthy 扱いとなり、上位の Traffic Steering が次の Pool にフェイルオーバーする。
+
+### Health Monitors
+Pool に紐付けるアクティブヘルスチェック。世界各地の Cloudflare データセンターから定期 Probe を投げ、複数 PoP の合議で判定するため、単一拠点からの誤検知を抑えられる。
+
+- **Type**：HTTP / HTTPS / TCP / UDP-ICMP / ICMP-Ping / SMTP。
+- **Selector 相当**：Path / Method / Expected Codes / Expected Body / Custom Header / Host Header / Port / Follow Redirects / Allow Insecure (TLS 検証無効化) / Probe Zone（どの Zone のレピュテーションで Probe するか）。
+- **Interval**：60 秒以上が一般的（Free / Pro 制約）。Enterprise は短縮可能。
+- **Consecutive up / down**：何回連続成功・失敗で状態遷移するかの閾値。チャタリング抑制の要。
+- **Probe Regions**：WNAM / ENAM / WEU / EEU / NSAM / SSAM / OC / ME / NAF / SAF / SEAS / NEAS のうち選択。`Probe All Regions` で全 PoP から検査も可能（Enterprise）。
+- 失敗時には **Notification**（Webhook / Email / PagerDuty 連携）を送出。
+
+### Origin Steering（Pool 内の Endpoint 振り分け）
+1 つの Pool に複数 Endpoint がある場合、Pool 内でどの Endpoint に流すかを決める方式。
+
+| 方式 | 動作 | 使い所 |
+|---|---|---|
+| **Random（重み付きラウンドロビン）** | Endpoint Weight に従って確率的に振り分け | 既定値。一般的な水平分散・カナリアリリース（重み 95/5 等） |
+| **Hash** | クライアント IP のハッシュで Endpoint を決定 | DNS-only モードでの簡易セッション固定。ECS 設定により粒度調整 |
+| **Least Outstanding Requests (LOR)** | 各 Endpoint への未完了リクエスト数 × 重みで最も負荷の低い Endpoint へ | Proxied のみ。リクエスト処理時間にばらつきがある API バックエンド |
+| **Least Connections** | 各 Endpoint へのアクティブ接続数で最少を選択 | Proxied のみ。WebSocket / SSE / 長時間接続が混在するワークロード |
+
+LOR と Least Connections は Cloudflare のエッジが各 Endpoint への流量を実測している必要があるため、**DNS-only モードでは選択不可**である。
+
+### Traffic Steering（Pool 間の振り分け）
+Load Balancer 単位で、どの Pool に振り分けるかを決める方式。Pool 内の Endpoint 振り分け（Origin Steering）と階層が分かれている点に注意。
+
+| 方式 | 動作 | DNS-only | Proxied | 使い所 |
+|---|---|:---:|:---:|---|
+| **Off（Failover Order）** | Pool リストの順序通り。先頭 Pool が Healthy ならそこへ全振り、Unhealthy で次へ | ○ | ○ | active-passive。DR 用 |
+| **Random** | Pool Weight に基づき確率分散 | ○ | ○ | リージョン横断のラフな A/B |
+| **Geo（Region）** | 訪問者の地域（13 リージョン）と Pool のマッピングに従う | ○ | ○ | 「APAC からは Tokyo Pool、EU からは Frankfurt Pool」 |
+| **Country（Geo Country）** | ISO 国コード単位でのマッピング | ○ | ○ | データレジデンシー（DE 国民は EU Pool 限定など） |
+| **Proximity（GeoCoordinate）** | 訪問者の地理座標から Pool の Lat/Lng への球面距離で最寄りを選択 | ○ | ○ | 国境より物理距離が支配的なワークロード |
+| **Dynamic（Latency）** | Cloudflare が継続測定する Pool ごとのレイテンシで最速を選択 | ○ | ○ | クラウド間で実効レイテンシが変動するケース |
+| **Least Outstanding Requests** | Pool 単位の未完了リクエスト数で最少を選択 | × | ○ | Pool（リージョン）間で処理時間が偏る API |
+| **Least Connections** | Pool 単位のアクティブ接続数で最少を選択 | × | ○ | 長時間接続が多いリアルタイム系 |
+
+DNS-only モードでは **EDNS Client Subnet (ECS)** をリゾルバが付与してくれる場合に限り、Geo / Proximity / Country が訪問者単位で機能する。`location_strategy.prefer_ecs` で ECS の優先度を制御できる。
+
+### Session Affinity（スティッキーセッション）
+同一クライアントを同じ Endpoint に固定する仕組み。**Proxied モードでのみ動作**（DNS-only では DNS Persistence で代替）。
+
+- **Cookie Only**：`__cflb` を Cloudflare が発行して Endpoint を覚える。デフォルト TTL 23 時間。HttpOnly / Secure 付与。
+- **Cookie + Client IP Fallback**：Cookie が無い初回はクライアント IP ハッシュで決定論的に振り分け。Cookie 取得後は Cookie 優先。
+- **HTTP Header**：指定ヘッダ値で固定。`require_all_headers` を有効化するとすべての指定ヘッダ揃いを要求。**Sticky Zero-Downtime Failover は非対応**。
+- 不健全になった Endpoint からは自動的に他 Endpoint に再ルーティング。**Session Drain**（メンテ時にセッション維持しつつ新規振り分けを止める）も Endpoint 単位で操作可能。
+
+### Adaptive Routing（フェイルオーバー強化）
+ルーティングの動的補正機能。2 つの設定からなる。
+
+- **Hash sessions for failover affinity**：Pool 内 Endpoint のフェイルオーバー時、同一クライアントが同じ代替 Endpoint に行くようハッシュで固定。
+- **Failover across pools**：521 / 522 / 523 / 525 / 526 など Cloudflare ⇄ Origin 間エラー発生時、別 Pool に**1 回だけ即時リトライ**。Healthy な代替 Pool が必要。
+
+ヘルスモニタが Critical 判定する前の「最初の 1 リクエスト失敗」を救う性質で、ユーザー体感の可用性に効く。
+
+### Layer 4 LB（Spectrum 連携）
+HTTP/HTTPS 以外の TCP / UDP プロトコル（SSH / SMTP / Minecraft / 任意の独自プロトコル）に対しては **Spectrum** が L4 プロキシとして手前に立ち、その配下に Load Balancing の Pool / Monitor / Steering を組み合わせる構成になる。
+
+- Health Monitor の TCP / UDP-ICMP / SMTP タイプはこの L4 構成のためにある。
+- ただし **Custom Rules は Spectrum と非互換**で、L7 のリクエスト属性ベースのルーティングはできない。
+- 料金は Spectrum 側（Enterprise）と Load Balancing 側の両方が発生する。
+
+### Custom Rules
+リクエスト属性に応じて Load Balancer の挙動を上書きするルール群。
+
+- **Expression**：URI パス / Host / ヘッダ / Cookie / Country / ASN など Cloudflare Rules engine と同等の式。
+- **Action**：Pool 上書き（特定 Pool へ強制）、Steering Policy 上書き、Session Affinity 上書き、TTL 上書き、Fixed Response（メンテページ等）。
+- **典型ユースケース**：`/api/*` は API Pool、`/static/*` は CDN Origin Pool、特定国は Sorry ページ、Beta ユーザー（Cookie）は Canary Pool、など。
+- 制約：**非 Enterprise は LB ホスト名あたり 1 ルール**、**Geo Steering と相互排他**、**Spectrum と非互換**。
+
+### DNS-only LB vs Proxied LB
+| 観点 | DNS-only（gray cloud） | Proxied（orange cloud） |
+|---|---|---|
+| 仕組み | Cloudflare DNS が Healthy Pool の A/AAAA を返す | Cloudflare エッジが TCP/TLS を終端しオリジンへ proxy |
+| TTL | 設定 TTL に依存（フェイルオーバー反映が遅い） | TTL 概念なし（即時フェイルオーバー） |
+| Session Affinity | × | ○ |
+| LOR / Least Connections | × | ○ |
+| Custom Rules | × | ○ |
+| Adaptive Routing | × | ○ |
+| WAF / Bot / Cache 連携 | × | ○ |
+| 任意プロトコル | ○（DNS だけなので何でも） | HTTP/HTTPS のみ（L4 は Spectrum 併用） |
+| 料金 | 安い | Proxy トラフィック費用が乗る |
+
+「TTL 縛りを外したい」「セッション固定が要る」「WAF と連動させたい」なら Proxied 一択、「とにかく軽量に GSLB だけ欲しい」「HTTP 以外を扱いたい」なら DNS-only、と判断軸を分けるのが現実解。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- AWS / GCP / Azure / オンプレを跨いだ active-active マルチクラウド構成。とくに既に Cloudflare をリバースプロキシとして前段に置いている組織。
+- リージョン障害時のフェイルオーバー RTO を **DNS TTL より短く**したい SaaS（Proxied + Adaptive Routing）。
+- 「東京・大阪・シンガポール」のような複数リージョン active-active で、ユーザー位置に応じた最寄り PoP を選びたいケース（Dynamic / Proximity）。
+- データレジデンシー要件で「DE のユーザーは EU 内 Origin に固定したい」ケース（Country Steering）。
+- API バックエンドが処理時間に偏りを持ち、単純なラウンドロビンで詰まりが起きるケース（Least Outstanding Requests）。
+- WebSocket / SSE / 長時間接続混在のリアルタイムサービス（Least Connections）。
+- 既に WAF / CDN / Bot Management を Cloudflare に集約している組織。LB だけ別ベンダーにするより一体管理が効率的。
+
+### 適していないシーン
+- 単一リージョン active-passive で済むワークロード。Route 53 Failover や Azure Traffic Manager で十分でコストも安い。
+- 既存 NS1 / F5 BIG-IP DNS / Akamai GTM に深く投資済みで、Real User Monitoring（RUM）ベースの精緻な GSLB 運用ができている組織。Cloudflare の Steering は十分高機能だが、RUM ベース GSLB の細密さでは NS1 / Akamai に劣るケースがある。
+- オリジンが完全に Cloudflare 配下（Workers / R2 / D1）で完結する場合は LB 不要。Workers のリージョンレス実行と Smart Placement で代替できる。
+- マルチクラスター Kubernetes の east-west トラフィックを GSLB したいケース。これは Service Mesh（Istio / Linkerd / Cilium Cluster Mesh）の領分で、Cloudflare LB は south-north 専用と割り切る。
+
+## 競合・代替
+
+| 観点 | Cloudflare Load Balancing | AWS Route 53 (ARC) | NS1 (IBM) | F5 BIG-IP DNS (旧 GTM) | Akamai GTM | Azure Front Door |
+|---|---|---|---|---|---|---|
+| 出自 | グローバル CDN/Anycast | AWS マネージド DNS | 純血 Managed DNS / GSLB 専業 | オンプレアプライアンス GSLB | グローバル CDN GSLB | Microsoft マネージド ADC |
+| プロキシ統合 | ○（同一エッジで proxy） | ×（DNS のみ。CloudFront 別物） | ×（DNS のみ） | △（BIG-IP LTM 併用） | ○（CDN と統合） | ○（Front Door L7） |
+| RUM ベース GSLB | △（Dynamic はエッジ計測） | × | ○（Pulsar） | ○ | ○（mPulse 連携） | △ |
+| 健康監視 PoP 数 | 330+ PoP から多点 | 限定リージョン | グローバル | 自前構築 | グローバル | Microsoft 網 |
+| L4 / 任意プロトコル | ○（Spectrum 併用） | ○（DNS なら何でも） | ○ | ○ | △ | △（HTTP 中心） |
+| 料金モデル | $5/月 + 従量 | $0.50/zone + クエリ + ヘルスチェック | 高い（要見積） | ライセンス（高額） | エンタープライズ契約 | $35/月 + 従量 |
+| 強み | エッジ統合・WAF/CDN 一体・即時フェイルオーバー | AWS 内サービス連携・低単価 | RUM ベース・DNS 専門ノウハウ | オンプレ・カスタムロジック自由度 | 大規模配信網との一体運用 | Azure 内サービス連携 |
+| 弱み | RUM 精緻さは GTM 系に劣る | プロキシ統合無し・反映が TTL 縛り | 価格・他クラウド統合は手作業 | クラウドネイティブ性に乏しい | 高コスト・小規模に向かない | Azure 外連携は弱い |
+
+Cloudflare の差別化は「**LB が CDN / WAF / Bot / Tunnel と同じデータプレーン上に座っている**」点に尽きる。GSLB 単機能比較では NS1 / Akamai GTM のほうが歴史と精度で勝る場面はあるが、運用面の統合性とコスト効率では Cloudflare に分がある。
+
+## 料金
+- **Pro / Business / Enterprise プランへのアドオン**：基本料金 **$5/月** から。
+- **従量課金**：
+  - **DNS Queries / Proxy Requests**：標準プランで月 50 万クエリ込み、超過分は約 $0.50 / 100 万クエリ。
+  - **Health Checks**：1 Endpoint あたり月 1 ドル前後（Probe Region 数・Interval に依存）。
+  - **追加 Endpoint / Pool**：標準枠を超えた分は超過課金。
+- **Enterprise 契約**：年間契約の総額に組み込まれ、上記単価は交渉対象。Probe All Regions・短い Interval・大量 Endpoint・Custom Rules 複数対応はここで現実的になる。
+- **Spectrum との併用（L4）**：Spectrum 自体が Enterprise 機能で別料金。L4 LB をやるなら実質 Enterprise 前提。
+
+「LB だけ単独で買う」より、Pro / Business で WAF や CDN を併用しているサイトに **$5 + 数ドル**で乗せられる手軽さが、競合との実コスト比較で効いてくる。
+
+## CLI / API 例
+
+### Health Monitor 作成
+```bash
+curl -X POST "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/load_balancers/monitors" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "type": "https",
+    "description": "API healthcheck",
+    "method": "GET",
+    "path": "/healthz",
+    "expected_codes": "200",
+    "expected_body": "ok",
+    "interval": 60,
+    "timeout": 5,
+    "retries": 2,
+    "consecutive_up": 2,
+    "consecutive_down": 3,
+    "follow_redirects": false,
+    "allow_insecure": false,
+    "probe_zone": "example.com",
+    "header": { "Host": ["api.example.com"] }
+  }'
+```
+
+### Pool 作成（AWS Tokyo に 2 Endpoint、LOR で振り分け）
+```bash
+curl -X POST "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/load_balancers/pools" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "name": "pool-aws-tokyo",
+    "description": "AWS ap-northeast-1 origins",
+    "enabled": true,
+    "minimum_origins": 1,
+    "monitor": "'"${MONITOR_ID}"'",
+    "origins": [
+      { "name": "tokyo-1", "address": "203.0.113.10", "weight": 1, "enabled": true },
+      { "name": "tokyo-2", "address": "203.0.113.11", "weight": 1, "enabled": true }
+    ],
+    "origin_steering": { "policy": "least_outstanding_requests" },
+    "latitude": 35.68,
+    "longitude": 139.76,
+    "notification_email": "ops@example.com"
+  }'
+```
+
+### Load Balancer 作成（Proxied / Dynamic Steering / Adaptive Routing 有効）
+```bash
+curl -X POST "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/load_balancers" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "name": "api.example.com",
+    "description": "Multi-region API LB",
+    "enabled": true,
+    "proxied": true,
+    "ttl": 30,
+    "steering_policy": "dynamic_latency",
+    "default_pools": ["'"${POOL_TOKYO}"'", "'"${POOL_OSAKA}"'", "'"${POOL_GCP_OSAKA}"'"],
+    "fallback_pool": "'"${POOL_TOKYO}"'",
+    "session_affinity": "cookie",
+    "session_affinity_ttl": 1800,
+    "session_affinity_attributes": { "samesite": "Auto", "secure": "Auto", "drain_duration": 60 },
+    "adaptive_routing": { "failover_across_pools": true },
+    "rules": [
+      {
+        "name": "static to cdn pool",
+        "condition": "starts_with(http.request.uri.path, \"/static/\")",
+        "overrides": { "default_pools": ["'"${POOL_CDN}"'"] }
+      }
+    ]
+  }'
+```
+
+### Terraform（cloudflare provider v5）
+```hcl
+resource "cloudflare_load_balancer_pool" "tokyo" {
+  account_id        = var.account_id
+  name              = "pool-aws-tokyo"
+  minimum_origins   = 1
+  monitor           = cloudflare_load_balancer_monitor.api.id
+  origins {
+    name    = "tokyo-1"
+    address = "203.0.113.10"
+    weight  = 1
+    enabled = true
+  }
+  origin_steering { policy = "least_outstanding_requests" }
+  latitude  = 35.68
+  longitude = 139.76
+}
+
+resource "cloudflare_load_balancer" "api" {
+  zone_id          = var.zone_id
+  name             = "api.example.com"
+  proxied          = true
+  steering_policy  = "dynamic_latency"
+  default_pool_ids = [cloudflare_load_balancer_pool.tokyo.id, cloudflare_load_balancer_pool.osaka.id]
+  fallback_pool_id = cloudflare_load_balancer_pool.tokyo.id
+  session_affinity = "cookie"
+  adaptive_routing { failover_across_pools = true }
+}
+```
+
+## 制限・注意点
+- **Session Affinity / Custom Rules / LOR / Least Connections / Adaptive Routing は Proxied 専用**。DNS-only モードでは選択できない。要件に Affinity が含まれるなら Proxied 前提で zone を設計する。
+- **Custom Rules は非 Enterprise だと「LB ホスト名あたり 1 ルール」に制限**される。本格的にパスベース・ヘッダベースで Pool を切るなら Enterprise を見込む。
+- **Custom Rules と Geo Steering は相互排他**。両方使いたい場合は Custom Rules の中で Pool 上書きをして Geo を再現する。
+- **Spectrum と Custom Rules は非互換**。L4 LB ではリクエスト属性ベースの分岐はできない。
+- **Health Monitor の Interval を短くする**と Probe トラフィックが Origin 側に乗る。Origin の `/healthz` は軽量・キャッシュなしで設計する。
+- **Probe Region を狭める**と単一 PoP 障害が誤検知に直結する。本番は最低 3 リージョン以上を推奨。
+- DNS-only モードでの Geo / Proximity / Country は **ECS が無いと Resolver IP の地理位置で判定**されるため、Public Resolver（1.1.1.1 / 8.8.8.8）経由のユーザーで意図しない Pool に振られる可能性がある。`location_strategy` の調整が必要。
+- `__cflb` Cookie は HttpOnly のため、フロントエンドの JS からは触れない。SPA からはユーザー識別子を別途持つ必要がある。
+- **TTL 縛り問題（DNS-only）**：DNS TTL を 30 秒にしてもキャッシュリゾルバ次第で守られない。RTO が秒単位なら Proxied を選ぶ。
+- Adaptive Routing の `Failover across pools` は **Cloudflare ⇄ Origin 系のエラー（5xx の特定コード）にだけ反応**する。アプリ層の 500 では発火しないため、ヘルスチェックの応答ボディ検査と組み合わせて欠損を埋める。
+- マルチアカウント運用では Pool / Monitor は Account スコープ、Load Balancer は Zone スコープという階層を意識する。Pool を別 Account から共有することはできない。
+
+## 参考リンク
+- Cloudflare Load Balancing Overview：https://developers.cloudflare.com/load-balancing/
+- Pools：https://developers.cloudflare.com/load-balancing/pools/
+- Monitors：https://developers.cloudflare.com/load-balancing/monitors/
+- Traffic Steering：https://developers.cloudflare.com/load-balancing/understand-basics/traffic-steering/
+- Steering Policies：https://developers.cloudflare.com/load-balancing/understand-basics/traffic-steering/steering-policies/
+- Session Affinity：https://developers.cloudflare.com/load-balancing/understand-basics/session-affinity/
+- Adaptive Routing：https://developers.cloudflare.com/load-balancing/understand-basics/adaptive-routing/
+- Custom Rules：https://developers.cloudflare.com/load-balancing/additional-options/load-balancing-rules/
+- Cloudflare Spectrum（L4 LB 連携）：https://developers.cloudflare.com/spectrum/
+- Load Balancing API：https://developers.cloudflare.com/api/operations/load-balancers-list-load-balancers
+- Terraform `cloudflare_load_balancer`：https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/load_balancer
+- Load Balancing llms.txt：https://developers.cloudflare.com/load-balancing/llms.txt
+
+---
+参照日: 2026-05-04

--- a/src/content/knowledge/web-development/cloudflare-docs/46-magic-transit-wan.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/46-magic-transit-wan.mdx
@@ -1,0 +1,208 @@
+---
+title: "Cloudflare Magic Transit / Magic WAN"
+description: "Magic Transitは「インターネット側から自社の既存IP帯域（最低/24）に来るトラフィック」をBGPアナウンスでCloudflareエッジに引き込み、Anycast PoPでDDoS吸収・L3-L4ファイアウォール適用後にGRE/IPsec/CNI経由で自社データセンターへ戻す“DDoS防御つきインターネットゲートウェイ”である。一方Magic WANは「自社拠点・クラウド・リモートユーザー（WARP）相互の社内通信」をCloudflareネットワーク上のオーバーレイとして束ね、MPLS・ハブ&スポークVPNを置き換えるWANaaS（SD..."
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 46
+---
+# Magic Transit / Magic WAN
+
+## 一行サマリ
+Magic Transitは「インターネット側から自社の既存IP帯域（最低/24）に来るトラフィック」をBGPアナウンスでCloudflareエッジに引き込み、Anycast PoPでDDoS吸収・L3-L4ファイアウォール適用後にGRE/IPsec/CNI経由で自社データセンターへ戻す“DDoS防御つきインターネットゲートウェイ”である。一方Magic WANは「自社拠点・クラウド・リモートユーザー（WARP）相互の社内通信」をCloudflareネットワーク上のオーバーレイとして束ね、MPLS・ハブ&スポークVPNを置き換えるWANaaS（SD-WAN）であり、トラフィックの“向き”と“目的”が真逆の製品である。
+
+## 解決する課題（Why）
+従来型のオンプレ・キャリアMPLS網は、DDoS被害・拠点増加に伴うフルメッシュVPN管理・クラウド直行通信のバックホールという3つの構造課題を抱える。リージョナルなScrubbing Centerに依存するDDoS防御は攻撃源から遠く、回線容量を超えれば即破綻する。MPLSは月額が高く新拠点追加に数週間〜数ヶ月かかる。SaaS全盛時代に全トラフィックを本社経由で出すと帯域とレイテンシが爆発する。Cloudflareはこれを以下のように解き直す。
+
+- 既存パブリックIP帯域（/24以上）をCloudflare Anycastで世界310拠点超に同時アナウンスし、攻撃を発信源近傍で吸収する（Magic Transit）。
+- 拠点・VPC・リモートユーザーを単一オーバーレイに集約し、フルメッシュ管理を不要化（Magic WAN）。
+- L3-L4ファイアウォール（Magic Firewall）をエッジで適用し、オンプレFW筐体を撤去可能にする。
+- パブリックインターネットを通らないCNI（専用線・Equinix/Megaport仮想接続）で帯域・遅延・コストを安定化。
+- WARPクライアントと統合し、リモート社員も同じWANオーバーレイの“拠点”として扱える。
+
+## 主要機能（What）
+
+### Magic Transit
+顧客のパブリック`/24`以上のプレフィックスをCloudflareがBGPでアナウンスし、AnycastでL3トラフィックを吸い上げ、洗浄後に顧客側へ戻す“on-ramp from the Internet”である。Always-On / On-Demand（攻撃時のみ切替）の両モードに対応する。
+
+- **BGP Advertisement**：BYOIP（Bring Your Own IP）で顧客プレフィックスをCloudflareがアナウンス。Cloudflare-leased IP（`/24`未満の場合）も選択可。
+- **Anycast 吸収**：世界中のPoPで同一プレフィックスを受け、攻撃源最寄りで遮断。容量は数百Tbps級。
+- **Advanced DDoS**：L3/L4の振幅増幅・SYN flood・UDP reflectionをML+シグネチャで自動緩和。SLAは攻撃検知3秒・緩和10秒以内。
+- **戻し経路（Return Path）**：GRE トンネル / IPsec トンネル / CNI（専用線）から選択。Direct Server Return（DSR）構成で、レスポンスはCloudflareを経由せず直接インターネットへ返す設計が標準。
+- **Magic Firewall 統合**：エッジでL3-L4ルールを適用し、不要プロトコル・国・IPを落とす。
+- **トンネルヘルスチェック・トラフィックステアリング**：複数トンネルの優先度設定とフェイルオーバー。
+
+### Magic WAN
+拠点・クラウドVPC・リモートWARPユーザーを単一オーバーレイで結ぶSD-WAN/WANaaS。MPLSとハブ&スポークIPsecを置き換える“Cloudflareをバックボーンとして使う”発想である。
+
+- **Sites & Tunnels**：各拠点を「Site」として登録し、IPsec / GRE トンネルで近傍PoPに接続。Site配下の内部プレフィックスを静的ルートまたはBGPで広告。
+- **Magic WAN Connector**：Cloudflareが配布する仮想/物理アプライアンス（x86 / ARM、KVM・VMware・AWS AMI等）。ZTP（Zero-Touch Provisioning）でオンサイト設定不要、SD-WAN相当のアンダーレイ束ねを担う。
+- **WARP 連携**：リモート社員のWARPクライアントをMagic WANの“仮想Site”として扱い、拠点リソースへ直接到達できる。Gateway / Accessポリシーがそのまま適用可能。
+- **Multi-Cloud Networking**：AWS / Azure / GCPのVPCをディスカバリし、Cloud Connector経由でWAN参加。クラウド間通信もCloudflareバックボーンを通る。
+- **BGP ピアリング**：Site側ルーターとPoP間でBGPセッションを張り、プレフィックス追加削除を動的化。
+- **Magic Firewall 統合**：拠点間（east-west）通信にも同じL3-L4ポリシーを強制。
+
+### Magic Firewall
+Magic Transit / Magic WANに付帯するクラウドL3-L4 FWaaS。Wireshark構文ベースの「Cloudflare Rules language」でパケットヘッダ・ペイロード長・プロトコルを評価し、エッジで遮断する。IDS（Intrusion Detection System）として既知シグネチャの監視も提供。オンプレのCisco ASA / Fortinet筐体を撤去し、ルール管理をAPI/Terraform化する用途が中心。Magic Transit / Magic WANの契約に内包され、単独販売はされない。
+
+### Cloudflare Network Interconnect (CNI)
+顧客ネットワークをパブリックインターネットを介さずCloudflareへ直接接続する物理/仮想クロスコネクト。
+
+- **Direct CNI**：Cloudflare PoPと同居するデータセンター内（Equinix / Coresite等）で物理ポートを直接ケーブル接続。
+- **Partner CNI**：Equinix Fabric / Megaport / Console Connect / PacketFabric等のNaaSパートナー経由で仮想クロスコネクト。物理同居なしに数分でプロビジョニング可能。
+- **Cloud CNI**：AWS Direct Connect / Azure ExpressRoute / Google Partner Interconnectからの専用接続。
+- **Dataplane v1 / v2**：v1はGREトンネル前提でMagic Transit DSR・Egress・Zero Trustに対応。v2はCustomer Connectivity Router（CCR）ベースでGRE不要のシンプルなBGPルーティングを提供。
+- Magic Transit/WANの“最終マイル”として、回線品質・MTU・レイテンシを安定化させる。
+
+### WARP-Magic 連携
+WARPクライアントはMagic WANの「リモートSite」として動作し、社員端末からWAN内のプライベートIPに直接到達できる。Gateway（外向きSWG）+ Access（内向き認可）+ Magic WAN（拠点間）+ WARP（端末）が単一プレーンで設計でき、SASE/SSE全機能を1ベンダーに集約できるのがCloudflareの構造的優位である。
+
+## アーキテクト視点：いつ選ぶか
+
+### Magic Transit を選ぶシーン
+- 自社で`/24`以上のIP帯域を保有しており、ゲーミング・金融・公共系等で大規模L3/L4 DDoSを常時警戒する組織。
+- オンプレDC・コロケーションを残しつつ、上流ISPのDDoS Scrubbingでは容量・SLA不足な場合。
+- WAFだけでなく、HTTP以外のプロトコル（DNS権威 / SMTP / ゲームサーバ / VoIP）も保護対象に含むケース。
+- 公開IPを変えずにCloudflareへ移行したい（既存DNSレコード・パートナー連携の更改コストを抑えたい）ケース。
+
+### Magic WAN を選ぶシーン
+- 数十〜数百拠点をMPLSまたはハブ&スポークIPsecで運用しており、回線費・運用負荷が肥大化している組織。
+- 拠点・マルチクラウド・リモート社員をひとつのWANポリシー面で扱いたい（SASE移行の一環）。
+- 既にCloudflare One（Access / Gateway / WARP）を導入済みで、L3レベルの拠点間通信もCloudflareに寄せたい。
+- 新規拠点立ち上げが頻繁で、回線開通リードタイムを数日以内に短縮したい。
+
+### 適していないシーン
+- 自社IPを持たず、Webサービスの保護だけが目的なら通常の**Cloudflare WAF / Proxy（Tier1）で十分**。Magic Transitはオーバースペックで高額。
+- 規制で「特定海外事業者にL3トラフィックを集約してはならない」制約がある政府・防衛系。
+- 数拠点しかない小規模組織でMPLS課題が顕在化していない場合、Magic WANは投資回収が遅い。
+- リアルタイム性が極端に重要（金融HFT・産業制御）な拠点間通信で、Cloudflare PoP経由のレイテンシが許容できないケース。
+- 既にAWS Cloud WAN / Azure Virtual WANに全面投資済みで、クラウド出口がそちらに寄っている場合。
+
+## 競合・代替
+
+| 観点 | Cloudflare Magic Transit/WAN | AWS Cloud WAN | Megaport (MCR) | Aryaka | Zscaler ZIA/ZPA | Cato Networks | Versa SASE |
+|---|---|---|---|---|---|---|---|
+| 出自 | Anycast CDN / DDoS防御 | AWSグローバルバックボーン | NaaS / クロスコネクト | マネージドSD-WAN（FlexCore） | 純血SASE / SWG | SD-WAN+SSEのフル統合PoP | SD-WAN（Versa OS）+SSE |
+| L3 DDoS 防御 | ◎（数百Tbps Anycast） | △（AWS Shield別） | ✕ | △ | △（HTTPS中心） | ○ | ○ |
+| 拠点間 SD-WAN | ○（Magic WAN Connector） | ◎（AWS内優位） | ◎（NaaS） | ◎（マネージド込み） | △（ZPA中心） | ◎（SASE統合） | ◎（機能最多） |
+| BYOIP / BGP | ◎（標準） | ○ | ○ | △ | ✕ | △ | ○ |
+| FWaaS / SWG | Magic Firewall + Gateway | NW Firewall | パートナー経由 | パートナー経由 | ◎（本職） | ◎（統合） | ◎（統合） |
+| クラウド接続 | CNI（Direct/Partner/Cloud） | AWSネイティブ | 全クラウド対応 | 全クラウド対応 | クラウドコネクタ | 統合PoP | 統合PoP |
+| 価格 | Enterprise契約（要見積） | AWS従量+Attachment課金 | ポート+VXC従量 | 高額・マネージド込み | 高額（ユーザー課金） | 中〜高（バンドル） | 高額（機能フル） |
+| 強み | DDoS実績・Anycast網・Cloudflare One統合 | AWSとの密結合・運用容易 | 物理接続の柔軟性 | フルマネージド・運用代行 | SASEの成熟度 | 単一ベンダーSASE完結 | 機能網羅性・カスタマイズ |
+| 弱み | 物理回線・ラストワンマイルは別途 | AWS外の拠点接続は別工夫 | セキュリティ機能なし | 高コスト・ロックイン | L3/拠点間は弱い | PoP数はCloudflareに劣る | 運用が複雑 |
+
+CloudflareはDDoS防御の容量・PoP数・Cloudflare Oneとの統合という3点で他に代替が利きにくい。逆に「拠点間SD-WANの機能網羅」だけを軸にするとCato/Versaのほうが成熟しており、AWS中心の組織はCloud WANと比較する価値がある。Megaport/Equinixは“競合”というよりCloudflare CNIの**パートナー側**として併用する関係である。
+
+## 料金
+Magic Transit / Magic WAN / Magic Firewall / CNIはいずれも**Enterprise専用・契約ベース**であり、公開価格は存在しない。一般的に以下の軸で見積もられる。
+
+- **Magic Transit**：保護対象帯域幅（Mbps / Gbps）、保護対象プレフィックス数、Always-On / On-Demand、トンネル本数、SLAレベル。
+- **Magic WAN**：Site数、契約帯域、Connectorライセンス数、Cloud Connector数、WARPシート数。
+- **Magic Firewall**：Magic Transit / WAN契約に内包（単独購入不可）。ルール数・IDS有効化で上振れ。
+- **CNI**：Direct CNIはポート費（年額）、Partner CNIはNaaS側ポート+VXC費+Cloudflare側接続費の合算、Cloud CNIは各クラウドのDirect Connect/ExpressRoute側課金が別途発生。
+
+PoC段階ではAlways-OnではなくOn-Demand Magic Transitから入る、CNI なしのIPsec接続で開始してから物理接続にアップグレードする、というステップで初期費を抑えるのが定石である。
+
+## CLI / API 例
+Cloudflare APIはアカウントスコープのRESTで、`/accounts/{account_id}/magic/...`配下にSites / Connectors / IPsec Tunnels / GRE Tunnels / Static Routesが並ぶ。以下はcurl例。
+
+### IPsec トンネル作成
+```bash
+curl -X POST "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/magic/ipsec_tunnels" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "tokyo-dc-ipsec-01",
+    "customer_endpoint": "203.0.113.10",
+    "cloudflare_endpoint": "162.159.65.1",
+    "interface_address": "10.212.0.1/31",
+    "description": "Tokyo DC primary IPsec to NRT PoP",
+    "psk": "REPLACE_WITH_STRONG_PSK",
+    "health_check": {
+      "enabled": true,
+      "type": "request",
+      "rate": "mid"
+    }
+  }'
+```
+
+### GRE トンネル作成（Magic Transit戻し経路）
+```bash
+curl -X POST "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/magic/gre_tunnels" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "tokyo-dc-gre-01",
+    "customer_gre_endpoint": "203.0.113.10",
+    "cloudflare_gre_endpoint": "162.159.66.1",
+    "interface_address": "10.224.0.1/31",
+    "mtu": 1476,
+    "ttl": 64,
+    "description": "Magic Transit return path"
+  }'
+```
+
+### Magic WAN Site と静的ルート作成
+```bash
+# Site作成
+curl -X POST "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/magic/sites" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "osaka-branch",
+    "description": "Osaka branch office",
+    "location": { "lat": "34.6937", "lon": "135.5023" }
+  }'
+
+# 拠点配下プレフィックスをトンネル経由でルーティング
+curl -X POST "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/magic/routes" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prefix": "10.10.20.0/24",
+    "nexthop": "10.212.0.0",
+    "priority": 100,
+    "description": "osaka-branch internal subnet"
+  }'
+```
+
+### Magic Firewall ルール（特定国からのSSHを遮断）
+```bash
+curl -X POST "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/magic/schemas/network_firewall/rulesets" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "block-foreign-ssh",
+    "expression": "ip.geoip.country in {\"KP\" \"RU\"} and tcp.dstport == 22",
+    "action": "block",
+    "enabled": true
+  }'
+```
+
+実運用ではTerraform `cloudflare` providerの `cloudflare_magic_wan_*` / `cloudflare_magic_firewall_ruleset` リソースで宣言的に管理するのが主流である。
+
+## 制限・注意点
+- **BGPアナウンスは原則`/24`単位**。`/25`以下は自社プレフィックスとしてはアナウンスできず、Cloudflare-leased IPの利用が必要になる。
+- **MTU設計が要**。GREは1476、IPsecは1436前後が目安。クライアント側でPath MTU Discoveryが効かない経路（ICMP遮断）だとTCP通信が無言で詰まる。設計段階でMSS Clamping必須。
+- **DSR（Direct Server Return）構成が前提**。下り（顧客→クライアント）はCloudflareを通らないため、戻り経路のFW・NATがCloudflareの送信元IPを許可している必要がある。
+- **Encrypted Magic Transit**（IPsec）はGRE比でスループットが落ちる。高帯域はGRE+別途暗号化、またはCNIでパブリック経路を回避する設計が無難。
+- **リージョン選定**：日本拠点ならNRT/HND/KIX/ITM等の最寄りPoPに紐付くようBGPコミュニティとSite Locationを設定する。グローバルAnycastのまま放置すると意図せず海外PoP経由になることがある。
+- **On-Demand Magic Transit**は攻撃検知時のみBGPを切り替えるため、平時はCloudflareを経由しない。Always-Onと比べてPoCは安価だが、切替時に数秒のセッション断が発生し得る。
+- **Magic WAN ConnectorはZTP前提**。MDM的な運用基盤がない場合、初期キッティングで詰まる。物理アプライアンスはサポート国・物流リードタイムを事前確認。
+- **CNI Partner経由**は中継NaaS（Megaport/Equinix）側のMTUとVLAN設計に依存する。両端でMTU 1500を確保できるかが性能の分かれ目。
+- **Magic Firewall**は単独販売されない。FWaaSだけ欲しいというユースケースには使えず、Magic Transit/WAN契約とセット。
+- **Cloudflare One（Gateway/Access/WARP）**との料金体系は別。SASE全部入りで見せられる見積もりでも、内訳上はZero Trustライセンス+Magic WAN+Magic Transit+CNIに分かれる点に注意。
+
+## 参考リンク
+- Magic Transit：https://developers.cloudflare.com/magic-transit/
+- Magic WAN：https://developers.cloudflare.com/magic-wan/
+- Magic Firewall（Network Firewall）：https://developers.cloudflare.com/magic-firewall/
+- Cloudflare Network Interconnect：https://developers.cloudflare.com/network-interconnect/
+- Magic WAN Connector：https://developers.cloudflare.com/magic-wan/configuration/connector/
+- Magic Transit BYOIP：https://developers.cloudflare.com/byoip/
+- Cloudflare API（Magic Transit/WAN）：https://developers.cloudflare.com/api/operations/magic-ipsec-tunnels-list-i-psec-tunnels
+- Terraform `cloudflare` provider：https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs
+
+---
+参照日: 2026-05-04

--- a/src/content/knowledge/web-development/cloudflare-docs/47-rate-limiting.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/47-rate-limiting.mdx
@@ -1,0 +1,244 @@
+---
+title: "Cloudflare Rate Limiting"
+description: "Cloudflareエッジで「同じ識別子（IP / Header / Cookie / Body フィールド等）から一定期間に何リクエスト来たか」をカウントし、閾値を超えたものをBlock / Challenge / Logするレートベース制御である。WAF配下の「Rate limiting rules」として統合され、Enterpriseでは複雑な特徴量や複雑度スコアに基づくAdvanced Rate Limitingまで一気通貫で書ける。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 47
+---
+# Rate Limiting
+
+## 一行サマリ
+Cloudflareエッジで「同じ識別子（IP / Header / Cookie / Body フィールド等）から一定期間に何リクエスト来たか」をカウントし、閾値を超えたものをBlock / Challenge / Logするレートベース制御である。WAF配下の「Rate limiting rules」として統合され、Enterpriseでは複雑な特徴量や複雑度スコアに基づくAdvanced Rate Limitingまで一気通貫で書ける。
+
+## 解決する課題（Why）
+WAFの署名ベース防御は「1リクエスト単体が悪性かどうか」しか見ない。そのためログイン総当たり、商品在庫の買い占め、価格スクレイピング、APIキー流出後の暴走呼び出しといった「個別リクエストは正常だが、頻度が異常」な攻撃を捉えられない。Originのアプリ側でカウンタを実装すると、(1) インスタンス間の状態共有（Redis等）、(2) WAF・LBより手前で止められない、(3) Botネットワークによる分散リクエストで識別子設計を間違えやすい、という運用負債を抱える。Cloudflare Rate Limitingはこれをエッジ側で完結させ、以下を解決する。
+
+- ログインPOSTやワンタイムトークン検証エンドポイントへの総当たりを、ユーザー名（リクエストボディ）単位で抑止。
+- 在庫・予約・チケット販売の買い占めBotを、Cookie / セッションID単位で抑止。
+- 公開API（無料プラン）における暴走呼び出しを、APIキー（Header）単位で抑止。
+- スクレイピングを、JA3/JA4フィンガープリントやASN単位でしきい値運用。
+- Originに到達する前にBlock / Managed Challengeで返すことで、バックエンドの計算資源・DB接続を保護。
+
+## 主要機能（What）
+
+### Rate Limiting Rules（WAF統合）
+2023年の刷新で従来の「Legacy Rate Limiting」はWAF配下の `rate limiting rules` として統合された。WAF Custom Rules / Managed Rulesと同じRules言語（`http.request.uri.path`, `http.request.method`, `ip.src`, `cf.bot_management.score` 等）でマッチ条件を書き、そこに「Period内に何回マッチしたら何をするか」を重ねる構造になっている。
+
+- **Expression**：マッチ対象を絞り込むRules言語式。`http.request.uri.path eq "/api/login" and http.request.method eq "POST"` のように、レート制限を効かせたいエンドポイントだけを切り出す。
+- **Characteristics（カウント単位）**：誰／何ごとにカウントするか。IP / IP with NAT / Header / Cookie / Body / JA3-JA4 / ASN / Country / Path / Custom など。
+- **Period**：カウントの時間窓（秒）。Free 10秒、Pro 最大1分、Business / Enterprise 最大10分（最大65,535秒まで対応するプランあり）。
+- **Requests per period**：閾値。
+- **Mitigation timeout（Duration）**：閾値到達後、どれだけの間アクションを継続するか。Pro 最大1時間、Business / Enterprise 最大24時間。
+- **Action**：Block / Managed Challenge / JS Challenge / Interactive Challenge / Log。EnterpriseではBlock時に「Throttle requests above rate」（超過分のみブロック、閾値以下は通す）が選べる。
+
+### Advanced Rate Limiting（Business以上 / 多くはEnterprise）
+標準のIP単位カウントでは捉えられないユースケースを、複合特徴量とペイロードベースで吸収する上位機能群。
+
+- **Complex characteristics**：複数のSelectorを組み合わせ「同一IP + 同一User-Agent + 同一Cookie値」のような複合キーでカウント。Botネットの分散攻撃で「IPは違うがUser-Agentが同じ」「Cookieは違うがJA4が同じ」といった揺らぎを潰せる。
+- **Payload-based**：`http.request.body.form["username"]` のようにリクエストボディ内のフィールドをカウント単位にできる。ログインAPIで「同じusernameに対する試行回数」を直接抑制でき、IP単位より攻撃意図に近い指標になる。
+- **Complexity score**：1リクエストの「重さ」（コスト）を score として加算し、純粋な回数ではなく総コストで閾値を切るモデル。重いGraphQLクエリやレポート生成APIでの暴走対策に向く。
+- **Throttle action**：閾値超過分のみをBlock / Challengeし、閾値以下のリクエストはそのまま通す（純粋な「整流」）。
+
+### Counting Characteristics（プラン別対応）
+カウント単位として何を選べるかはプランで明確に分かれる。
+
+| プラン | 利用可能な Characteristics |
+|---|---|
+| Free | IP のみ |
+| Pro | IP |
+| Business | IP / IP with NAT |
+| Enterprise（Advanced） | IP / IP with NAT / Header / Cookie / ASN / Country / Path / JA3-JA4 Fingerprint / JSON field / Body / Form input / Custom expression |
+
+「IP with NAT」はCloudflareが推定する「同一NAT配下を1ユーザーとみなす」拡張で、モバイルキャリアNATや企業プロキシで誤ブロックを抑える。
+
+### Mitigation Timeout（Duration）
+閾値到達後、どれくらい制裁を続けるか。短すぎれば攻撃側が即座にリトライするだけになるし、長すぎれば誤検知が業務を止める。一般的な設計指針は次の通り。
+
+- ログインBrute-force：Period 60s / Threshold 5〜10 / Timeout 10〜30分（人間のリトライ時間に合わせる）。
+- スクレイピング：Period 60s / Threshold 100〜300 / Timeout 1〜24時間（ターゲットコンテンツの重要度次第）。
+- API濫用：Period 60s / Threshold = プランごとのRPS×60 / Timeout 10分〜1時間（請求と整合する制裁時間）。
+
+### Workers Rate Limiting API（自前実装の選択肢）
+WAFのRate Limiting Rulesは「ゾーン全体に対するエッジ手前の機械的制御」だが、Workers Rate Limiting APIは「Worker内のロジック条件込みでカウントしたい」場合の補完である。
+
+- `env.MY_RATE_LIMITER.limit({ key })` のシンプルなAPIで、内部的にDurable Objectsベースのカウンタが走る。
+- 認証後のユーザーID単位、ワークフローのステップ単位など、WAF Expressionでは表現しづらい「アプリ文脈で正規化したキー」でレート制限できる。
+- KV / Durable Objectsを直接叩いて自前カウンタを書くこともできるが、それは整合性・コスト・実装複雑度を引き受ける覚悟が要る。Rate Limiting APIは「DOで自前実装する一歩手前」を引き受ける位置づけである。
+
+### Legacy Rate Limiting（deprecated）からの移行
+2017年から提供されていた旧Rate Limiting（ダッシュボード上で「Tools → Rate Limiting」にあった独立機能）は、現在は新しい「WAF配下のRate limiting rules」に統合されている。
+
+- 旧ルールは引き続き動作するが、新規作成は新形式で行う前提。
+- 旧ルールは「URLパターン + Method + Threshold」しか持たないため、Expressionによる柔軟な絞り込みやEnterprise Advanced機能が使えない。
+- 移行はCloudflareダッシュボードの誘導またはAPI（`POST /zones/{id}/rulesets/.../rules` で `phase = http_ratelimit`）で行う。Terraform管理下なら `cloudflare_ruleset` リソースに `phase = "http_ratelimit"` で書き直す。
+
+## アーキテクト視点：いつ選ぶか
+
+### Bot Management / API Shield との役割分担
+3者は「速度・形・素性」のどこで切るかで棲み分ける。
+
+- **Rate Limiting**：速度（頻度）で切る。識別子と閾値・期間というシンプルなモデル。Bot判定ができない（しない）リクエストにも効く。
+- **Bot Management**：素性（人間 / 良性Bot / 悪性Bot）で切る。Bot Score、JA4、機械学習による行動分析。「人間っぽいかどうか」の判定そのもの。
+- **API Shield**：形（API契約）で切る。OpenAPIスキーマからの逸脱、Schema Validation、Sequence Mitigation、JWT検証。APIエンドポイントを「正しい形のリクエストか」で守る。
+
+実運用では `[Bot Management で明確な悪性Botを落とす] → [API Shieldでスキーマ違反を落とす] → [Rate Limitingで人間/Bot問わず頻度異常を抑える]` のように直列配置する。Rate Limiting単独では「分散Bot」「人間っぽいBot」を取り逃がしやすく、Bot Management単独では「正規ユーザーの暴走」「APIキー漏洩後の悪用」を取り逃がしやすい。
+
+### 適しているシーン
+- ログインAPI / OTP送信API / パスワードリセットAPIなど、明確に「同一識別子からの連続試行」が攻撃シグナルになるエンドポイント。
+- 公開APIの無料プランRPS制限の実装基盤（課金プラン別のしきい値運用）。
+- 在庫・予約・チケットなど買い占めBot対策（Cookie / セッション単位）。
+- スクレイピング対策の第1段（JA3/JA4 / ASN単位でPeriod長め）。
+
+### 適していないシーン
+- そもそもCloudflare経由していないトラフィック（Origin直アクセス可能なIP）にはRate Limitingは効かない。Origin IP秘匿が前提。
+- Worker内のロジック条件・認証後ユーザーID単位の制御は、Workers Rate Limiting APIまたはアプリ側実装の方が適切。
+- 短期スパイクではなく長期傾向（1日単位の総量配分）はQuota管理の世界で、Apigee Quotaや自前のメータリングが向く。
+
+## 競合・代替
+
+| 観点 | Cloudflare Rate Limiting | AWS WAF Rate-based | Kong Rate Limiting | Apigee Quota / Spike Arrest | Akamai Rate Controls | Imperva ABP |
+|---|---|---|---|---|---|---|
+| 配置 | エッジ（Cloudflareネットワーク） | エッジ（CloudFront / ALB / API GW） | API Gateway内 | API Management内 | エッジ（Akamai） | エッジ（Imperva） |
+| カウント単位 | IP / Header / Cookie / Body / JA3-JA4 / ASN / Country 他（Enterprise） | IP / Header / Forwarded IP / カスタムキー | Consumer / Credential / IP / Service / Header | API key / Developer / App / Product | IP / Geo / カスタム | IP / セッション / フィンガープリント |
+| ペイロード単位カウント | あり（Form input / JSON field / Body）※Enterprise | 限定的（ヘッダ・クエリ中心） | あり（Body parser plugin） | あり（API Productに紐づく） | あり | あり |
+| Throttle（超過分のみ） | あり | あり（Block / Count） | あり | Spike Arrestで実装 | あり | あり |
+| Bot対策との統合 | Bot Managementと密結合 | AWS WAF Bot Controlは別ルール | 別Plugin | 別商品 | Bot Manager別商品 | 同一プラットフォーム強み |
+| 強み | エッジ統合・JA4 / Body単位までエッジで完結 | AWSスタック完結・IaC成熟 | OSS基盤・自前運用OK・拡張性 | API管理基盤としての設計力 | 大規模配信基盤・成熟度 | Bot対策と一体運用 |
+| 弱み | Free / ProでIP単位以外不可 | カウント単位の柔軟性は中位 | 自前運用のオーバーヘッド | エッジではなくAPIゲートウェイ位置 | 高コスト・調達ハードル | 高コスト |
+
+CloudflareのRate Limitingは「エッジで止められる」「JA4 / Body / Cookieまでエッジで効く」「Bot Management / API Shield / WAFと同じプレーンで書ける」点に集約される。Originがマルチクラウドだったり、API Gatewayレイヤを別ベンダーで揃えていてもエッジ手前で1段絞れるのが最大の差別化要因である。
+
+## 料金
+- **Free**：Rate Limiting Rules 1ルール（一部公開情報では「Previously Free」枠相当）。Period最大10秒、IP単位のみ。検証用途。
+- **Pro**：5ルール程度。Period最大1分、Mitigation Timeout最大1時間、IP単位のみ。
+- **Business**：15ルール程度。IP / IP with NAT。Period・Timeoutともに上限拡張。
+- **Enterprise**：100ルール超 + Advanced Rate Limiting（Header / Cookie / Body / JA4 / ASN / Country / Custom expression、Complexity score、Throttle action）。Period最大10分（プラン詳細によっては65,535秒まで）、Timeout最大24時間。
+
+実装上は「Free / Proは『IPベースの最低限の防衛線』、Business以上から『業務要件に沿ったRate Limiting設計』が現実解」と割り切るのが妥当である。WAFやBot Managementとセットで Enterprise Advanced を引くケースが多い。
+
+## CLI / API 例
+
+### Ruleset API（curl）でレート制限ルールを追加
+http_ratelimit phaseのrulesetに追加する形になる。
+
+```bash
+ZONE_ID="..."
+TOKEN="..."
+
+# 1) http_ratelimit phaseのentry point rulesetを取得（無ければ作成）
+curl -s -X GET \
+  "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/rulesets/phases/http_ratelimit/entrypoint" \
+  -H "Authorization: Bearer ${TOKEN}"
+
+# 2) ルールを追加：/api/login への POST に対し、IP単位で60秒5回を超えたら10分Block
+curl -s -X POST \
+  "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/rulesets/phases/http_ratelimit/entrypoint/rules" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "description": "Login brute-force protection",
+    "expression": "(http.request.uri.path eq \"/api/login\" and http.request.method eq \"POST\")",
+    "action": "block",
+    "ratelimit": {
+      "characteristics": ["ip.src", "cf.colo.id"],
+      "period": 60,
+      "requests_per_period": 5,
+      "mitigation_timeout": 600
+    }
+  }'
+```
+
+### Terraform（cloudflare provider v5）
+```hcl
+resource "cloudflare_ruleset" "rate_limit_login" {
+  zone_id     = var.zone_id
+  name        = "Rate limiting rules"
+  description = "Edge rate limiting"
+  kind        = "zone"
+  phase       = "http_ratelimit"
+
+  rules = [
+    {
+      description = "Login brute-force: 5 req/60s per IP -> block 10min"
+      expression  = "(http.request.uri.path eq \"/api/login\" and http.request.method eq \"POST\")"
+      action      = "block"
+      ratelimit = {
+        characteristics     = ["ip.src", "cf.colo.id"]
+        period              = 60
+        requests_per_period = 5
+        mitigation_timeout  = 600
+      }
+    },
+    {
+      description = "API key abuse: 1000 req/60s per X-Api-Key -> managed_challenge 1h"
+      expression  = "(starts_with(http.request.uri.path, \"/api/\"))"
+      action      = "managed_challenge"
+      ratelimit = {
+        characteristics     = ["http.request.headers[\"x-api-key\"]", "cf.colo.id"]
+        period              = 60
+        requests_per_period = 1000
+        mitigation_timeout  = 3600
+      }
+    },
+    {
+      description = "Login attempts per username (Advanced Rate Limiting / Enterprise)"
+      expression  = "(http.request.uri.path eq \"/api/login\" and http.request.method eq \"POST\")"
+      action      = "block"
+      ratelimit = {
+        characteristics     = ["http.request.body.form[\"username\"]", "cf.colo.id"]
+        period              = 60
+        requests_per_period = 10
+        mitigation_timeout  = 1800
+      }
+    },
+  ]
+}
+```
+
+### Workers Rate Limiting API
+```jsonc
+// wrangler.jsonc
+{
+  "name": "api-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2025-01-01",
+  "ratelimits": [
+    { "name": "API_LIMITER", "namespace_id": "1001", "simple": { "limit": 100, "period": 60 } }
+  ]
+}
+```
+
+```ts
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const userId = await authenticate(req); // 認証後のユーザーID
+    const { success } = await env.API_LIMITER.limit({ key: userId });
+    if (!success) return new Response("rate limited", { status: 429 });
+    return handle(req);
+  },
+};
+```
+
+## 制限・注意点
+- **カウンタ更新の遅延**：Cloudflareは「リクエスト検知からカウンタ反映まで数秒の遅延がある」と明記している。閾値直後の数秒間は超過リクエストがOriginに届く前提で設計する（Origin側にも保険を置く）。
+- **Period上限はプラン依存**：Free 10秒、Pro 1分、Business / Enterprise 10分〜（プラン詳細により最大65,535秒）。Period長を前提にした設計（例：1時間レート）はBusiness以上。
+- **Counting Characteristics数とルール数の上限**：プランごとに利用可能な特徴量の種類数とルール数が決まる。Header / Cookie / Body単位が必要なら原則Enterprise。
+- **`cf.colo.id` の扱い**：CloudflareはAnycastで複数PoPに分散するため、特徴量に `cf.colo.id` を加えて「PoPごとカウント」とする運用が公式サンプルでも採用されている。グローバルに厳密な集約カウントが要るケースには向かない（その用途はWorkers Rate Limiting APIや自前DOで実装）。
+- **OriginIP直叩き対策**：Cloudflareを通らなければ意味がない。Authenticated Origin Pulls / Cloudflare Tunnel / Origin IPホワイトリストで直アクセスを塞ぐ前提が必要。
+- **Bot Managementとの順序**：同一フェーズで動作するため、ルールの優先順位（Custom Rules → Rate Limiting Rules → Managed Rules）を意識して設計する。Bot Management未契約の環境でRate Limitingだけに頼ると、分散Botに対しては効果が薄い。
+- **Legacy Rate Limitingの扱い**：旧ルールは新形式と並存できるが、Advanced機能・新Expression言語が使えないため、移行を前提に棚卸しする。
+
+## 参考リンク
+- Cloudflare WAF Rate Limiting Rules：https://developers.cloudflare.com/waf/rate-limiting-rules/
+- Advanced Rate Limiting：https://developers.cloudflare.com/waf/rate-limiting-rules/use-cases/
+- Counting characteristics（プラン別対応）：https://developers.cloudflare.com/waf/rate-limiting-rules/parameters/#characteristics
+- Workers Rate Limiting API：https://developers.cloudflare.com/workers/runtime-apis/bindings/rate-limit/
+- Ruleset API（http_ratelimit phase）：https://developers.cloudflare.com/ruleset-engine/about/phases/
+- Terraform `cloudflare_ruleset`：https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/ruleset
+- Cloudflare Plans（料金）：https://www.cloudflare.com/plans/
+- Bot Management（役割分担）：https://developers.cloudflare.com/bots/
+- API Shield（役割分担）：https://developers.cloudflare.com/api-shield/
+
+---
+参照日: 2026-05-04

--- a/src/content/knowledge/web-development/cloudflare-docs/48-spectrum.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/48-spectrum.mdx
@@ -1,0 +1,200 @@
+---
+title: "Cloudflare Spectrum"
+description: "HTTP/HTTPSに収まらない任意のTCP/UDPアプリケーション（SSH・Minecraft・MQTT・RDP・FTP・カスタムゲームプロトコル等）を、Cloudflare Anycastエッジでリバースプロキシし、L3/4 DDoS緩和・オリジンIP秘匿・アクセス制御・Argo経路最適化を一括で適用するL4プロキシサービスである。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 48
+---
+# Spectrum
+
+## 一行サマリ
+HTTP/HTTPSに収まらない任意のTCP/UDPアプリケーション（SSH・Minecraft・MQTT・RDP・FTP・カスタムゲームプロトコル等）を、Cloudflare Anycastエッジでリバースプロキシし、L3/4 DDoS緩和・オリジンIP秘匿・アクセス制御・Argo経路最適化を一括で適用するL4プロキシサービスである。
+
+## 解決する課題（Why）
+ゲームサーバー・SSH踏み台・産業用MQTTブローカー・社内RDPゲートウェイのような「HTTP化できない」サービスを公開すると、CDN/WAFの恩恵を受けられず、オリジンIPがそのままインターネットに露出する。一度IPが特定されればL3/4 DDoSで簡単に落ち、IPローテーションで逃げ続けるか、回線会社のクリーンパイプ契約に頼るしかない。Spectrumはこの状況を以下のように解決する。
+
+- オリジンIPをCloudflare Anycast IPの背後に隠蔽し、IPベースの直撃DDoSを物理的に届かなくする。
+- Cloudflareの無制限L3/4 DDoS緩和をHTTP以外のプロトコルにも適用する（Pro以上は緩和能力に追加課金なし）。
+- IP Access Rulesで国/ASN/IPレンジ単位のホワイトリスト/ブラックリストを、ゲームサーバーやSSHにも適用する。
+- Origin Authentication（mTLS）でCloudflareエッジ↔オリジン間を相互認証し、IPフィルタすり抜けからオリジンを守る。
+- Argo Smart Routingでゲーム/対戦系のRTTジッタを実測ベースで最適化する。
+- Load Balancingと組み合わせ、TCP/UDPサービスにもヘルスチェック・ジオステアリングを適用する。
+
+## 主要機能（What）
+
+### TCP/UDP Application
+Spectrumの中核オブジェクト。「edge側のhostname:port」と「origin側のIP:port」をマッピングし、プロトコル（tcp/udp）・TLS終端（off / flexible / full / strict）・Proxy Protocol（v1 / v2 / Simple）を指定する。Edge IPはAnycast Dynamic（Cloudflareの共有IPプール）またはStatic/Reserved IP（Enterprise）から選択する。
+
+- DNSターゲットはCNAME（zone内hostname）またはApex（ルートドメイン）を指定可能。
+- Edge portとOrigin portは異なる値を取れる（例：edge 25565 → origin 25600）。
+- 単一Anycast IPの背後に複数アプリケーションを束ねられる（ポート単位で多重化）。
+
+### Origin Authentication (mTLS)
+Cloudflareエッジ↔オリジン間でmTLSを張り、「このTLSセッションは間違いなくCloudflareから来た」とオリジン側で検証する仕組み。Cloudflare Origin CAが発行するクライアント証明書をエッジが提示し、オリジンのTLSサーバーがCAチェーン検証で受理する。これによりオリジンIPが何らかの形で漏れても、直接接続を拒否できる。
+
+### IP Access Rules
+ゾーン/アカウント単位のIP / CIDR / ASN / Country単位のAllow / Block / Challenge / JS Challengeルールが、Spectrumで公開したTCP/UDPサービスにも自動適用される。SSH踏み台を「日本のオフィスIPと特定VPN ASNのみAllow、それ以外Block」といった運用がGUI/APIで完結する。
+
+### Argo Smart Routing 連動
+Argoを契約している場合、Spectrumトラフィックも実測RTTベースの最適経路でCloudflareバックボーンを通す。BGPデフォルトでは中継ASを跨ぐ非効率な経路に落ちるリージョン間（例：日本↔ブラジル、APAC↔EU）で、対戦ゲーム・株取引・SSHのレスポンス改善に効く。
+
+### Load Balancing 連動
+Cloudflare Load Balancerをoriginに指定でき、TCPヘルスチェック（接続成功 or 任意のバナー文字列マッチ）でフェイルオーバー、ジオステアリング（最寄りリージョンへ振る）、加重ステアリング、Session Affinityを適用できる。「Tokyo / Singapore / Frankfurt にゲームサーバーを置き、プレイヤーの最寄りに飛ばす」がL4のまま実現する。
+
+### Wireshark / PCAP 連携
+Enterpriseプランでは、特定Spectrumアプリのエッジ受信パケットをCloudflareダッシュボード/APIからPCAP形式でキャプチャできる（Magic Network Monitoring / PCAPs機能）。L4トラブル（TCP RSTの発生源、独自プロトコルのハンドシェイク失敗）をエッジ側から直接観測できる。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- Minecraft / FPS / MOBA等のゲームサーバーをDDoS被害から守りたいケース。Anycast IP + L3/4無制限緩和の組み合わせが本職。
+- 全社員に踏み台SSHを公開する必要があり、IP Access RulesでBYOD/出張IPまでホワイトリスト管理したい運用（ただし長期運用ではAccess for Infrastructureの方が監査要件に強い）。
+- 産業IoT / コネクテッドカーのMQTTブローカーを公開し、デバイス→Cloudflare→オリジンの経路でTLS/mTLSを終端したい。
+- カスタムTCPプロトコル（独自ゲームメタサーバ、金融系FIX、監視系Syslog等）でCDN/WAFの恩恵を受けたい。
+- 既存のCloudflare契約にArgo / Load Balancingがあり、HTTP以外の社内サービスにも経路最適化と冗長化を波及させたい。
+
+### 適していないシーン
+- HTTP/HTTPSアプリ。通常のCloudflareプロキシ（オレンジクラウド）+ Workers + Cacheで十分であり、Spectrum経由はキャッシュもWAFも効かないため筋が悪い。
+- TLS終端を絶対にオリジンでしか行いたくないが、Cloudflareでアプリ層WAFも掛けたいというケース（Spectrumはペイロード検査をしない）。
+- 任意UDPやカスタムTCPポートが要件で、契約がBusiness以下のケース。Pro/Businessは限定ポート（SSH 22 / Minecraft 25565等）しか開けられず、Enterprise契約が前提になる。
+- ゼロトラスト原則でSSHを完全に潰し、ブラウザベースのSSHコンソールに置き換えたい組織。Cloudflare Tunnel + Access for Infrastructure（旧SSH over Access）の方が監査・録画・短期証明書発行まで一気通貫で揃う。
+- 大量の小さなUDPパケット（VoIP / WebRTC SFU / リアルタイム音声）。SpectrumはL4プロキシであり、特定のリアルタイム最適化（Cloudflare Calls / Realtime SFU）は別製品である。
+
+## 競合・代替
+
+| 観点 | Cloudflare Spectrum | AWS NLB + Shield Advanced | Fastly TCP/TLS | Akamai App Layer L4 (Prolexic Connect) | Path.net | Imperva Network DDoS |
+|---|---|---|---|---|---|---|
+| 提供形態 | Anycast L4リバースプロキシ | リージョナルNLB + DDoS保護 | TLSターミネーション中心 | BGP経路転換 + L4スクラビング | ゲーム特化スクラビング | BGP / GREトンネル型スクラビング |
+| 任意TCP/UDP | Enterprise | NLBで任意ポート可、UDPも可 | TLS over TCPが中心、任意UDPは弱い | 任意TCP/UDP対応 | 任意TCP/UDP（ゲーム特化） | 任意TCP/UDP対応 |
+| Anycast | 全PoP | 単一リージョン（Global Acceleratorで補完） | 全PoP | Anycast scrubbing | 専用Anycast | スクラビングセンター |
+| DDoS緩和 | 無制限・追加課金なし | Shield Advanced契約必須・年$3kベース＋越過費用免除 | 標準DDoS+追加契約 | 業界トップ級・契約ベース | ゲーム特化大容量 | 大容量・スクラビング型 |
+| ゲームサーバー実績 | 多数（Minecraft / Hypixel事例） | 一般用途中心 | 少なめ | エンタープライズ寄り | 本職 | エンタープライズ寄り |
+| mTLS to Origin | Origin Authentication標準 | NLB単体では不可（ターゲット側で実装） | 対応 | 対応 | 対応 | 対応 |
+| IP Access Rules | ダッシュボード即時 | Security Groups / NACLで実装 | ACL記述 | 個別設定 | 管理画面 | 管理画面 |
+| 価格モデル | プラン+Enterprise契約 | リソース課金+Shield Advanced固定費 | 従量課金 | 高額・契約ベース | 中価格・ゲーム向け | 高額・契約ベース |
+
+CloudflareのAnycast網と「L3/4 DDoS緩和の超過課金なし」モデルは、ゲーム/SSH/カスタムプロトコル領域では価格性能比で他を圧倒する。一方、エンタープライズ大規模回線（数百Gbpsの帯域保証付きスクラビング）はAkamai Prolexic / Imperva側に分がある。
+
+## 料金
+
+- **Free / Pro**：Pro以下はSpectrumの利用範囲が極めて限定的で、SSH（TCP 22）/ Minecraft（TCP 25565）等の特定アプリケーション向けプリセットのみ。任意ポートやカスタムTCPプロトコルは不可。
+- **Business**：Pro範囲に加えて一部追加プロトコル（メール系・限定ポート）が利用可能。それでも任意TCP/UDPは開けない。
+- **Enterprise**：任意のTCP/UDPポート、UDPアプリケーション全般、Reserved/Static IP、Origin Authentication、Argo連動、Load Balancing連動、PCAPs、BYOIPがフルに使える。Spectrum自体がEnterpriseアドオン契約として価格設定され、帯域・接続数・対象アプリケーション数ベースで個別見積もりとなる。
+
+ProプランでSSH踏み台をCloudflare経由にする、というのが小規模ユースケースとして成立する数少ない選択肢である。Minecraft運営はProから始められるが、UDPベースのゲーム（多くのFPS / RTS）はEnterprise必須となる点に注意。
+
+## CLI / API 例
+
+### Spectrumアプリ作成（curl）
+```bash
+# SSH踏み台（Pro以上で可）。edge 22 → origin 192.0.2.10:22
+curl -X POST "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/spectrum/apps" \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "protocol": "tcp/22",
+    "dns": { "type": "CNAME", "name": "ssh.example.com" },
+    "origin_direct": ["tcp://192.0.2.10:22"],
+    "ip_firewall": true,
+    "proxy_protocol": "v2",
+    "tls": "off",
+    "edge_ips": { "type": "dynamic", "connectivity": "all" }
+  }'
+
+# カスタムUDPゲーム（Enterprise必須）。edge 30000 → origin 198.51.100.20:30000
+curl -X POST "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/spectrum/apps" \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "protocol": "udp/30000",
+    "dns": { "type": "CNAME", "name": "game.example.com" },
+    "origin_direct": ["udp://198.51.100.20:30000"],
+    "ip_firewall": true,
+    "edge_ips": { "type": "static", "ips": ["203.0.113.5"] }
+  }'
+```
+
+### Terraform（cloudflare provider v5）
+```hcl
+# Minecraft（Proでも可）
+resource "cloudflare_spectrum_application" "minecraft" {
+  zone_id        = var.zone_id
+  protocol       = "tcp/25565"
+  ip_firewall    = true
+  proxy_protocol = "off"
+  tls            = "off"
+
+  dns = {
+    type = "CNAME"
+    name = "play.example.com"
+  }
+
+  origin_direct = ["tcp://192.0.2.50:25565"]
+
+  edge_ips = {
+    type         = "dynamic"
+    connectivity = "all"
+  }
+}
+
+# Origin AuthenticationありのMQTTブローカー（Enterprise）
+resource "cloudflare_spectrum_application" "mqtt" {
+  zone_id        = var.zone_id
+  protocol       = "tcp/8883"
+  ip_firewall    = true
+  proxy_protocol = "v2"
+  tls            = "strict"   # Origin証明書をCAチェーン検証
+
+  dns = {
+    type = "CNAME"
+    name = "mqtt.example.com"
+  }
+
+  origin_direct = ["tcp://198.51.100.30:8883"]
+
+  edge_ips = {
+    type = "static"
+    ips  = ["203.0.113.10"]
+  }
+}
+```
+
+### IP Access Rule（Spectrumにも適用される）
+```bash
+# 日本以外をBlock
+curl -X POST "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/firewall/access_rules/rules" \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "mode": "block",
+    "configuration": { "target": "country", "value": "!JP" },
+    "notes": "SSH/Game: JP only"
+  }'
+```
+
+## 制限・注意点
+- **UDP・任意TCPはEnterprise限定**。Pro/BusinessはSSH/Minecraft等プリセットアプリに固定で、ポート変更も基本不可。要件出しの段階で契約レベルの確認が必須。
+- **L7処理は一切行われない**。WAFルール、Bot Management、Cache、Workersは適用されず、Spectrumを通したトラフィックはL3/4 DDoS緩和とIP Access Rulesしか効かない。HTTP/HTTPSは通常プロキシで通すべき。
+- **Reserved IP（Static Edge IP）はEnterpriseアドオン**。固定IPでファイアウォール許可リスト登録が必要なクライアント（産業機器・企業VPN）相手では事実上必須となる。
+- **Origin Authentication（mTLS）を有効化しないとIP漏洩時に丸裸**になる。Spectrumを「IP隠蔽」の手段として使うなら、tls=strict + Origin CA証明書 + オリジン側のクライアント証明書検証はセットで設計する。
+- **帯域・PPS制限**：Enterprise契約でも、Spectrumのアプリケーション単位で接続数・PPS・帯域に上限がある（具体値は契約ごと）。大規模UDP洪水を「サービスとして」受け切る要件は、Magic Transit（BGP経路転換型）の方が筋が良い。
+- **PROXY Protocol対応はオリジン側の実装が必要**。HAProxy / Nginx（stream module）/ MosquittoなどはPROXY v1/v2を解釈できるが、独自実装サーバーには改修が必要。Simple ProxyはCloudflare独自の軽量ヘッダで、自作実装の負担を減らせる。
+- **CDN / Workers / Cacheの恩恵はゼロ**。「HTTPなのにSpectrumに乗せる」設計は、機能を捨てているだけになる。
+- **IPv6ターゲットへの対応は限定的**。オリジンはIPv4前提で組むのが安全。
+- **同一Anycast IP/portの衝突**：Free/Proの共有Anycast IPでは、他テナントとの兼ね合いで特定ポートが既に占有されている可能性がある。Reserved IPで回避する。
+- **長期SSH運用ではAccess for Infrastructureを優先**。Spectrum + IP Access Rulesは「公開ポートの最低限の保護」止まりで、ユーザー単位のポリシー・録画・短期証明書発行はできない。
+
+## 参考リンク
+- Cloudflare Spectrum 概要：https://developers.cloudflare.com/spectrum/
+- Get started：https://developers.cloudflare.com/spectrum/get-started/
+- Configuration options：https://developers.cloudflare.com/spectrum/reference/configuration-options/
+- Spectrum API（Cloudflare API docs）：https://developers.cloudflare.com/api/operations/spectrum-applications-list-spectrum-applications
+- Terraform `cloudflare_spectrum_application`：https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/spectrum_application
+- Argo Smart Routing：https://developers.cloudflare.com/argo-smart-routing/
+- Load Balancing（TCP/UDPヘルスチェック）：https://developers.cloudflare.com/load-balancing/
+- Magic Transit（BGP型の代替）：https://developers.cloudflare.com/magic-transit/
+- Spectrum llms.txt：https://developers.cloudflare.com/spectrum/llms.txt
+
+---
+参照日: 2026-05-04

--- a/src/content/knowledge/web-development/cloudflare-docs/49-waf.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/49-waf.mdx
@@ -1,0 +1,239 @@
+---
+title: "Cloudflare WAF (Web Application Firewall)"
+description: "Cloudflareのグローバルエッジ上でHTTP/HTTPSリクエストをL7インスペクションし、署名ベースのManaged Rules・スコアリング型のOWASP Core Rule Set・式言語で書く自前のCustom Rules・Rate Limitingを単一のRuleset Engineで合成評価する、エッジ統合型のアプリケーションファイアウォールである。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 49
+---
+# WAF (Web Application Firewall)
+
+## 一行サマリ
+Cloudflareのグローバルエッジ上でHTTP/HTTPSリクエストをL7インスペクションし、署名ベースのManaged Rules・スコアリング型のOWASP Core Rule Set・式言語で書く自前のCustom Rules・Rate Limitingを単一のRuleset Engineで合成評価する、エッジ統合型のアプリケーションファイアウォールである。
+
+## 解決する課題（Why）
+オリジン手前でアプリケーション層攻撃を止める仕組みは、もはやオプションではなく前提である。一方で、自前運用のWAF（ModSecurity・appliance型）はルールメンテナンス・誤検知調整・スケール・ゼロデイ追従の負荷が重く、SaaSベンダーのWAFは料金とロックインが重い。Cloudflare WAFは既にCDNとしてプロキシしている経路上にWAFを差し込めるという、アーキテクチャ的な「ついで」の優位を持つ。具体的には以下を解決する。
+
+- 既知CVE・OWASP Top 10・ゼロデイ脆弱性に対する署名・スコアリング両建ての即時防御。
+- 自社固有のビジネスロジック（特定パス・特定User-Agent・国別・JA3指紋など）に対する宣言的な拒否ルール。
+- 認証エンドポイントへのクレデンシャルスタッフィング、漏洩済みパスワードでのログイン試行の検知。
+- レスポンスボディからのPII / クレジットカード番号漏洩の検出（Enterprise）。
+- DDoS・Bot Management・Rate Limitingと同じプレーンで一貫したアクション（Block / Challenge / Managed Challenge / JS Challenge / Log / Skip）を運用できること。
+- 全ゾーン横断のポリシー適用（Account-level Ruleset）による、子会社・マルチブランド構成での統制。
+
+## 主要機能（What）
+
+### Ruleset Engine と Expression Language
+Cloudflare WAFは2021年以降、すべてのルール（Managed・Custom・Rate Limiting）を「Ruleset Engine」と呼ばれる単一の評価基盤と、Wiresharkライクな式言語の上に統合している。古い「Firewall Rules」「Page Rules（WAF部分）」はこのエンジンへ移行済みである。
+
+- Expressionの例：`(http.request.uri.path contains "/admin" and ip.geoip.country ne "JP") or (cf.threat_score gt 14)`
+- フィールド：HTTPメソッド / URI / ヘッダ / ボディ / Cookie / IP / ASN / Country / TLS指紋（`cf.bot_management.ja3_hash`）/ Bot Score / Threat Score / Verified Bot 等。
+- Action：`block` / `challenge` / `managed_challenge` / `js_challenge` / `log` / `skip` / `rewrite` / `compress_response`。
+- Phase：`http_request_firewall_managed`、`http_request_firewall_custom`、`http_ratelimit`、`http_response_firewall_managed`（Sensitive Data Detection用）など、評価フェーズ単位でルールセットが束ねられる。
+
+### Managed Rulesets
+Cloudflareのセキュリティチームが運用する署名ベースの保守済みルール群である。プランごとに使える対象が分かれる。
+
+- **Cloudflare Free Managed Ruleset**：全プランで有効化可能な、誤検知が少ない高インパクト脆弱性の最低限カバー。Freeプランでも使える。
+- **Cloudflare Managed Ruleset**：CVE追従・ゼロデイ対応を含む本命のManaged Rules。Pro以上で利用可能。
+- **Cloudflare OWASP Core Ruleset**：後述のスコアリング型ルール。Pro以上。
+- **Cloudflare Exposed Credentials Check Ruleset**：認証エンドポイント向けの漏洩クレデンシャル照合。Pro以上（公式ドキュメントは新しい「Leaked Credentials Detection」機能の利用を推奨）。
+- **Cloudflare Sensitive Data Detection**：レスポンスフェーズで動作するDLP相当のルールセット。Enterprise限定。
+
+各Managed Rulesetは個別ルール単位でOverride（無効化・アクション変更・特定フィールドのSensitivity調整）が可能で、誤検知が出たら「ルールごと殺す」のではなく「該当パス・該当パラメータでだけ緩める」運用が定石である。
+
+### Custom Rules
+Expression Languageで書く自前のFirewallルールである。Managed Rulesetが汎用署名で網を張る一方、Custom Rulesは「自社ドメイン特有の拒否要件」を表現する。
+
+- 典型ユースケース：管理画面パスを社内IPに限定 / 特定ASN（VPN・ホスティング系）を一括Challenge / 古いTLSバージョンや特定User-Agentを遮断 / 特定エンドポイントへのPOSTサイズ制限。
+- Skipルールにより「以降のManaged RulesetやBot Fight Modeを評価しない」ホワイトリスト経路を作れる。順序設計（precedence）が事故源になりやすい。
+- プラン別ルール本数上限：Free 5、Pro 20、Business 100、Enterprise 1,000（Account-level Rulesetを含めるとさらに拡張可）。
+
+### OWASP Core Rule Set
+Cloudflare版のOWASP CRS実装で、伝統的なModSecurity CRSとは異なりCloudflareがメンテナンスする独自フォークである。
+
+- **スコアリングモデル**：個別ルールがマッチするごとに「threat score」に加点され、設定したスコア閾値を超えた時点でアクション（Block等）が発火する。1ルール1ブロックではない。
+- **Paranoia Level**：CRS文化を踏襲したParanoia Level（PL1〜PL4相当）で網の細かさを切り替える。PLを上げると検知率と誤検知率が同時に上がるため、Logモードで一定期間ベースラインを取ってから本適用する運用が前提。公式に明記の閾値推奨値については最新ドキュメント参照。
+- Cloudflare ManagedとOWASPは並列に動かすのが標準で、Managedで個別CVEを止めつつ、OWASPで未知パターンの傾向検知を担う。
+
+### Rate Limiting 統合
+旧「Rate Limiting Rules」も現在はWAFのRuleset Engineに統合されている。Custom Rulesと同じExpressionで対象を絞り込み、`http_ratelimit` フェーズで評価される。
+
+- **キー指定**：IP / Cookie / ヘッダ値 / クエリパラメータ / JA3指紋など任意フィールドの組合せでカウンタを分けられる。
+- **カウント条件**：レスポンスステータスを条件にできる（例：401を返した数だけカウント＝失敗ログインのみ計測）。
+- **Action**：Block / Managed Challenge / JS Challenge / Log。Block時のレスポンス内容（ステータス・本文・ヘッダ）も指定可能。
+- **Advanced Rate Limiting**：Enterprise限定で、複雑なキー設計・長時間ウィンドウ・高QPSに耐える本格運用向け。Bot Managementと組み合わせて「Bot Score低いものだけ厳格にレート制御」が可能。
+
+### Exposed Credentials Check / Leaked Credentials Detection
+ログインフォームに投げられたユーザー名・パスワード組合せを、Cloudflareが保有する漏洩クレデンシャルDBに対してハッシュ照合する機能である。Pro以上で利用可能。
+
+- 検出時はリクエストにヘッダ（`Exposed-Credential-Check: 1` 相当）を付加するか、Custom Rulesから`cf.waf.credential_check.*` 系フィールドを参照して任意のアクション（Block / Challenge / 強制パスワードリセット導線への302）を取れる。
+- 公式ドキュメントでは旧「Exposed Credentials Check Ruleset」より新しい「Leaked Credentials Detection」機能の利用が推奨されている。アプリ側でログインエンドポイント（パス・パラメータ名）の登録が必要。
+
+### Sensitive Data Detection（Enterprise限定）
+レスポンスフェーズで動作する稀なルールセットで、オリジンからの応答ボディに含まれるPII（メールアドレス・電話番号・SSN・クレジットカード番号など）を検出する。事故的な大量データ流出をエッジで検知・ログ化する用途である。Blockではなく検知・通知ベースで運用するのが現実的で、純粋な「DLP製品」のリプレースとしては機能不足の領域もある。
+
+### Deployment Models
+- **Zone-level Ruleset**：個別ドメイン（Zone）単位でManaged / Custom / Rate Limitingを設定する標準形。
+- **Account-level Ruleset**：Enterprise限定で、アカウント配下の複数Zoneに横串でルールを適用する。M&A後の多ブランド統制、グループ会社全体の最低基準ポリシーの強制に使う。
+- いずれもRuleset APIまたはTerraformで宣言的に管理でき、ダッシュボード操作とコード管理を併用するとprecedenceが壊れやすい点に注意。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- 既にCloudflareをCDN / DNSとして使っており、オリジン手前にWAFを差し込む追加コストが「プランアップだけ」で済むケース。最速のROI。
+- グローバル分散・高QPSのWebサービスで、リージョン選定なしにエッジで弾ける運用が要件のケース。AWS WAF（ALB / CloudFront貼付け）よりも全リージョン一様にレイテンシが低い。
+- マルチブランド・マルチドメインで、Account-level Rulesetによる「全社最低基準」ポリシーをコードで強制したい組織。
+- API GatewayとしてのCloudflare（API Shield / Workers）と組合せ、スキーマバリデーション・mTLS・JWT検証を含む包括的なAPI防御を一本化したいケース。
+- セキュリティ専任が薄く、Managed RulesetsとBot Fight Modeのデフォルト品質に頼りたい中規模事業者。
+
+### 適していないシーン
+- オリジンがCloudflareをプロキシしていない、またはオンプレ・閉域網にあって外部公開していないアプリ。WAFは前段に立てて初めて意味を持つ。
+- 「真のWAAP」要件としてAPI Discovery（未知エンドポイントの自動発見）・スキーマ自動生成・GraphQLインスペクション・自動学習型ベースラインを業務要件として求めるケース。CloudflareもAPI Shieldで追従しているが、Imperva / Akamai EAA / Salt Securityなど専業の成熟度には届かない領域がある。
+- 厳しい規制業界（金融・公的機関）で、トラフィックを米系CDN事業者に集約することが許されないケース。
+- アプリケーションの応答にPIIが大量に含まれ、本格DLPとしてのインスペクション・トークナイゼーション・暗号化を必要とするケース。Sensitive Data Detectionは検知止まりで、Imperva DAM相当の機能ではない。
+- 既存のオリジン側WAF（AWS WAF + Shield Advanced、ModSecurity）に深く投資済みで、ルール資産の移植コストが正当化できないケース。
+
+## 競合・代替
+
+| 観点 | Cloudflare WAF | AWS WAF | Akamai App & API Protector | Imperva Cloud WAF | F5 Distributed Cloud WAAP |
+|---|---|---|---|---|---|
+| 出自 | CDN統合・Anycastエッジ | クラウドベンダー純正 | CDN統合（Kona Site Defenderの後継） | 専業セキュリティベンダー | NGINX / Shape Securityを統合したWAAP |
+| Managed Rules | Cloudflare Managed + OWASP CRS（自社フォーク） | AWS Managed Rule Groups + Marketplace | Akamai KSD Rules + Adaptive Security Engine | Imperva Threat Research | F5 Signature DB + ML |
+| Custom Rules式言語 | Wiresharkライク統合DSL（強力） | JSON Statement（冗長） | GUI中心 | GUI + 独自DSL | GUI + JSON |
+| Rate Limiting | WAF統合・Advanced（EE） | 別機能（Rate-based rules） | 標準 | 標準 | 標準 |
+| Bot Management | 同一プレーン（Bot Management別ライセンス） | Bot Control（別料金） | Bot Manager（別ライセンス） | Advanced Bot Protection（別） | Shape由来で強力 |
+| API Security | API Shield（同梱・別ライセンスあり） | 弱い（API Gateway側で別構成） | 強い | 強い | 強い |
+| Account / Org横断ポリシー | Account-level Ruleset（EE） | Firewall Manager | 標準 | 標準 | 標準 |
+| 価格モデル | プラン同梱（Pro $25 / Business $250 / EE要見積） | 従量（ルール数 + リクエスト数） | 高額・要見積 | 高額・要見積 | 高額・要見積 |
+| 強み | エッジ統合・式言語の表現力・コスト | AWS資産との統合・IaC親和性・細粒度課金 | 大企業向け運用実績・サポート | 検知精度・専業の成熟度 | Bot対策とWAFの一体化 |
+| 弱み | 大企業向けAPI Discovery / 高度DLPは追従途上 | 式が冗長・グローバルレイテンシ・DDoS連携が弱い | 高コスト・運用が重い | 高コスト・クラウド統合は後発 | 導入コスト・国内事例が少ない |
+
+Cloudflare WAFの本質的優位は「CDN・DDoS・Bot・Workers・API Shieldと同じプレーンで完結する」点にあり、AWS WAFの優位は「IaCとIAMが他のAWS資産と一体で語れる」点にある。Akamai / Imperva / F5は機能成熟度では先行するが、価格と運用負荷でCloudflareに置き換える事例が増えている、というのが現状の力学である。
+
+## 料金
+公式の最新価格は `https://www.cloudflare.com/plans/` を参照のこと。本稿執筆時点（2026-05-04）の概観は以下である。
+
+- **Free**：Cloudflare Free Managed Ruleset、Custom Rules 5本、基本的なRate Limiting。OWASP Core RulesetとCloudflare Managed Rulesetは含まれない。検証用途・個人ブログ向け。
+- **Pro**（$25/月程度）：Cloudflare Managed Ruleset、OWASP Core Ruleset、Exposed Credentials Check、Custom Rules 20本。中小事業者の標準ライン。
+- **Business**（$250/月程度）：Pro機能 + Custom Rules 100本、Custom WAFルール拡張、PCI DSS対応構成、Page Shield等の連携機能。
+- **Enterprise**（要見積もり）：Sensitive Data Detection、Advanced Rate Limiting、Account-level Ruleset、Custom Rules 1,000本、API Shield統合、Logpush、24/365 SLA。多ドメイン・規制業種・高QPSサービスはここを前提に設計する。
+
+注意点として、Bot Management・API Shield Advanced・Page Shield Plus・DDoS Advanced等の上位機能は同じプランの中でも追加SKUになる場合がある。営業見積もりを取る際は「WAF本体」ではなく「Bot / API / DDoSの上位機能とのセット価格」を必ず確認する。具体的な金額は公式に明記なしの組合せが多く、Enterprise契約は個別交渉が前提である。
+
+## CLI / API 例
+
+Cloudflare WAFには専用CLIは存在せず（`cf waf` 系のコマンドは公式に明記なし）、運用はRuleset APIまたはTerraform Cloudflare Providerで行うのが定石である。
+
+### curl：Custom Rule追加（Zone-level Ruleset）
+```bash
+# 該当ZoneのCustom Ruleset IDを取得
+curl -sS "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/rulesets" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  | jq '.result[] | select(.phase=="http_request_firewall_custom")'
+
+# Custom Rulesetに「管理画面は社内IPのみ」ルールを追加
+curl -sS -X POST \
+  "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/rulesets/${RULESET_ID}/rules" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "description": "Allow /admin from corp IPs only",
+    "expression": "(http.request.uri.path contains \"/admin\") and not (ip.src in {203.0.113.0/24 198.51.100.0/24})",
+    "action": "block",
+    "enabled": true
+  }'
+```
+
+### Terraform（cloudflare provider v5）
+```hcl
+# Managed Rulesetを有効化（Cloudflare Managed Ruleset を Block で適用）
+resource "cloudflare_ruleset" "zone_managed_waf" {
+  zone_id     = var.zone_id
+  name        = "Zone managed WAF entrypoint"
+  description = "Deploy Cloudflare Managed Ruleset"
+  kind        = "zone"
+  phase       = "http_request_firewall_managed"
+
+  rules {
+    action      = "execute"
+    description = "Execute Cloudflare Managed Ruleset"
+    expression  = "true"
+    action_parameters {
+      id = "efb7b8c949ac4650a09736fc376e9aee" # Cloudflare Managed Ruleset ID（公式参照）
+      overrides {
+        action = "block"
+      }
+    }
+  }
+}
+
+# OWASP Core Ruleset：Paranoia Levelを上げ閾値Block
+resource "cloudflare_ruleset" "zone_owasp" {
+  zone_id = var.zone_id
+  name    = "Zone OWASP entrypoint"
+  kind    = "zone"
+  phase   = "http_request_firewall_managed"
+
+  rules {
+    action      = "execute"
+    description = "OWASP CRS with PL2"
+    expression  = "true"
+    action_parameters {
+      id = "4814384a9e5d4991b9815dcfc25d2f1f" # OWASP Ruleset ID（公式参照）
+      overrides {
+        # Paranoia Level・閾値・タグ別アクションをここで上書き
+        action = "block"
+      }
+    }
+  }
+}
+
+# Custom Rule：失敗ログインのRate Limiting（IP+ユーザー名キー）
+resource "cloudflare_ruleset" "zone_ratelimit" {
+  zone_id = var.zone_id
+  name    = "Zone rate limiting"
+  kind    = "zone"
+  phase   = "http_ratelimit"
+
+  rules {
+    action      = "block"
+    description = "Throttle failed logins per IP+user"
+    expression  = "(http.request.uri.path eq \"/api/login\") and (http.request.method eq \"POST\")"
+    ratelimit {
+      characteristics     = ["ip.src", "http.request.body.form[\"username\"]"]
+      period              = 60
+      requests_per_period = 5
+      mitigation_timeout  = 600
+      counting_expression = "http.response.code eq 401"
+    }
+  }
+}
+```
+
+Ruleset IDは公式ドキュメント（`https://developers.cloudflare.com/waf/managed-rules/reference/`）に列挙されており、コード固定ではなくDataソースとして参照する書き方も可能である。
+
+## 制限・注意点
+- Managed Rulesetsの個別ルールに対するOverrideは可能だが、ルール内部の検知ロジックそのものはブラックボックスである。「なぜ誤検知したか」の最終的な再現はサポートチケットで問い合わせる前提となる。
+- OWASP Core Rulesetはスコアリング方式のため、単一ルールの除外ではなく「閾値・対象パスごとのアクション切替」で運用する。誤検知対応にはPenalty Box的なログ駆動チューニングが必要。
+- Custom Rulesのprecedence設計を誤ると、Skipルールが想定外にManaged Rulesetを無効化する事故が起きる。Terraformで全ルール宣言を一元管理し、ダッシュボード手編集を禁止する運用が安全。
+- Sensitive Data Detectionはレスポンスフェーズで動作するため、レスポンスのパフォーマンスに微影響がある。さらに大規模なPIIマスキング・トークナイゼーションは本機能の対象外で、別途DLP製品との併用が必要。
+- Rate Limitingのカウンタはエッジノード分散カウントであり、厳密な「グローバルで秒間Nリクエスト」を保証するものではない。許容スパイクを織り込んだ閾値設計が必要。
+- Cloudflare WAFはあくまで「Cloudflareをプロキシとして経由するトラフィック」にしか効かない。オリジンIPが漏れて直接叩かれる経路を残すと無意味になるため、Authenticated Origin Pulls / Argo Tunnel / オリジンIPホワイトリストによる「バイパス防止」設計が必須である。
+- Bot Management・API Shield Advanced・Page Shield Plusなどの上位機能は同じWAFプレーンに乗るが別ライセンスである。コスト試算時は「WAF本体」だけで見積もると後で外れる。
+- Account-level RulesetはEnterprise限定で、Zone-levelとの優先順位ルールを把握しないと「子Zoneで上書きしたつもりが効かない」事故が起きる。
+
+## 参考リンク
+- Cloudflare WAF：https://developers.cloudflare.com/waf/
+- Managed Rules：https://developers.cloudflare.com/waf/managed-rules/
+- Custom Rules：https://developers.cloudflare.com/waf/custom-rules/
+- Rate Limiting Rules：https://developers.cloudflare.com/waf/rate-limiting-rules/
+- Ruleset Engine：https://developers.cloudflare.com/ruleset-engine/
+- Expression Language（Fields）：https://developers.cloudflare.com/ruleset-engine/rules-language/fields/
+- Leaked Credentials Detection：https://developers.cloudflare.com/waf/detections/leaked-credentials/
+- Sensitive Data Detection：https://developers.cloudflare.com/waf/managed-rules/reference/sensitive-data-detection/
+- Plans：https://www.cloudflare.com/plans/
+- Terraform `cloudflare_ruleset`：https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/ruleset
+
+---
+参照日: 2026-05-04

--- a/src/content/knowledge/web-development/cloudflare-docs/50-waiting-room.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/50-waiting-room.mdx
@@ -1,0 +1,183 @@
+---
+title: "Cloudflare Waiting Room"
+description: "オリジンが捌ける同時セッション数を超えて押し寄せたトラフィックをCloudflareエッジ側のバーチャル待機室に滞留させ、FIFO / Randomで順次解放することでサーバー過負荷と機会損失を同時に回避する仮想行列サービスである。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 50
+---
+# Waiting Room
+
+## 一行サマリ
+オリジンが捌ける同時セッション数を超えて押し寄せたトラフィックをCloudflareエッジ側のバーチャル待機室に滞留させ、FIFO / Randomで順次解放することでサーバー過負荷と機会損失を同時に回避する仮想行列サービスである。
+
+## 解決する課題（Why）
+チケット販売、ECのフラッシュセール、新製品ローンチ、ワクチン予約、人気ゲームのアカウント登録のような「特定時刻に需要がスパイクする」イベントは、オートスケールでもDB / 在庫 / 決済APIまで拡張しきれず、原則としてどこかでオリジンが折れる。折れた瞬間に全ユーザーが5xxを踏み、CSへの問い合わせが洪水化し、ブランド毀損とリピート機会損失が積み上がる。Waiting Roomはこれをエッジで吸収する形で解決する。
+
+- オリジンが安全に処理できる同時セッション数の上限を宣言し、超過分はエッジで「順番待ち」させる。
+- 待機ユーザーには進捗表示付きのカスタムページを返すため、5xxやタイムアウトに比べて離脱率が下がる。
+- セール開始前のプレキュー（pre-queue）でアクセス解禁時刻に押し寄せる瞬間最大値を平準化する。
+- Bot / 自動化スクリプトに対する事実上のレート制限としても機能する。
+- オリジン側のスケーリングコストを過大に積まなくても、ピーク時の体験品質を担保できる。
+
+## 主要機能（What）
+
+### Waiting Room と Waiting Room Rule
+Zone単位で「対象とするhost / pathの組」を定義したものがWaiting Roomで、その上に「この条件のリクエストは待機室をバイパスする」ルール（Bypass Rule）や「この期間だけ別パラメータで動かす」イベントを重ねる構造になっている。Waiting Room自体は自動的にCloudflare CDNの後段に挿入されるため、対象のDNSレコードはProxied（オレンジ雲）が前提となる。
+
+### Active users と New users per minute
+待機室の挙動を決める二大パラメータである。
+
+- **Total active users**：ルート上で同時に「アクティブ」と見なせるセッション数の上限。`session_duration`（分）非アクティブだったセッションは枠を解放する。オリジンが安全に処理できる同時セッション数を入れる。
+- **New users per minute**：1分間あたりに新規でルートへ通すユーザー数の目標値。アクティブ枠が空いていてもこの蛇口で流入を絞れる。
+- 計算は各データセンターのローカル予算とグローバル予算の二層で行われ、急激なスパイク時はグローバル伝播に約2分かかるためオーバーシュートが発生し得る。閾値はオリジン許容量の8〜9割で設定するのが安全である。
+
+### Queueing Method（4種類）
+キューから誰を先に通すかのアルゴリズム。Advanced Waiting Room（Enterprise add-on）でのみ全種類選択でき、Businessは事実上FIFO相当である。
+
+- **FIFO (First In First Out)**：到着順。最も公平で説明責任が立てやすく、一般的なECセール・チケット販売の第一選択。
+- **Random**：キュー内からランダムに選出。「9:00開始の抽選販売で、5分前から並んでも有利にしない」ような体験を作るときに、`shuffle_at_event_start`と組合せて使う。
+- **Passthrough**：通常時はキューイングせず通すが、イベント期間中など条件下でのみ制限する切り替え型。
+- **Reject**：超過分を待機させずに即拒否（カスタムRejectページを返す）。メンテナンス・営業時間外・席数完全固定型イベントで使う。
+
+### Event Scheduling
+セール・抽選などの時刻が事前に分かっているイベント向けに、`event_start_time` / `event_end_time` / `prequeue_start_time` / イベント中だけ書き換える各種パラメータを設定できる。プレキューに入ったユーザーは開始時刻まで「もうすぐ開始します」ページに留まり、開始時刻にRandomシャッフルで一斉に並び替えるとフェアな抽選が成立する。
+
+### Custom Waiting Room Page
+待機ページのHTMLをMustacheテンプレートで自作できる。Advanced Waiting Roomが必要。標準で使える主な変数は以下。
+
+- `{{waitTime}}` / `{{waitTimeFormatted}}`：推定待ち時間。
+- `{{queueIsFull}}` / `{{queueAll}}`：キュー全埋め / 全員キュー中の状態フラグ。
+- `{{refreshIntervalSeconds}}`：自動リロード間隔（既定20秒）。
+- ブランド統一・多言語化・アナリティクスタグ埋め込みなど、5xxよりはるかにマシなUXに仕立て上げる。
+
+### Bypass Rules
+特定パスや国、IPからのトラフィックを待機室の対象外にするルール。Ruleset Engineの式で書く。
+
+- 利用可能フィールド：`http.request.uri.path` / `http.request.uri.path_extensions` / `http.request.method` / `http.host` / `http.cookie` / `http.request.country` / `ip.src` など。
+- 利用不可：`cf.threat_score` / `cf.bot_management.*` / HTTPレスポンス側フィールド（待機判定はリクエスト時点で行うため）。
+- 例：`/api/health`や静的アセット（`.js` / `.css` / `.png`）は待機室を通さず素通りさせるのが運用上の定石。
+
+### Mobile App API（JSON Response）
+ネイティブアプリから待機室を利用する場合、`json_response_enabled: true`にしてリクエスト時に`Accept: application/json`を付けると、待機ページHTMLの代わりに以下のJSONが返る。アプリ側でネイティブUIを描画でき、HTMLレンダリングを挟まないモバイル決済フローでも使える。
+
+```json
+{
+  "cfWaitingRoom": {
+    "inWaitingRoom": true,
+    "waitTime": 10,
+    "queueAll": false,
+    "queueingMethod": "fifo",
+    "refreshIntervalSeconds": 20
+  }
+}
+```
+
+### Queueing All Visitors mode
+`queue_all: true`にすると、対象ルートに来た全リクエストを問答無用でキューに送る。負荷試験前のリハーサル・新製品の事前登録ページ・「準備中」を見せたい本番直前など、全ユーザーをまずプールしてから順次通したいケースで使う。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- 開始時刻が決まっているスパイク型イベント（チケット・コンサート・ECセール・限定ドロップ）の運営。
+- オリジンの最大同時処理数（DB接続・在庫API・決済プロバイダのレート上限）が事前に見積もれる業務。
+- すでにCloudflare CDNにDNSをProxiedで載せていて、Waiting Roomを挿入するだけで保護できる構成。
+- 「5xxは出したくないが、オリジンを過剰スケーリングするコストもかけたくない」というSREの中庸要件。
+- ボット・スクレイピング対策として「人間の行列に並ばせる」フィクションが有効なドメイン。
+
+### 適していないシーン
+- スパイクが予測不能で、かつ低レイテンシ（待機UIを挟むこと自体が許されない）が必須なリアルタイム取引・ゲームマッチング。
+- DNSをCloudflareにProxyせず、外部CDN・ロードバランサのみで運用している構成。
+- そもそも全リクエストをキャッシュ可能な静的配信中心のサイト。CDNキャッシュとオリジンスケールで足りる。
+- 同時アクティブセッションの厳密な上限がビジネス上特定できないサービス。閾値の設計ができない。
+- BusinessプランしかないがFIFO以外のキューイングや複数ホスト・カスタムページが要件のケース。Enterprise + Advanced add-onを前提に再検討する。
+
+## 競合・代替
+
+| 観点 | Cloudflare Waiting Room | Queue-it | Akamai Visitor Prioritization Cloudlet | AWS Virtual Waiting Room (solution) |
+|---|---|---|---|---|
+| 提供形態 | CDNエッジに統合（同一プレーン） | SaaS（DNS or JS / Connector挿入型） | Akamai EdgeWorkersベースのCloudlet | AWSリファレンス実装（CloudFront + Lambda + DynamoDB） |
+| 導入容易性 | DNSをProxiedにするだけ | Connector or JSタグ追加が必要 | Akamayプロパティに紐付け | CloudFormation展開・運用は自社 |
+| キューイング方式 | FIFO / Random / Passthrough / Reject | FIFO / 抽選 / 優先度付きが豊富 | 優先度ベースの通過制御 | FIFO相当（実装次第） |
+| カスタムページ | Mustacheテンプレ（Advanced必要） | フル自由 / 多言語テンプレ豊富 | 限定的 | 自前で構築 |
+| 抽選・プレキュー | Event + shuffle_at_event_start | 専業として最も成熟 | 限定的 | 自前で構築 |
+| Mobile App API | JSON Response標準 | SDK / API提供 | 個別対応 | 自前で構築 |
+| 料金感 | Business以上 + Advanced add-on | 高価（チケット業界の定番） | Akamai契約必須 | AWS従量＋運用コスト |
+| 強み | エッジ統合・運用がCloudflareに閉じる | 抽選・優先度・分析の専業ノウハウ | Akamai既存資産との親和性 | AWSスタック内で完結 |
+| 弱み | キューイング戦略はQueue-itほど多彩でない | 別ベンダー・別契約・別連携が増える | Akamai前提・他社で使えない | 運用責任が自社に残る |
+
+エッジCDNとして既にCloudflareを使っているなら、追加の連携を増やさずに済むWaiting Roomがコスト・運用面で優位である。一方、抽選付きチケット販売やキャパシティが極端に逼迫するメガイベントでは、Queue-itのような専業の機能の細かさが効くケースも多い。
+
+## 料金
+- **Business**：基本Waiting Room 1個。FIFOのみ、デフォルトテンプレート、host単一対象。とりあえず保護したいだけならここで足りる。
+- **Enterprise**：基本Waiting Room 1個に加え、**Advanced Waiting Room**をadd-onで購入できる。複数ホスト/パス対象、Random / Passthrough / Reject、カスタムテンプレート、Event Scheduling、Mobile App API、複数Waiting Roomの同時稼働が解禁される。価格は同時稼働数（concurrent waiting rooms）ベースで個別見積もり。
+- 待機室に「入っている」ユーザーへのリクエストはCloudflare側で吸収されるため、オリジン課金（帯域・ワーカー実行）に影響しないのも実利的なメリットである。
+
+## CLI / API 例
+
+### Waiting Room の作成
+```bash
+curl "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/waiting_rooms" \
+  --request POST \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  --json '{
+    "name": "shop_waiting_room",
+    "host": "shop.example.com",
+    "path": "/shop",
+    "total_active_users": 300,
+    "new_users_per_minute": 200,
+    "session_duration": 1,
+    "queueing_method": "fifo",
+    "json_response_enabled": true,
+    "queue_all": false
+  }'
+```
+
+### Event のスケジュール（プレキュー + Random抽選）
+```bash
+curl "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/waiting_rooms/$ROOM_ID/events" \
+  --request POST \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  --json '{
+    "name": "flash_sale_2026_05_10",
+    "event_start_time": "2026-05-10T11:00:00Z",
+    "event_end_time":   "2026-05-10T13:00:00Z",
+    "prequeue_start_time": "2026-05-10T10:55:00Z",
+    "new_users_per_minute": 500,
+    "total_active_users": 800,
+    "shuffle_at_event_start": true,
+    "queueing_method": "random"
+  }'
+```
+
+### Bypass Rule（Ruleset Engine 式の例）
+```text
+# 静的アセットとヘルスチェックは待機室をバイパス
+ends_with(http.request.uri.path, ".js")
+or ends_with(http.request.uri.path, ".css")
+or ends_with(http.request.uri.path, ".png")
+or http.request.uri.path eq "/api/health"
+```
+
+## 制限・注意点
+- 対象ドメインのDNSレコードがCloudflare ProxiedでないとWaiting Roomは動作しない。SaaSドメイン・別CDN前段構成では使えない。
+- 訪問者のCookie受け入れが必須である。Cookieを拒否するブラウザ・プライバシーモード・iframe埋め込み（Safari + CHIPS非対応）では二重カウント・誤動作が起こり得る。
+- 標準で20秒間隔の自動リロードが行われるため、Rate Limiting RulesやWAFで20秒以内の連続リクエストをブロックしない設計が必要。
+- 待機ページ自体は静的・キャッシュ可能だが、待ち時間表示の精度はデータセンターローカル予算とグローバル予算の集約の遅延に依存し、最初の2分程度はオーバーシュートが起こり得る。閾値設定は実オリジン能力の8〜9割で設計する。
+- BypassフィールドにBot Managementの判定値（`cf.bot_management.*`）やレスポンス側フィールドは使えない。Bot Managementと併用する場合はWAF / Bot Fight Modeを前段で動かして、待機室はあくまで容量制御に専念させる。
+- Custom Page・複数ホスト・FIFO以外のキューイング・Eventは**Advanced Waiting Room（Enterprise add-on）**前提である。Business契約でこれらを要件化すると後で詰む。
+- Waiting Roomは「同時セッション制御」であり、不正アクセス対策・在庫整合性保証ではない。決済・在庫の整合性はオリジン側で別途確保する必要がある。
+
+## 参考リンク
+- Waiting Room 概要：https://developers.cloudflare.com/waiting-room/
+- Queueing Methods：https://developers.cloudflare.com/waiting-room/reference/queueing-methods/
+- Customize Waiting Room（Custom Page）：https://developers.cloudflare.com/waiting-room/how-to/customize-waiting-room/
+- Bypass Rules：https://developers.cloudflare.com/waiting-room/additional-options/waiting-room-rules/bypass-rules/
+- JSON Response（Mobile App API）：https://developers.cloudflare.com/waiting-room/how-to/json-response/
+- Plans：https://developers.cloudflare.com/waiting-room/plans/
+- Waiting Room API：https://developers.cloudflare.com/waiting-room/reference/waiting-room-api/
+- API Reference（waiting_rooms）：https://developers.cloudflare.com/api/resources/waiting_rooms/methods/list/
+- Waiting Room llms.txt：https://developers.cloudflare.com/waiting-room/llms.txt
+
+---
+参照日: 2026-05-04

--- a/src/content/knowledge/web-development/cloudflare-docs/60-ai-search.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/60-ai-search.mdx
@@ -1,0 +1,251 @@
+---
+title: "Cloudflare AI Search & AI Crawl Control"
+description: "AI Searchは、R2バケット・任意Webサイト・直接アップロードしたファイルを自動でチャンク・埋め込みしてVectorizeにインデックスし、ハイブリッド検索／リランキング／回答生成までを単一インスタンスで提供するマネージドRAGサービスであり、AI Crawl Controlは、その逆方向、つまり「自分のサイトに来るAIクローラ」をBot Managementの識別基盤の上で可視化・許可ブロック・課金（Pay per crawl, HTTP 402）するコントロールパネルである。RAGを「作る側」と「クロールされる側」の両端を、Cloudf..."
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 60
+---
+# AI Search & AI Crawl Control
+
+## 一行サマリ
+AI Searchは、R2バケット・任意Webサイト・直接アップロードしたファイルを自動でチャンク・埋め込みしてVectorizeにインデックスし、ハイブリッド検索／リランキング／回答生成までを単一インスタンスで提供するマネージドRAGサービスであり、AI Crawl Controlは、その逆方向、つまり「自分のサイトに来るAIクローラ」をBot Managementの識別基盤の上で可視化・許可ブロック・課金（Pay per crawl, HTTP 402）するコントロールパネルである。RAGを「作る側」と「クロールされる側」の両端を、Cloudflareがエッジで一体化して扱う。
+
+## 解決する課題（Why）
+LLMの応答精度を業務データで底上げするには「RAG（Retrieval-Augmented Generation）」が事実上の標準だが、これを自前で組むと、データソースの差分取り込み、PDF/HTMLからのテキスト抽出、チャンキング、埋め込みモデル呼び出し、ベクタDB運用、ハイブリッド検索、リランキング、コンテキスト組み立て、LLM呼び出し、という7〜8段の配管を構築・維持しなければならない。各レイヤを別ベンダーで組むと、認証・コスト・レイテンシ・データ転送料が累積して破綻しやすい。AI Search（旧AutoRAG）はこのスタック全体を1インスタンスにまとめ、ソースを指定するだけで動く形に圧縮する。
+
+一方で、AIクローラ問題は逆方向の課題である。GPTBot / ClaudeBot / PerplexityBot / Google-Extended などが大量にコンテンツを取得し、サイト運営者は帯域コストとオリジン負荷を負担しながら、自分のコンテンツがどう使われたかを把握できない。robots.txtは紳士協定であり、無視するクローラも多い。AI Crawl Controlは、Cloudflare Bot Managementが既に持っている「正規Botの一次ソース識別」を流用し、AIクローラだけを切り出して可視化・ブロック・課金する。Pay per crawlは「払えば通す、払わなければ402を返す」という新しい交渉プロトコルで、コンテンツ提供者が初めて主体的に値付けできる。
+
+要するに、AI Searchは「自社データをLLMに食わせる側」の運用負荷を、AI Crawl Controlは「LLMにデータを食われる側」の経済的・技術的非対称を、それぞれエッジで解消する。両者は対になっており、Cloudflareが「AIインターネットの双方向ゲートウェイ」を取りに行っているプロダクトである。
+
+## 主要機能（What）
+
+### AI Search Pipeline（マネージドRAG）
+インスタンスを作成すると、データソース取り込み → チャンキング → 埋め込み生成 → Vectorize書き込み → クエリ書き換え → ベクタ／キーワード検索 → リランキング → 回答生成、という8段のパイプラインが自動で組み上がる。各段はインスタンス作成後も編集可能で、埋め込みモデルだけは作成時に固定（インデックスとモデルが1対1）になる。
+
+- **インデックス更新**：データソースを継続監視して差分を再取り込みする「Automated Indexing」を内蔵。手動再同期も可能。
+- **Hybrid Search**：ベクタ検索（意味）とBM25キーワード検索（厳密一致）を同一クエリで合成。スコア閾値・件数を指定できる。
+- **Retrieval type**：`hybrid` / `vector` / `keyword` の3モードをクエリ時に切替可能。
+- **Metadata filtering**：チャンクに付与した任意メタデータ（カテゴリ・バージョン・言語・テナントID等）に対し`eq / ne / gt / gte / lt / lte`の演算子で絞り込み。
+
+### Sources（R2 / Webサイト / 直接アップロード）
+取り込み元は3種類。
+
+- **R2 Bucket**：PDF / Markdown / HTML / プレーンテキスト等をR2に置けば、Path filterで対象を限定しつつ取り込み。最も標準的な使い方。
+- **Website（Web Crawler）**：自分の管理ドメインに対し、AI Search内蔵のクローラを差し向けて自動収集する。2026年4月以降の新規インスタンスは「managed storage, vector index, and web crawling」が同梱され、外部ストレージなしで完結する。
+- **Direct Upload**：API経由で個別ファイルをインスタンスに直投入。ユーザー単位・テナント単位で動的にコーパスを作るユースケース（per-tenant search）に向く。
+
+### Embedding & Vectorize 連携
+埋め込みはWorkers AI上のモデル（`@cf/baai/bge-*`系など）を呼び出して生成され、結果は裏側でCloudflare Vectorizeに格納される。利用者からは「Vectorizeを直接触らずに済む抽象化」として提供されるが、料金面ではVectorize（dimensions × vectors stored / queried）の従量が背後で走っているため、コスト試算では意識する必要がある。
+
+### Re-ranking
+ベクタ検索の上位候補を、別の小型クロスエンコーダ系モデルで再スコアリングして並べ直す機能。リコールが大きいインデックスでも、最終的にLLMに渡るチャンク数を絞り込みつつ精度を上げられる。リランキング用モデルもインスタンス設定で差し替え可能。
+
+### Generation（chatCompletions）
+Workers Bindingの`chatCompletions()`またはREST APIで「検索＋回答生成」を1呼び出しで実行できる。検索したチャンクを自動でコンテキストに差し込み、System Promptをカスタマイズし、`stream: true`でストリーミング応答も返せる。クエリ書き換え（過去ターンを踏まえてユーザー質問をリライト）もここに統合されている。
+
+### MCP & Embeddable UI
+各インスタンスはMCPエンドポイントを自動公開するため、ClaudeやChatGPTなどのMCP対応エージェントから「ツール」としてそのまま検索できる。さらに埋め込み可能なSearch UIコンポーネントも用意され、社内ポータル等にコピペで貼れる。
+
+### AI Crawl Control（識別とポリシー）
+Cloudflareが既存のBot Managementで蓄積している「正規Botのフィンガープリント＋IPレンジ＋User-Agent」のデータベースから、AI関連クローラ（GPTBot / ChatGPT-User / ClaudeBot / Claude-Web / PerplexityBot / Google-Extended / CCBot / Amazonbot / Bytespider など）を切り出して、専用ダッシュボードで可視化する。
+
+- **ポリシー**：個別クローラ単位、または「すべてのAIクローラ」単位で `Allow / Block / Challenge` を設定。
+- **robots.txtコンプライアンス追跡**：「robots.txtで拒否しているのに来ているクローラ」をハイライトし、ルール違反者にだけブロックを適用といった運用ができる。
+- **トラフィック分析**：どのクローラがどのパスをどれだけ叩いているかをパス単位・時系列で確認可能。
+
+### Pay per crawl
+コンテンツ単価をサイト側が設定し、AIクローラがそれを払えば通す、払わなければ`HTTP 402 Payment Required`を返す、という課金プロトコル。CloudflareがAI事業者との決済を仲介し、サイト所有者にレベニューシェアされる。出版社・ニュースメディア・教育コンテンツ事業者向けのマネタイズ機能で、現状ベータ。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- **AI Search**：すでにR2でドキュメント・社内マニュアル・カスタマーサポート記事を保管している、または自社サイトをそのままナレッジベース化したい組織。RAG配管を自前運用する人員がない。
+- **AI Search**：MCPサーバとしてエージェントから検索を呼びたいケース。Workers Binding／REST API／MCP／埋め込みUIを横並びで使い分けたいプロダクト。
+- **AI Search**：マルチテナントSaaSで「テナントごとに独立したインデックス」を動的に作って捨てる必要があるユースケース（namespace bindingで最大10インスタンスを束ねられる）。
+- **AI Crawl Control**：すでにCloudflareプロキシ配下にあるメディア・出版・ドキュメントサイトで、AIクローラの帯域消費とコンテンツ流出を可視化したい組織。
+- **AI Crawl Control**：robots.txtに`Disallow`を書いても無視されている疑いがあり、技術的にブロックする必要があるケース。
+- **Pay per crawl**：高品質コンテンツを抱え、AI事業者からの収益化交渉力を上げたい大手メディア。
+
+### 適していないシーン
+- **AI Search**：1日数千万チャンクを超える超大規模インデックス、または1ms未満のレイテンシ要件。マネージドである以上チューニング自由度は限定される。Vectorizeを直接、もしくはPinecone / Qdrantを使う方が適する。
+- **AI Search**：Cloudflare以外のLLM（Anthropic API、OpenAI API、Bedrock）を生成側に使い、検索だけ別ベンダーに置きたい場合は、`search()`のみ使って自前でLLMに渡す形になり、`chatCompletions()`の旨味が薄れる。
+- **AI Crawl Control**：Cloudflareをプロキシ経由していない（DNSのみ）サイト。トラフィックがエッジを通らないため識別もブロックも効かない。
+- **Pay per crawl**：個人ブログレベルのトラフィックでは交渉力もレベニューシェアも実額が立たない。エンタープライズメディア向けの機能と割り切る。
+
+## 競合・代替
+
+| 観点 | Cloudflare AI Search | OpenAI Assistants File Search | Pinecone Assistant | Vertex AI Search | Amazon Kendra | Algolia AI Search | Elastic ESRE |
+|---|---|---|---|---|---|---|---|
+| 出自 | エッジ統合マネージドRAG（旧AutoRAG） | OpenAI純正RAG（Assistants API） | Pinecone上のマネージドRAG | Google Cloud純正Enterprise Search | AWS純正Enterprise Search | サイト内検索SaaSのAI拡張 | Elasticsearch + AIツール群 |
+| データ取り込み | R2 / Webクロール / 直接Upload | ファイルUpload | ファイル / URL Upload | GCS / BigQuery / Web / 多数 | S3 / SharePoint / RDS等 | 各種コネクタ | 各種Beats / Logstash / Connector |
+| ベクタDB | Vectorize（同梱） | OpenAI管理（不可視） | Pinecone | Vertex Vector Search | Kendra内蔵 | Algolia独自 | Elasticsearch dense_vector |
+| ハイブリッド検索 | ◯（Vector + BM25） | △（Vector中心） | ◯ | ◯ | ◯ | ◯（Algoliaの強み） | ◯ |
+| リランキング | ◯（差し替え可） | △ | ◯ | ◯ | ◯ | ◯ | ◯（ELSER等） |
+| MCPエンドポイント | 標準提供 | × | × | × | × | × | × |
+| LLM生成統合 | Workers AI連携 | 同社GPT固定 | 任意LLM | Geminiに最適化 | 任意LLM | 任意LLM | 任意LLM |
+| 強み | エッジ実行・低レイテンシ・配管不要 | OpenAIエコシステム密結合 | ベクタDBの成熟度 | GCPデータ資産との統合 | 企業データソースの広さ | UX・ファセット検索の作り込み | OSS資産・運用知見 |
+| 弱み | Beta、モデル選択の幅は限定 | 透明性低・コスト不透明 | RAG配管は別途必要 | GCP前提・複雑 | 高コスト・複雑 | RAG（生成）は外付け | 自前運用負荷 |
+
+AI Searchの本質的な独自性は「Vectorize / Workers AI / R2 / Workersをエッジで束ねた1パッケージ」であり、特にWorkers BindingからLLM呼び出しまで往復ゼロ・ネットワーク跨ぎゼロでRAGを完結できる点は、他クラウドのRAGスタックでは到達しづらい。一方で、エンタープライズコネクタ（SharePoint・Salesforce・Confluence等）の品揃えはKendra / Vertex AI Searchが圧倒的に厚い。
+
+AI Crawl Controlに直接対応する商用プロダクトは現状ほぼ存在せず、`DataDome` / `HUMAN`（旧PerimeterX）等のBot対策SaaSがAIクローラ識別を強化しつつある段階。Pay per crawlに至ってはCloudflare独自で、`TollBit`のようなスタートアップが類似モデルを提供する程度である。
+
+## 料金
+
+AI Searchは複数コンポーネントの合算課金で、以下の各レイヤが個別に従量化される。
+
+- **Workers AI（埋め込み生成 + 生成 + リランキング + クエリ書き換え）**：呼び出すモデルごとにNeurons課金。インデックス時の埋め込み生成、クエリ時の埋め込み生成、リランキング、回答生成すべてが累積する。
+- **Vectorize**：保管ベクタ数 × dimensions と、クエリ時のベクタ読み出し量で課金。AI Searchが背後で消費する。
+- **R2**：データソース側のストレージ＋取り込み時のClass Aオペレーション。2026年4月以降の新規インスタンスは「managed storage」を選べばここはAI Search内に内包される。
+- **Search Query**：AI Search固有のクエリ単価が別途加算される（料金表は`AI Search → Limits & Pricing`を参照）。
+- **Workers**：Worker経由でクエリを叩くなら通常のWorkers Requests / CPU Time。
+
+つまり「埋め込み生成のNeurons」「Vectorizeの保管／クエリ」「Search Query単価」「LLM生成のNeurons」の4本立てで見積もるのが実務的である。最新値はダッシュボードの`AI Search → 該当インスタンス → Pricing`で必ず実測すること。
+
+AI Crawl Control本体は、Cloudflareプロキシ配下のZoneであれば基本機能（識別ダッシュボード・Allow/Block・robots.txt追跡）は無料〜既存プラン込みで提供される。Pay per crawlはベータで、課金フローが回り始めればAI事業者からの支払いに対するレベニューシェアモデルとなる。Bot Managementの上位機能（高度なヒューリスティック、ML Botスコア）はEnterpriseプランの`Bot Management`アドオンが前提なので、識別精度を上げるならそこと組み合わせる設計になる。
+
+## CLI / API 例
+
+### AI Search インスタンス作成（wrangler）
+```bash
+# R2バケットをソースにしたインスタンスを作成
+wrangler ai-search create my-knowledge \
+  --source-type=r2 \
+  --r2-bucket=docs-bucket \
+  --embedding-model=@cf/baai/bge-base-en-v1.5 \
+  --generation-model=@cf/meta/llama-3.3-70b-instruct \
+  --rerank-model=@cf/baai/bge-reranker-base
+
+# Webサイトをクロールするインスタンス
+wrangler ai-search create my-site-rag \
+  --source-type=website \
+  --site-url=https://docs.example.com \
+  --include-paths="/guide/*,/api/*"
+```
+
+### Workers Binding（wrangler.toml）
+```toml
+compatibility_date = "2026-03-27"
+
+# 単一インスタンスにバインド
+[[ai_search]]
+binding = "MY_SEARCH"
+instance_name = "my-knowledge"
+
+# Namespace全体にバインド（最大10インスタンスを動的にlist/get）
+[[ai_search_namespaces]]
+binding = "TENANT_SEARCH"
+namespace = "tenants"
+```
+
+### Worker からのクエリ（search + chatCompletions）
+```ts
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const { query } = await req.json<{ query: string }>();
+
+    // 1. 検索のみ（ベクタ＋BM25のハイブリッド、メタデータでフィルタ）
+    const hits = await env.MY_SEARCH.search({
+      query,
+      retrieval_type: "hybrid",
+      max_num_results: 8,
+      score_threshold: 0.5,
+      rewrite_query: true,
+      rerank: true,
+      filters: { language: { eq: "ja" }, version: { gte: 3 } },
+    });
+
+    // 2. 検索 + LLM応答生成（ストリーミング）
+    const stream = await env.MY_SEARCH.chatCompletions({
+      messages: [{ role: "user", content: query }],
+      stream: true,
+      system_prompt: "あなたは社内ナレッジに基づいて回答するアシスタントです。",
+    });
+
+    return new Response(stream, {
+      headers: { "content-type": "text/event-stream" },
+    });
+  },
+};
+```
+
+### REST API（外部システムからのクエリ）
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "query": "Workers KVとR2の使い分けは？",
+    "retrieval_type": "hybrid",
+    "max_num_results": 5,
+    "rerank": true
+  }' \
+  "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-search/instances/my-knowledge/search"
+```
+
+### AI Crawl Control ルール（REST API）
+```bash
+# 全AIクローラに対するブロックルールを作成
+curl -X POST \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "action": "block",
+    "scope": "all_ai_crawlers",
+    "description": "Block all AI crawlers by default"
+  }' \
+  "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/ai-crawl-control/rules"
+
+# 特定クローラだけ許可（GPTBot / ClaudeBotは通す）
+curl -X POST \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "action": "allow",
+    "crawlers": ["GPTBot", "ClaudeBot"],
+    "description": "Allow OpenAI and Anthropic only"
+  }' \
+  "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/ai-crawl-control/rules"
+```
+
+### Pay per crawl（HTTP 402を返す設定例）
+```bash
+# 1ページあたりの単価を設定（USD）してPay per crawlを有効化
+curl -X PUT \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "enabled": true,
+    "price_per_request_usd": 0.001,
+    "applicable_paths": ["/articles/*"],
+    "fallback_action": "402"
+  }' \
+  "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/ai-crawl-control/pay-per-crawl"
+```
+
+## 制限・注意点
+- **AI SearchはBeta**（2026-05時点）。SLAは未提供で、APIシグネチャや課金体系は変更され得る。プロダクションで使うなら、`search()`の戻り値型を抽象化レイヤで包んでベンダー依存を局所化しておく。
+- **埋め込みモデルはインスタンス作成時に固定**。後から変更すると全チャンクの再埋め込みが必要なため、最初のモデル選定を慎重に行う（多言語が必要なら`bge-m3`系、英語特化なら`bge-base-en-v1.5`等）。
+- **対応モデルはWorkers AIのカタログ依存**。`@cf/baai/bge-*` / `@cf/meta/llama-*` / `@cf/google/gemma-*` 等、Workers AI側で提供されているモデルが順次取り込まれる。OpenAI埋め込み（`text-embedding-3-large`等）は直接は使えない。
+- **リージョン**：Cloudflareのグローバルエッジ上で動作するが、Workers AIのGPUリージョンはまだ全PoPに行き渡っておらず、推論は最寄りのGPU PoPにルーティングされる。データレジデンシー要件があるEU等では、Vectorizeおよび埋め込み実行がEU内に閉じる構成かを確認する必要がある。
+- **インデックス再同期のタイミング**：Automated Indexingは「継続的」だが、ニアリアルタイムではなく数分〜数十分のラグがある。投稿直後の新着記事をすぐ検索したいなら、明示的な再同期APIを叩く設計が必要。
+- **AI Crawl Controlの識別精度はBot Management依存**。User-Agent詐称＋住宅プロキシ経由のスクレイパは、Bot Managementの上位プラン（ML Score / JA3 / JA4フィンガープリンティング）がないと完全には捕捉できない。
+- **Pay per crawlはベータ**かつAI事業者側の対応が前提。GPTBot / ClaudeBot等が決済プロトコルに対応していなければ、現状は単純に402で拒否されるだけになる。導入前に対応状況を確認する。
+- **robots.txtは依然として必要**。AI Crawl Controlでブロックしてもrobots.txtを更新していなければ「正直なクローラ」も巻き込んで止めることになる。技術ブロックと宣言（robots.txt / `ai.txt` / `llms.txt`）はセットで運用する。
+- **MCP公開時の認可**：AI SearchインスタンスのMCPエンドポイントを外部エージェントに開放する場合、トークンスコープ・レート制限・テナント分離を必ず噛ませる。社内データが他テナントに漏れる経路になり得る。
+
+## 参考リンク
+- AI Search Overview：https://developers.cloudflare.com/ai-search/
+- AI Search Configuration：https://developers.cloudflare.com/ai-search/configuration/
+- AI Search Workers Binding：https://developers.cloudflare.com/ai-search/usage/workers-binding/
+- AI Crawl Control Overview：https://developers.cloudflare.com/ai-crawl-control/
+- Pay per crawl：https://developers.cloudflare.com/ai-crawl-control/features/pay-per-crawl/
+- Workers AI（埋め込み・生成モデル）：https://developers.cloudflare.com/workers-ai/
+- Vectorize：https://developers.cloudflare.com/vectorize/
+- Bot Management：https://developers.cloudflare.com/bots/
+- Cloudflare AI Search product page：https://www.cloudflare.com/developer-platform/products/ai-search/
+- llms.txt（AI Crawl Control）：https://developers.cloudflare.com/ai-crawl-control/llms.txt
+
+---
+参照日: 2026-05-04

--- a/src/content/knowledge/web-development/cloudflare-docs/61-analytics-logs.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/61-analytics-logs.mdx
@@ -1,0 +1,207 @@
+---
+title: "Cloudflare Analytics & Logs (Web Analytics / Logpush / Log Explorer / Workers Observability)"
+description: "Cloudflareエッジを通過したリクエストとアプリ実行のテレメトリを、無料のRUM（Web Analytics）からSIEM転送（Logpush）、Cloudflare内SQL検索（Log Explorer）、Workers専用のログ・トレース（Workers Observability）まで、レイヤごとに使い分けて観測するための一連の製品群である。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 61
+---
+# Analytics & Logs (Web Analytics / Logpush / Log Explorer / Workers Observability)
+
+## 一行サマリ
+Cloudflareエッジを通過したリクエストとアプリ実行のテレメトリを、無料のRUM（Web Analytics）からSIEM転送（Logpush）、Cloudflare内SQL検索（Log Explorer）、Workers専用のログ・トレース（Workers Observability）まで、レイヤごとに使い分けて観測するための一連の製品群である。
+
+## 解決する課題（Why）
+CDN・WAF・Workersに業務トラフィックを通すと、ボトルネックや攻撃の痕跡はCloudflare側にしか残らない。一方でアプリ側のAPMやSIEMにそのデータを取り込めなければ、インシデント調査時に「Cloudflareでは止まったが、その先で何が起きたか」「誰が踏み台になったか」が突合できない。さらにGDPR・改正電気通信事業法以降、サードパーティCookieに依存する従来のWeb分析（GA4等）はそのまま使い続けにくく、エッジ側でCookieを置かずに集計する選択肢が現実的な代替として求められている。Cloudflareの観測系はこれらを以下のように分担して解決する。
+
+- Cookieを置かないRUMでCore Web Vitalsとアクセス数を計測（Web Analytics）。
+- HTTPリクエスト・WAFイベント・DNS・Workers Traceなどを連続バッチでR2 / S3 / Datadog / Splunk / Sentinelに転送（Logpush）。
+- Cloudflare内に同じログをR2バックエンドで保管し、ダッシュボードからSQL検索（Log Explorer）。
+- Workersは`console.log`を書くだけでダッシュボードから検索でき、OTLP互換のトレースも取り出せる（Workers Observability）。
+- 全ダッシュボードの数値の出所であるGraphQL Analytics APIを叩いて自前BIに投入。
+
+## 主要機能（What）
+
+### Web Analytics（Cookie-less RUM）
+ブラウザ側で動く軽量JS beaconが、Cookie・LocalStorage・Fingerprintingを使わずにPageviews・Visits・Core Web Vitals（LCP / INP / CLS / TTFB / FCP）・Referrer・Country・Device classを集計する仕組みである。GDPR下でCookie同意バナーを出さずに済むのが最大の価値で、全プラン（Freeを含む）で無料で使える。
+
+- **Automatic setup**：Cloudflare上のZoneであれば、ダッシュボードで有効化するだけでHTML応答にbeaconを自動注入する（HTML proxyingが前提）。
+- **Manual setup**：Cloudflareプロキシ外のサイト（Vercel / Netlify / S3静的ホスティング等）にも、`<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token":"..."}'></script>`を埋めるだけで集計できる。
+- **Sites と Token**：計測単位は「Site」で、Siteごとに発行されるTokenでデータが紐付く。1アカウント複数Site可。
+- **Edge Analytics（旧Browser Insights）との違い**：Web AnalyticsはRUM（クライアント側beaconベース）。Zone Analyticsはエッジ側で見たHTTPリクエスト全件をサンプリング集計したもので、性質が違う。両者は別物として並列に存在する。
+- **エクスポート**：GraphQL Analytics APIから`rumPageloadEventsAdaptiveGroups`等のデータセットで取り出せる。
+
+### Logpush（連続バッチ転送）
+Cloudflare上で発生した各種ログを、5分単位前後のバッチで外部ストレージ・SIEMに転送するサービスである。Enterpriseが正規価格帯だが、HTTP requestsデータセットはBusinessでも条件付きで使えるなどデータセットごとに利用可否が異なる。
+
+- **対応データセット**（主なもの）：HTTP requests、Firewall events / WAF、Spectrum events、DNS firewall、Gateway DNS / HTTP / Network、Access requests、Audit logs、Workers Trace events、Workers Invocations、R2 access、Magic IDS / Magic Network Monitoring、CASB findings、Zaraz、DNS logs、Sinkhole、Device Posture results、Page Shield。
+- **対応宛先**：R2、S3、GCS、Azure Blob、Datadog、Splunk（HEC）、Microsoft Sentinel、Sumo Logic、New Relic、汎用HTTPS endpoint、S3互換（MinIO等）。
+- **フィールド選択 / フィルタ**：データセットごとのフィールド一覧から必要なカラムだけ抽出でき、`filter`式でステータスコード・ホスト・WAFアクション等で絞り込み可能。これでR2・SIEM転送量を抑える。
+- **サンプリング**：HTTP requestsはデフォルト全件、`sample`パラメータで0.01〜1.0の比率を指定できる。
+- **Logpull（旧REST API）**：HTTP request logsを直近7日間REST取得できた旧API。新規利用は非推奨で、Logpush + R2 / Log Explorerに置き換える設計が公式の推奨。
+
+### Log Explorer（Cloudflare内SQL検索）
+LogpushでR2に書き出すのと同じデータを、Cloudflare側で管理されるストレージに保管し、ダッシュボードまたはAPIから**SQL**で検索できるマネージドログ検索サービスである。Splunkを買うほどではないがダッシュボード保持期間（数十時間〜数日）では足りない、という中規模組織のスイートスポット。
+
+- **保持期間**：Enterprise契約で最大2年。
+- **料金**：保管$0.10/GB/月（執筆時点）。クエリ料金は別建て、リージョンと実行時間で課金される。
+- **対応データセット**：HTTP requests / Firewall events / Access requests / Gateway / WAF / DNS / Page Shield など、Logpush対応データセットのうち順次GA化されている。
+- **クエリ例**：`SELECT ClientIP, count(*) FROM http_requests WHERE EdgeResponseStatus = 500 GROUP BY ClientIP ORDER BY 2 DESC LIMIT 50`のようにANSI SQLで書ける。
+- **Logpushとの関係**：「Cloudflareに置く（Log Explorer）」と「外に出す（Logpush）」は併用可能。SIEMには既存運用のままLogpushで送りつつ、開発者がアドホックに掘る用途でLog Explorerを引く、というのが実運用パターン。
+
+### Instant Logs（リアルタイム尾引き）
+HTTP requestsだけ、ダッシュボードまたは`wrangler`CLI経由でリアルタイムにストリーミング表示できる機能である。本番障害発生時に「いま流れているリクエスト」を直接見るのに使う。Enterprise zone限定。データは保管されない（その場で見るだけ）。
+
+### Workers Observability
+Cloudflare Workersに特化した観測スタック。`wrangler.toml`に`[observability] enabled = true`を書くだけで、`console.log`の出力がダッシュボードに集約され、検索・絞り込みができる。
+
+- **Workers Logs**：`console.log` / `console.error`を自動収集。デフォルトで`head_sampling_rate = 1`（全件）、保持期間はFree/Standardともに数日〜7日。`invocation_logs`オプションでリクエスト単位のメタデータも取れる。
+- **Tail Workers**：別Workerを「ログ送出先」に指定して、自前で外部システムに転送する仕組み。OTLPエクスポートやSentry連携の中継に使える。
+- **`wrangler tail`**：CLIから本番Worker実行ログをリアルタイムストリーム。`--format pretty`でローカルで色付き表示、`--status error`等でフィルタ可。
+- **Trace events**：Workers Traceデータセットとして、Worker実行ごとにbindings（KV / R2 / D1 / DO）の呼び出しと処理時間が自動的に記録される。Logpush転送可。
+- **OpenTelemetry export**：OTLP互換でHoneycomb / Grafana Cloud / Axiom / Sentry等にトレース・ログを直接送れる。
+- **Source maps**：ビルド時に`upload_source_maps = true`を設定するとスタックトレースが圧縮前のソース行に解決される。
+- **Query Builder**：エラー率・p99 CPU time・メモリ・サブリクエスト数などを絞り込み・グルーピングして可視化するダッシュボード組み込みクエリツール。
+
+### GraphQL Analytics API
+ダッシュボードの全グラフのバックエンドであり、自前BIに数値を持っていく場合の正規ルート。`https://api.cloudflare.com/client/v4/graphql`に対し、Bearer Tokenでクエリを投げる。
+
+- **データセット**：`httpRequestsAdaptiveGroups`、`firewallEventsAdaptive`、`workersInvocationsAdaptive`、`r2OperationsAdaptiveGroups`、`rumPageloadEventsAdaptiveGroups`、`dnsAnalyticsAdaptive`、`gatewayResolverByTimeAdaptiveGroups`等、製品ごとに数十種。
+- **Adaptive Sampling**：`Adaptive`が付くデータセットはCloudflareが自動でサンプリング比率を調整しており、レスポンスに`_sampleInterval`が含まれる。集計値はサンプル比率を補正済み。
+- **Account / Zone**：`viewer.accounts`配下と`viewer.zones`配下で取れる粒度が異なる。アカウント横断はAccount側、ホスト名・URLパス単位のZone Analytics系はZone側。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- 「とりあえずGA4の代わりにCookie-lessでPV計測したい」→ Web Analyticsで即終わる（Pro未満でも無料）。
+- CDN / WAFを既にCloudflareで運用しており、SIEM（Splunk / Sentinel / Datadog）に流す要件が出てきた → Logpushが自然な接続点。
+- ログ保管をAWS / GCPに置きたくない（DXコスト・データ主権）→ R2 + Log ExplorerでCloudflare内に閉じる。
+- WorkersでAPI / SaaSバックエンドを構築する組織。`console.log`から本番調査までDXが完結し、別途APMを買わずに回せる。
+- 監査要件で「全リクエストを保管」が必要な金融・公共。Logpush（R2 / S3）+ Log Explorerで保持期間を満たす。
+
+### 適していないシーン
+- 大規模な行動分析・ファネル・コホート分析が必要なマーケ要件。Web AnalyticsはPV / Vitals中心でAmplitude / Mixpanel / GA4の代替にはならない。
+- 既にDatadog / New Relic / Splunkで全アプリのAPMを統一している組織は、Workers Observability単独では運用が分断する。OTLP exportでAPM側に集約する設計が良い。
+- HTTP requests以外のリアルタイム尾引き（DNSやFirewall eventsをライブで眺めたい）はInstant Logsが対応していない。
+- BusinessプランでLogpush全データセットを使いたいケース。多くはEnterprise必須。
+
+## 競合・代替
+
+| 観点 | Cloudflare（Web Analytics + Logs） | GA4 | Plausible | Fathom | Datadog Logs | Splunk | Grafana Loki | AWS CloudWatch Logs |
+|---|---|---|---|---|---|---|---|---|
+| 主用途 | エッジ計測 + ログ転送 | マーケ全般 | 軽量Web分析 | 軽量Web分析 | APM中心SIEM | エンタープライズSIEM | OSSログ集約 | AWS統合ログ |
+| Cookie | 不要（RUM） | 必要（同意必須） | 不要 | 不要 | NA | NA | NA | NA |
+| 価格帯 | 無料〜Enterprise | 無料〜GA360（高） | $9/月〜 | $14/月〜 | $0.10/GB〜 | 高（要見積） | OSS無料〜Cloud | $0.50/GB ingest〜 |
+| 保持 | 6ヶ月（RUM）/ 2年（Log Explorer） | 14ヶ月（無料） | 無制限 | 無制限 | 7〜30日標準 | 契約次第 | 自前 | 自由設定 |
+| SQL検索 | Log Explorer | BigQuery export | × | × | Log Patterns | SPL | LogQL | Logs Insights |
+| エッジ統合 | ◎（自社製品） | ✕ | ✕ | ✕ | ✕ | ✕ | ✕ | ✕ |
+| 強み | エッジで取れたものをそのまま | マーケ機能の厚み | 簡潔・倫理的 | 簡潔・倫理的 | APM統合 | エンタープライズ機能 | OSS・コスト | AWS統合 |
+| 弱み | 行動分析は弱い | Cookie同意・複雑 | エッジログなし | エッジログなし | Cloudflare固有メトリクスは別経由 | コスト・運用 | スケール運用が重い | クロスクラウド弱い |
+
+Cloudflareの強みは「エッジで止まったリクエストの本物のログをそのまま転送・検索できる」点に尽きる。マーケ分析やアプリAPMの代替ではなく、エッジ側の真実を持って既存の分析基盤に合流させる存在として位置づけるのが現実的。
+
+## 料金
+
+- **Web Analytics**：全プラン無料。Site数・ドメイン数の実質的な制限はなく、保持期間6ヶ月（執筆時点）。Pro以上で詳細なフィルタ・Path単位ドリルダウン精度が改善する程度の差分。
+- **Logpush**：基本Enterprise必須。一部データセット（HTTP requests等）はBusinessでも追加課金で使える場合がある。R2に書く場合のR2側コスト（$0.015/GB/月の保管 + Class A/B Operations）が別途かかる。Splunk / Datadog等の宛先側課金は別建て。
+- **Log Explorer**：保管 $0.10/GB/月（Enterprise契約）。クエリ実行料金は別途、リージョンと処理データ量に応じて課金。最大2年保持。
+- **Workers Observability**：Free / Standard（Paid Workers）に**Workers Logs無料枠**が含まれる（執筆時点で20M logs/月相当）。超過分は$0.60 / 1M logs程度の従量。Logpushで外部に出す場合はEnterprise扱い。Tracesは執筆時点でβ含み、料金体系は順次明示化されている。
+- **GraphQL Analytics API**：API利用自体は無料（プランに紐付くデータ範囲・粒度・サンプリングに従う）。
+
+「無料で取れるところ（Web Analytics・Workers Logs・GraphQL API）で要件を満たし、長期保管・SIEM転送が必要になったときだけEnterpriseに上がる」という段階導入が定石。
+
+## CLI / API 例
+
+### Logpush ジョブ作成（HTTP requests → R2）
+```bash
+# データセットとフィールドはまずDescribeで確認
+curl -s "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/logpush/datasets/http_requests/fields" \
+  -H "Authorization: Bearer $CF_API_TOKEN" | jq
+
+# ジョブ作成（R2バケットに5xxだけ書く）
+curl -X POST "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/logpush/jobs" \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "http-5xx-to-r2",
+    "destination_conf": "r2://prod-cf-logs/http/{DATE}?account-id='"$ACCOUNT_ID"'&access-key-id='"$R2_KEY"'&secret-access-key='"$R2_SECRET"'",
+    "dataset": "http_requests",
+    "logpull_options": "fields=RayID,EdgeStartTimestamp,ClientIP,ClientRequestHost,ClientRequestURI,EdgeResponseStatus&timestamps=rfc3339",
+    "filter": "{\"where\":{\"key\":\"EdgeResponseStatus\",\"operator\":\"geq\",\"value\":\"500\"}}",
+    "enabled": true
+  }'
+```
+
+### GraphQL Analytics API（直近1時間の5xx率）
+```bash
+curl -s https://api.cloudflare.com/client/v4/graphql \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "query($zone:String!,$since:Time!,$until:Time!){viewer{zones(filter:{zoneTag:$zone}){httpRequestsAdaptiveGroups(limit:1,filter:{datetime_geq:$since,datetime_leq:$until}){sum{requests} avg{sampleInterval} dimensions{__typename}} http5xx:httpRequestsAdaptiveGroups(limit:1,filter:{datetime_geq:$since,datetime_leq:$until,edgeResponseStatus_geq:500}){sum{requests}}}}}",
+    "variables": {"zone":"'"$ZONE_ID"'","since":"2026-05-04T00:00:00Z","until":"2026-05-04T01:00:00Z"}
+  }' | jq
+```
+
+### Workers ログのライブ尾引き
+```bash
+# 本番Workerに繋いでリアルタイムログ（5xxのみ・整形）
+wrangler tail my-api --format pretty --status error
+
+# observabilityをwrangler.tomlで有効化
+cat >> wrangler.toml <<'TOML'
+[observability]
+enabled = true
+head_sampling_rate = 1.0
+
+[observability.logs]
+invocation_logs = true
+TOML
+```
+
+### Log Explorer SQL（ダッシュボードまたはAPI経由）
+```sql
+-- 直近1時間のホスト別5xx Top 20
+SELECT ClientRequestHost AS host, count(*) AS errors
+FROM http_requests
+WHERE EdgeStartTimestamp > now() - INTERVAL '1' HOUR
+  AND EdgeResponseStatus >= 500
+GROUP BY host
+ORDER BY errors DESC
+LIMIT 20;
+```
+
+### Web Analytics 手動beacon（Cloudflare外サイトへの埋め込み）
+```html
+<!-- Token は Web Analytics ダッシュボードから発行 -->
+<script defer
+  src="https://static.cloudflareinsights.com/beacon.min.js"
+  data-cf-beacon='{"token": "YOUR_SITE_TOKEN"}'></script>
+```
+
+## 制限・注意点
+- **Logpushはプラン依存**：データセットの大半がEnterpriseのみ、HTTP requestsは一部Businessでも可、という不揃いな状態。導入前に必ず`/logpush/datasets`で利用可否を確認する。
+- **Log Explorer保持期間とコスト**：最大2年だが、HTTP requests全件をフィルタなしで保管するとTB単位/月になり保管料金が嵩む。`fields`絞り込み・`filter`での減量設計が必須。
+- **サンプリング**：ダッシュボードや`*Adaptive*`系GraphQLはトラフィック規模に応じて自動サンプリングされる。`sum.requests`は補正済み数値だが、生ログを必要とする監査用途ではLogpushでサンプル無し転送が必要。
+- **Workers Logsの保持と上限**：保持は短期（数日）。長期保管が要るならLogpush（Workers Trace events）でR2に流す前提で設計する。`head_sampling_rate`を下げているとデバッグ時に見たいログが落ちている事故が起きやすい。
+- **Web AnalyticsはRUM**：BotやJS無効ブラウザの数は計測されない。Zone Analytics（エッジ集計）と合わせて読むのが正攻法。Bot Managementと組み合わせれば人間トラフィックだけのRUM結果を出せる。
+- **PII**：HTTP request logsには`ClientIP`・`ClientRequestURI`・`User-Agent`・`Cookie`等が含まれ、フィールド選択で外さないと個人情報が外部SIEMに出る。GDPR / 個情法対応を前提に最初からフィールドを絞る。
+- **Logpullは新規非推奨**：API互換のために残っているが、新規導入はLogpushに統一する。
+- **Instant Logsは保管されない**：尾引き専用。後から振り返るならLog Explorer / Logpush + R2を並走させる。
+- **GraphQL料金プラン制限**：プランによって取れるデータセット・時間粒度・遡れる期間が違う（FreeはZone analyticsの一部のみ等）。BIに取り込む前にプラン要件を確認する。
+
+## 参考リンク
+- Cloudflare Analytics ハブ：https://developers.cloudflare.com/analytics/
+- Web Analytics：https://developers.cloudflare.com/web-analytics/
+- Logs（Logpush / Instant Logs / Logpull）：https://developers.cloudflare.com/logs/
+- Logpush 宛先一覧：https://developers.cloudflare.com/logs/logpush/logpush-job/
+- Log Explorer：https://developers.cloudflare.com/log-explorer/
+- Workers Observability：https://developers.cloudflare.com/workers/observability/
+- Workers Logs：https://developers.cloudflare.com/workers/observability/logs/workers-logs/
+- `wrangler tail`：https://developers.cloudflare.com/workers/wrangler/commands/#tail
+- GraphQL Analytics API：https://developers.cloudflare.com/analytics/graphql-api/
+- Logs llms.txt：https://developers.cloudflare.com/logs/llms.txt
+- Analytics llms.txt：https://developers.cloudflare.com/analytics/llms.txt
+
+---
+参照日: 2026-05-04

--- a/src/content/knowledge/web-development/cloudflare-docs/62-containers.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/62-containers.mdx
@@ -1,0 +1,211 @@
+---
+title: "Cloudflare Containers"
+description: "Cloudflare Containersは、Workers Runtime（V8 Isolate）に収まらない任意のDockerイメージをCloudflareエッジ上の軽量VMで実行し、Workerからバインディング経由で `fetch()` 呼び出しできる「Workers拡張用コンテナ実行基盤」である。Region: Earth・Auto-sleep・Durable Object結合が組み込まれており、運用モデルはECSやCloud Runと根本的に異なる（2026-05時点でOpen Beta）。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 62
+---
+# Containers
+
+## 一行サマリ
+Cloudflare Containersは、Workers Runtime（V8 Isolate）に収まらない任意のDockerイメージをCloudflareエッジ上の軽量VMで実行し、Workerからバインディング経由で `fetch()` 呼び出しできる「Workers拡張用コンテナ実行基盤」である。Region: Earth・Auto-sleep・Durable Object結合が組み込まれており、運用モデルはECSやCloud Runと根本的に異なる（2026-05時点でOpen Beta）。
+
+## 解決する課題（Why）
+Cloudflare Workersは高速・グローバル・無料枠強力という強みを持つ一方、V8 Isolate上のWeb標準Runtimeで動かすという制約から以下が苦手だった。
+
+- ネイティブバイナリやffmpeg、Headless Chromium、Pandocなど「Linuxバイナリ前提」のライブラリを呼びたい。
+- PythonやGoの既存サーバ実装（Flask / Gin等）をそのまま動かしたい。
+- 数十秒〜数分の長時間処理（動画変換、PDFレンダリング、機械学習推論の前処理）。
+- 数百MB〜GB規模のヒープやファイルシステムを使う処理。
+- 既存のDockerfile資産を捨てずにCloudflareネットワークに載せたい。
+
+選択肢としてはECS / Cloud Run / Fly.io Machinesがあるが、「Workersから呼び出す重処理だけのために別クラウドのVPC・IAM・LB・スケーリング設定を組む」のは過剰投資である。Containersはこの隙間を埋める。Workerが入口・ルーティング・キャッシュ・認可を担い、コンテナはWorkerに収まらない処理だけを引き受ける、という役割分担が前提である。
+
+## 主要機能（What）
+
+### Container Application
+Dockerfileまたは事前ビルド済みイメージ（`linux/amd64`）をCloudflare Registryにアップロードし、グローバルに分散配置する。Workerから初めてリクエストが来たタイミングでインスタンスが起動するオンデマンド方式である。
+
+- **インスタンスタイプ**：`lite` / `basic` / `standard-1〜4` のプリセット、またはカスタム（vCPU 1-4、メモリ最大12 GiB、ディスク最大20 GB）。
+- **ディスク**：すべてエフェメラル。Auto-sleepで停止すると次回起動時はクリーンな状態に戻る。永続化はR2 / D1 / Durable Object Storageに任せる前提。
+- **環境変数 / シークレット**：`envVars`プロパティおよびWorkers Secretsから注入。
+
+### Auto-sleep
+リクエストが途絶えてから一定時間（`sleepAfter` プロパティ、例：`'10m'`）でインスタンスを停止する。停止中はvCPU課金が止まる。常駐サーバを24/7立ち上げるのではなく「リクエスト駆動でスピンアップする小さなVM」というモデルが核心であり、コスト構造もこれを前提に設計されている。
+
+### Workers Binding
+WorkerからContainerへは、Durable Objects互換のバインディング経由でアクセスする。`getByName()` で名前付きインスタンス（同一名は同一インスタンスにルーティング）、`getRandom()` でロードバランシングを書ける。Worker側がリクエストルーティング・認証・WAF判定を行い、コンテナはピュアなアプリケーションロジックに集中できる。
+
+### Durable Object 連携
+Containerクラス自体が Durable Object のサブクラスとして定義される。これにより「DO状態 + コンテナプロセス」を同じインスタンス境界で管理でき、Cloudflareの言うProgrammable Sidecarモデルが成立する。DOのSQLiteストレージにメタデータを置きつつ、コンテナで重処理を回す、という構成が自然に書ける。
+
+### リージョン配置（Region: Earth）
+明示的なリージョン指定は不要で、Cloudflareの300拠点超のネットワークから「イメージがプリフェッチされた最寄りのロケーション」が選ばれる。例として南米のリクエストはNeuquénやBuenos Aires、北米西海岸はSan Diegoなどに自動配置される。逆に「東京固定で動かしたい」「特定リージョンを禁止したい」という要件には現状フィットしない。
+
+### イメージ管理
+`wrangler containers images list` / `delete` でCloudflare Registry上のイメージを管理する。アカウント全体で50 GBのストレージ上限がある（個別イメージはインスタンスタイプのディスク上限まで）。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- Workers中心のアプリケーションで、一部だけWeb標準Runtimeに収まらない処理を切り出したい（PDF生成、画像/動画変換、Headlessブラウザ、Pandoc、ffmpeg）。
+- 既存のDockerfile資産があり、ECS / Cloud RunのIAM・VPC・LB設計を一から組むほどの規模ではないケース。
+- リクエスト駆動でスパイクが立つが、平常時はアイドルでよい処理。Auto-sleepの恩恵を受けやすい。
+- Durable Objectベースのアプリでセッション単位の重処理（音声処理、AIパイプラインの前処理）をピン留めしたい。
+- 「Workers + R2 + D1 + Containers」だけで完結させたい単一ベンダー構成。
+
+### 適していないシーン
+- **GPUワークロード**：現時点で非対応。LLM推論はWorkers AIまたは別クラウドのGPUインスタンスに寄せる。
+- **24/7常駐の長時間処理**：Auto-sleep前提のコスト構造のため、常時稼働させるとメモリ・ディスクの継続課金で割高になる。専用VPSかECS Fargateの方が安い。
+- **TCP/UDP直接受け**：エンドユーザーが非HTTPプロトコルで直接コンテナに接続することはできない。SMTPサーバ・ゲームサーバ用途は不可。
+- **特定リージョン縛り**：データレジデンシー要件（EUのみ・日本のみなど）を厳格に求められるワークロード。
+- **既にKubernetesを運用している組織**：Helm / Istio / Argo CDなど周辺エコシステムは使えない。Workers中心への思想転換が前提。
+
+## 競合・代替
+
+| 観点 | Cloudflare Containers | AWS Fargate | Cloud Run | Fly.io Machines | Render | Koyeb | Railway |
+|---|---|---|---|---|---|---|---|
+| 課金モデル | 秒課金、Auto-sleep標準 | 秒課金、常駐前提 | 100msリクエスト課金、Scale-to-zero標準 | 秒課金、Auto-stop設定可 | 月額固定（Service単位） | 秒課金、Scale-to-zero | 月額従量 |
+| Scale-to-zero | あり（標準） | なし（タスク常駐） | あり（標準） | あり（オプション） | 一部プランのみ | あり | なし |
+| GPU | 不可 | あり | あり（L4/A100） | あり | なし | 一部 | なし |
+| TCP/UDP直接 | 不可（Workers経由必須） | 可（NLB併用） | HTTP/gRPCのみ | TCP/UDP対応 | HTTPのみ | HTTPのみ | HTTP/TCP |
+| エッジ性 | 300+拠点、最寄り起動 | リージョン指定 | リージョン指定 | 35+リージョン | 中央集約 | 8リージョン | 中央集約 |
+| Workers / Edge統合 | ネイティブ | API Gateway別 | Cloud Functions別 | なし | なし | なし | なし |
+| 主用途の相性 | Workersの拡張 | エンタープライズ常駐 | コンテナ全般 | Geo分散アプリ | フルスタック小規模 | 軽量グローバル | 開発体験重視 |
+
+CloudflareがFargate / Cloud Runと張り合うのではなく「Workersに紐づく重処理を置く場所」というポジショニングである点が肝。代わりにWorkersを使わない素のコンテナ実行基盤としては、機能的にCloud RunやFly.ioの方が成熟している。
+
+## 料金
+Workers Paid（$5/月）契約が前提。Workers Free単独では使えない。
+
+| 項目 | レート | Workers Paid 込み枠 |
+|---|---|---|
+| vCPU | $0.000020 / vCPU秒 | 375 vCPU分/月 |
+| メモリ | $0.0000025 / GiB秒 | 25 GiB時間/月 |
+| ディスク | $0.00000007 / GB秒 | 200 GB時間/月 |
+
+**重要な課金挙動**：vCPUはアクティブ実行時のみ秒課金、メモリ・ディスクは「インスタンスが起動している間ずっと」プロビジョン分が課金される。Auto-sleepでアイドルアウトすると全項目止まる。10msグラニュラリティで計測される。
+
+**ネットワーク下り**：
+
+| リージョン | 単価 | 月次無料枠 |
+|---|---|---|
+| 北米・欧州 | $0.025/GB | 1 TB |
+| オセアニア・韓国・台湾 | $0.05/GB | 500 GB |
+| その他 | $0.04/GB | 500 GB |
+
+設計指針：「Auto-sleepで止まる前提で `sleepAfter` を短く」「メモリ/ディスクは過剰プロビジョンしない（停止中以外は払い続ける）」「インスタンスタイプはliteから始めて必要に応じて昇格」。
+
+## CLI / API 例
+
+### wrangler.jsonc 設定
+```jsonc
+{
+  "name": "my-app",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-05-01",
+  "containers": [
+    {
+      "class_name": "PdfRenderer",
+      "image": "./Dockerfile",
+      "instance_type": "basic",
+      "max_instances": 10
+    }
+  ],
+  "durable_objects": {
+    "bindings": [
+      { "name": "PDF_RENDERER", "class_name": "PdfRenderer" }
+    ]
+  },
+  "migrations": [
+    { "tag": "v1", "new_sqlite_classes": ["PdfRenderer"] }
+  ]
+}
+```
+
+### Container クラス定義（Worker側）
+```typescript
+import { Container, getRandom } from "@cloudflare/containers";
+
+export class PdfRenderer extends Container {
+  defaultPort = 8080;
+  sleepAfter = "10m";
+  envVars = { LOG_LEVEL: "info" };
+
+  override onStart() { console.log("container started"); }
+  override onStop() { console.log("container stopped"); }
+  override onError(err: unknown) { console.error("container error", err); }
+}
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const url = new URL(req.url);
+
+    // 同一ユーザーは同じインスタンスにピン留め
+    if (url.pathname.startsWith("/render/")) {
+      const userId = url.pathname.split("/")[2];
+      const container = env.PDF_RENDERER.getByName(userId);
+      return container.fetch(req);
+    }
+
+    // ロードバランシング（3インスタンスにランダム分散）
+    if (url.pathname.startsWith("/batch/")) {
+      const container = await getRandom(env.PDF_RENDERER, 3);
+      return container.fetch(req);
+    }
+
+    return new Response("not found", { status: 404 });
+  },
+};
+```
+
+### Dockerfile（最小例）
+```dockerfile
+FROM node:22-slim
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+COPY . .
+EXPOSE 8080
+CMD ["node", "server.js"]
+```
+
+### デプロイ・運用コマンド
+```bash
+# Worker + Container を一括デプロイ
+npx wrangler deploy
+
+# 稼働状況確認
+npx wrangler containers list
+
+# Registry上のイメージ一覧（50GB上限管理用）
+npx wrangler containers images list
+
+# 古いイメージ削除（ストレージ解放）
+npx wrangler containers images delete <image-ref>
+```
+
+## 制限・注意点
+- **Open Beta（2025年6月開始、2026-05時点も継続）**：API・wrangler設定キー・課金単価がGAまでに変わる可能性がある。プロダクション本番投入は慎重に。
+- **GPU不可**：機械学習推論はWorkers AIまたは別ベンダーへ。
+- **コールドスタート1〜3秒**：イメージサイズと初期化処理に依存。レイテンシ要件がシビアな同期APIには向かない。Workerでキャッシュを噛ませる、min_instancesを使う等の対策が必要。
+- **`linux/amd64` のみ**：Apple Silicon環境からビルドする場合は `--platform=linux/amd64` の指定が必須。
+- **メモリ/ディスク上限**：単一インスタンスは最大vCPU 4 / メモリ 12 GiB / ディスク 20 GB。これを超える処理は分割するか別基盤を検討。
+- **アカウント上限**：Workers Paidでは同時メモリ6 TiB・同時vCPU 1,500・同時ディスク30 TB・Registry総容量50 GB。Enterpriseでの引き上げは個別交渉。
+- **エフェメラルディスク**：Auto-sleepで状態は消える。永続化はR2 / D1 / DO Storageへ。
+- **直接的なTCP/UDP受け不可**：エンドユーザー向けのSMTP・カスタムプロトコルサーバには使えない。Workersを介したHTTPトンネルが必須。
+- **リージョン明示不可**：データレジデンシー要件があるならGAまで様子見、または代替手段（Workers for Platforms + 専用クラスタ等）を検討。
+- **Workers Paid必須**：Free Plan単独では利用不可。$5/月の最小コストが乗る。
+
+## 参考リンク
+- Cloudflare Containers Overview：https://developers.cloudflare.com/containers/
+- Get Started：https://developers.cloudflare.com/containers/get-started/
+- Platform Details / Limits：https://developers.cloudflare.com/containers/platform-details/limits/
+- Pricing：https://developers.cloudflare.com/containers/pricing/
+- Cloudflare Containers Coming 2025 (Blog)：https://blog.cloudflare.com/cloudflare-containers-coming-2025/
+- @cloudflare/containers npm：https://www.npmjs.com/package/@cloudflare/containers
+- Cloudflare developers llms.txt：https://developers.cloudflare.com/llms.txt
+
+---
+参照日: 2026-05-04

--- a/src/content/knowledge/web-development/cloudflare-docs/63-dns.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/63-dns.mdx
@@ -1,0 +1,212 @@
+---
+title: "Cloudflare DNS (Authoritative / DNS Firewall / Internal DNS)"
+description: "Cloudflare DNSは、Anycastで世界配信される権威DNS（Authoritative）と、外部権威ネームサーバの前段にキャッシュ層を挟むDNS Firewall、そしてZero Trust配下のクライアントだけが解決できるInternal DNSを束ねた、エッジ統合型のDNSプラットフォームである。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 63
+---
+# DNS (Authoritative / DNS Firewall / Internal DNS)
+
+## 一行サマリ
+Cloudflare DNSは、Anycastで世界配信される権威DNS（Authoritative）と、外部権威ネームサーバの前段にキャッシュ層を挟むDNS Firewall、そしてZero Trust配下のクライアントだけが解決できるInternal DNSを束ねた、エッジ統合型のDNSプラットフォームである。
+
+## 解決する課題（Why）
+DNSは「動いて当たり前」と扱われやすい一方、レイテンシ・改ざん耐性・対DDoS・社内外名前空間の分離・複数プロバイダ間のフェイルオーバといった要件が現実には積層しており、単一の権威サーバ運用では捌けない。Cloudflare DNSは以下を一つのコントロールプレーンで解決する。
+
+- 全レコードをAnycast配信し、地理的に最も近いPoPから応答してDNSルックアップのレイテンシを最小化する。
+- DNSSECで応答の改ざん・キャッシュポイズニングを抑止し、Multi-signer DNSSECで複数プロバイダ運用とも両立させる。
+- 既存のBIND/PowerDNSなど自社権威の前段にDNS Firewallを置き、recursive側からのDDoSとRandom Prefix Attackを吸収する。
+- 社内向けプライベートゾーンをInternal DNSとしてZero Trust（WARP/Gateway）配下にだけ公開する。
+- パブリックリゾルバ（1.1.1.1）と権威DNSは別プロダクトであり、役割を分離した上で同一エッジ網に同居させる。
+
+## 主要機能（What）
+
+### Authoritative DNS
+ドメインのNSをCloudflareに委任し、A/AAAA/CNAME/MX/TXT/SRV/CAA/HTTPS/SVCB等のレコードをAnycastで配信する権威DNSサービスである。Free zoneでも商用利用可能で、DNSのみ利用（プロキシなし、いわゆる"DNS-only"運用）も許容される。
+
+- **CNAME Flattening**：Apex（example.com）にCNAMEを置く構成を、応答時に解決済みA/AAAAへ畳み込んで返す。RFC違反を回避しつつSaaS（HerokuやNetlify）をApexに当てられる。
+- **Proxied vs DNS-only**：レコード単位でプロキシ（オレンジ雲）を切り替え、CDN/WAF経由かDNS応答のみかを選択する。
+- **Bulk import / export**：BINDゾーンファイル形式でのインポート・エクスポートに対応。
+- **Wildcard / Geo Steering**：Wildcardレコード、およびLoad Balancing連携でのGeoルーティング・ヘルスチェック付き応答。
+
+### DNSSEC / Multi-signer DNSSEC
+ゾーンに対してDNSSECを有効化すると、CloudflareがKSK/ZSKを管理しDSレコードをレジストラに登録するだけで運用が完結する。Multi-signer DNSSECは、Cloudflareと別プロバイダの両方を権威として並立させるマルチプロバイダ構成においても、各プロバイダが自分のZSKで署名し合う仕組みで、片寄せなしのDNSSEC運用を可能にする。
+
+- ワンクリック有効化（自動鍵管理 / 自動ロールオーバー）。
+- Multi-signer Model 2（各プロバイダが自分の鍵で署名し、互いのDNSKEYをゾーンに含める）を公式サポート。
+- Secondary DNSと組み合わせた冗長構成でもDNSSECを維持できる。
+
+### Secondary DNS / Multi-provider DNS
+Cloudflareをsecondaryとして使う構成（外部primary → Cloudflare）と、primaryとして使う構成（Cloudflare primary → 外部secondary）の双方をサポートする。AXFR/IXFRゾーン転送、TSIGによる転送認証に対応する。
+
+- **Cloudflare as Secondary**：BIND/PowerDNS/Route 53などのprimaryからAXFR/IXFRで取り込み、Cloudflareエッジから配信。プロキシ機能やDDoS吸収はsecondary構成でも有効。
+- **Cloudflare as Primary**：Cloudflareをマスタにして、他社DNSへ転送。
+- **Multi-provider DNS**：両プロバイダをNSに並べる構成で、片方の障害時にもクライアントが他方から応答を得られる。Multi-signer DNSSECはこのパターンの完成形。
+- TSIG（HMAC-SHA256等）でゾーン転送を相互認証。
+
+### Internal DNS（Zero Trust連携）
+WARP/Gateway配下のデバイスにのみ解決させたい社内ホスト名を、パブリックには露出しない形で配信する仕組みである。Gateway DNS resolverに「DNS view」を設定し、Internal Zoneに登録したレコードを社内クライアントへ返す。社外から同じFQDNを引いても応答は返らない。
+
+- **DNS Views**：ソース（拠点・ユーザ・グループ・Virtual Network）に応じて異なるゾーンを返す split-horizon DNS。
+- **Internal Zones**：パブリックゾーンとは別管理のプライベートゾーン。Tunnel経由の社内リソースに名前を付ける用途と相性が良い。
+- **Conditional Forwarding**：特定サフィックス（例：corp.example.com）だけオンプレDNSに転送する設定。
+- 既存のActive Directory DNSやRoute 53 Resolverに代替・併用できる位置付け。
+
+### DNS Firewall
+お客様自身が運用する外部権威ネームサーバ（BIND/NSDなど）の前段にCloudflareのAnycast IPを置き、そこにキャッシュとDDoS緩和層を挿入するサービスである。Authoritative DNSと違い「権威そのものをCloudflareに委ねる」のではなく、「権威の前にプロキシキャッシュを噛ませる」アーキテクチャである。
+
+- 専用Anycast IPv4/IPv6ペアを発行し、レジストラ側のNSをそのIPに張ったgluedレコードに切り替えて運用。
+- Random Prefix Attack（ランダムサブドメインによるキャッシュ枯渇攻撃）を含むDNS DDoSをエッジで吸収。
+- TTL尊重のキャッシュ層により、オリジンnameserverへのQPSを大幅に削減。
+- 既存DNS基盤（オンプレBIND、ベンダロックを避けたい商用DNS）の延命策として有効。
+
+### DNS Analytics / Logpush
+全クエリの応答コード・QType・PoP・国別分布をダッシュボードとGraphQL Analytics APIで参照できる。EnterpriseではLogpushでDNSクエリログをR2/S3/GCS/Splunk/Datadogへ継続転送可能。
+
+- レコード単位・国別・QType別のクエリ数とエラー率の可視化。
+- DNSSEC validation failureやNXDOMAIN比率の監視。
+- LogpushによるSIEM連携とコンプライアンス用途の長期保管。
+
+### 1.1.1.1 リゾルバとの違い
+1.1.1.1 は **public recursive resolver**（クライアントから引かれる側）、Cloudflare DNSのAuthoritative/DNS Firewallは **authoritative**（ゾーンを保持する側）であり、役割が完全に異なる。同じCloudflareエッジに同居しているため一見混同されがちだが、課金・設定・運用ドメインは別物である。Zero TrustのGateway DNS resolverは1.1.1.1ベースで動作し、Internal DNSはこのGateway resolverに「自社ビュー」をオーバレイする形で実装されている。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- すでにCloudflareをCDN/WAFとして使っており、DNSを同じプレーンに寄せて運用を単純化したい組織。
+- DNSSECを「鍵管理込みでワンクリック運用」したいが、自前でBIND鍵ローテーションを書きたくないチーム。
+- マルチプロバイダ冗長を組みたいが、Multi-signer DNSSECで片寄せなしの設計を維持したいケース。
+- 自社権威ネームサーバを温存しつつ、DDoS対策とキャッシュ層だけ外注したい（=DNS Firewall）伝統的インフラ部門。
+- WARP/Tunnelで社内アプリを公開しており、Internal DNSで「社内からだけ引ける名前空間」を欲しいZero Trust組織。
+
+### 適していないシーン
+- AWS / GCPでマネージド運用をRoute 53 / Cloud DNSに完全寄せ済みで、Terraformやエコシステム連携も含めて他社に外せないケース。
+- DNSベースの高機能トラフィックステアリング（NS1のFiltersや細かいGeo IPデータベース連携）を業務要件として使い倒しているケース。Cloudflare Load Balancingでも近いことはできるが、純血DNSベンダの柔軟性には及ばない部分がある。
+- Internal DNSが必須要件で、かつZero Trust（WARP）配布の運用体制が未整備な組織。BetaフェーズかつWARP前提のため、「DNSだけ欲しい」用途では過剰となる。
+
+## 競合・代替
+
+| 観点 | Cloudflare DNS | AWS Route 53 | Google Cloud DNS | NS1 (IBM) | Akamai Edge DNS | Dyn (Oracle) |
+|---|---|---|---|---|---|---|
+| 出自 | CDN / Anycastネットワーク | AWSマネージドDNS | GCPマネージドDNS | DNS専業（高機能ステアリング） | CDN / DNS専業 | DNS老舗（Oracle買収） |
+| Authoritative | 標準（Free zoneあり） | 標準 | 標準 | 標準 | 標準 | 標準 |
+| DNSSEC | ワンクリック / Multi-signer対応 | KSK持ち込み運用 | 標準対応 | 標準対応 | 標準対応 | 標準対応 |
+| Secondary / Multi-provider | AXFR/IXFR + TSIG / Multi-signer | Primary中心、Secondary別途 | Primary中心 | 強力 | 強力 | 強力 |
+| DNS Firewall（権威前段） | 標準提供（専用プロダクト） | なし（Shieldは別概念） | なし | なし | Edge DNSが該当機能を内包 | なし |
+| Internal / Private DNS | Internal DNS（Beta、WARP連携） | Route 53 Resolver / Private Zone | Cloud DNS Private Zones | NS1 Private DNS | 別プロダクト | 別プロダクト |
+| Geo / Traffic Steering | Load Balancing連携 | Routing Policies（豊富） | Routing Policies | 最強クラス（Filter Chain） | 強力 | 強力 |
+| Analytics | ダッシュボード+GraphQL+Logpush | CloudWatch Logs（Resolver Query Logs別途） | Cloud Logging | NS1 Pulsar / Data Streams | 標準同梱 | 標準同梱 |
+| 価格 | Authoritativeは無料、Advanced/Enterpriseで段差 | $0.50/zone/月+クエリ課金 | $0.20-0.40/zone/月+クエリ課金 | 高価（要見積もり） | 高価（要見積もり） | 高価（要見積もり） |
+| 強み | エッジ統合・無料権威・Multi-signer・DNS Firewall単独提供 | AWS資産との統合・Routing Policies | GCP資産との統合・シンプル | Steeringの柔軟性 | グローバル網・大企業向け運用 | 老舗の運用ノウハウ |
+| 弱み | 高機能Steeringは追従途上、Internal DNSはBeta | Multi-signer DNSSECは未成熟 | 機能数で他社に劣る | 価格と運用負荷 | 価格 | プロダクトの将来性に懸念 |
+
+CloudflareはAuthoritative DNSが無料で開始でき、DNSSEC・Multi-signer・DNS Firewall・Internal DNSまで同一アカウントに揃う点が最大の差別化要因である。逆に、ルーティング表現の柔軟性やGeoIPステアリングの精緻さを業務要件の中核に据えるなら、NS1やRoute 53を併用するのが妥当である。
+
+## 料金
+
+- **Authoritative DNS（Free zone）**：レコード数の実質的な上限はゾーンあたり3,500件程度（プラン依存）、クエリ数は無制限・無料。Free/Pro/Businessプランすべてに含まれる。
+- **Advanced DNS（add-on）**：年契約。レコード数上限の引き上げ、Multi-signer DNSSEC、Secondary DNS、Logpush（DNS logs）、専用Anycast IP、99.9999% SLAなどが解放される。中堅以上のドメイン運用が前提。
+- **Enterprise DNS**：Advanced DNSをEnterprise契約にバンドル。サポートSLA・専用Anycast IPv4/IPv6・カスタムDNSSEC運用・GraphQL長期保持などが含まれる。
+- **DNS Firewall**：Enterpriseプランの専用プロダクト。クラスタ単位（Anycast IPペア）で課金され、月額固定+QPS従量の構成。Authoritative運用しないがCloudflareの保護層だけ買いたい層向け。
+- **Internal DNS**：Zero Trust（Cloudflare One）ライセンスに紐付く。Gateway/WARP配布が前提。
+
+「Authoritative DNSは無料、付加価値（Multi-signer / Secondary / Logpush / Internal / Firewall）でEnterpriseに段差」が値付けの基本構造である。
+
+## CLI / API 例
+
+### curl（v4 API）
+```bash
+# ゾーン作成
+curl -X POST "https://api.cloudflare.com/client/v4/zones" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data '{"name":"example.com","account":{"id":"'${CF_ACCOUNT_ID}'"},"type":"full"}'
+
+# Aレコード追加（DNS-only）
+curl -X POST "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data '{"type":"A","name":"api","content":"203.0.113.10","ttl":300,"proxied":false}'
+
+# DNSSEC有効化（Cloudflare署名・自動鍵管理）
+curl -X PATCH "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dnssec" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data '{"status":"active"}'
+
+# Secondary DNSのprimary登録（Cloudflareをsecondaryとして使う場合）
+curl -X POST "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/secondary_dns/primaries" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data '{"name":"primary-bind","ip":"198.51.100.10","port":53,"ixfr_enable":true,"tsig_id":"'${TSIG_ID}'"}'
+```
+
+### Terraform（cloudflare provider v5）
+```hcl
+resource "cloudflare_zone" "main" {
+  account_id = var.account_id
+  name       = "example.com"
+  type       = "full"
+}
+
+resource "cloudflare_dns_record" "api" {
+  zone_id = cloudflare_zone.main.id
+  type    = "A"
+  name    = "api"
+  content = "203.0.113.10"
+  ttl     = 300
+  proxied = false
+}
+
+resource "cloudflare_dnssec" "main" {
+  zone_id = cloudflare_zone.main.id
+  status  = "active"
+}
+
+# DNS Firewall（recursive保護ではなくauthoritative前段キャッシュ）
+resource "cloudflare_dns_firewall" "edge" {
+  account_id          = var.account_id
+  name                = "primary-bind-cluster"
+  upstream_ips        = ["198.51.100.10", "198.51.100.11"]
+  minimum_cache_ttl   = 60
+  maximum_cache_ttl   = 900
+  deprecate_any_requests = true
+}
+```
+
+### BINDゾーンファイル取り込み
+```bash
+# UI: DNS → Records → Import and Export → Import DNS records
+# API:
+curl -X POST "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records/import" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -F "file=@example.com.zone" \
+  -F "proxied=false"
+```
+
+## 制限・注意点
+- Free/Pro/BusinessプランのDNSレコード上限はゾーンあたり概ね3,500件であり、巨大ゾーンを運用する場合はAdvanced DNSが前提となる。
+- Multi-signer DNSSECは双方のプロバイダがModel 2に対応している必要がある。Route 53は対応途上のため、組み合わせ次第で実装が成立しないことがある。
+- Cloudflareから割り当てられるNSホスト名（例：`xxx.ns.cloudflare.com`）は固定ペアで、自分で名指しすることはできない。Vanity Nameservers（自社ドメインのNS名で配信）はBusinessプラン以上が必要。
+- DNS Firewallの専用Anycast IPは契約単位で固定だが、IP自体の永続性は契約継続が前提。クラスタ廃止と同時に失効するため、レジストラのglue更新が必要。
+- DNS-onlyレコード（プロキシ無効）はCloudflareのDDoS吸収対象外であり、オリジンIPが直接露出する。プロキシ前提の防御を効かせたいレコードはオレンジ雲のままにする。
+- Internal DNSはBetaであり、Enterprise(Zero Trust)契約とWARP配布が前提。GA前のため設定UIや挙動が変動する。
+- AXFR/IXFRゾーン転送はTSIG必須。プレーン転送は認証なしの脆弱構成となるため、本番では使わない。
+- 1.1.1.1 publicリゾルバはAuthoritative DNSと別プロダクトであり、ゾーン側の障害は1.1.1.1には影響しない（逆も同様）。混同しない。
+- DNSSECのDSレコード登録はレジストラ側の操作であり、Cloudflareから自動で完結しない（CDS/CDNSKEY自動同期に対応するレジストラなら自動化可能）。
+
+## 参考リンク
+- Cloudflare DNS overview：https://developers.cloudflare.com/dns/
+- Cloudflare DNS llms.txt：https://developers.cloudflare.com/dns/llms.txt
+- DNSSEC：https://developers.cloudflare.com/dns/dnssec/
+- Multi-signer DNSSEC：https://developers.cloudflare.com/dns/dnssec/multi-signer-dnssec/
+- Secondary DNS：https://developers.cloudflare.com/dns/zone-setups/zone-transfers/
+- DNS Firewall：https://developers.cloudflare.com/dns/dns-firewall/
+- Internal DNS：https://developers.cloudflare.com/dns/internal-dns/
+- DNS Analytics：https://developers.cloudflare.com/dns/additional-options/analytics/
+- 1.1.1.1 Public Resolver：https://developers.cloudflare.com/1.1.1.1/
+- Terraform `cloudflare_dns_record` / `cloudflare_dnssec` / `cloudflare_dns_firewall`：https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs
+
+---
+参照日: 2026-05-04

--- a/src/content/knowledge/web-development/cloudflare-docs/64-email-routing.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/64-email-routing.mdx
@@ -1,0 +1,173 @@
+---
+title: "Cloudflare Email Routing"
+description: "独自ドメインに届くメールを任意のメールボックスへ転送する受信専用のメール基盤で、MXレコード自動設定・カスタムアドレス・キャッチオール・Email Workersによるコード処理までを無料で提供するCloudflareの軽量メールゲートウェイである。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 64
+---
+# Email Routing
+
+## 一行サマリ
+独自ドメインに届くメールを任意のメールボックスへ転送する受信専用のメール基盤で、MXレコード自動設定・カスタムアドレス・キャッチオール・Email Workersによるコード処理までを無料で提供するCloudflareの軽量メールゲートウェイである。
+
+## 解決する課題（Why）
+独自ドメインで `info@` や `support@` を「受けたいだけ」のとき、Google WorkspaceやMicrosoft 365を契約するのは過剰投資である。SES（受信）やPostfixの自前運用は学習コスト・保守負荷が重く、ImprovMXのようなフォワーディング専業SaaSは無料枠に通数制限が付く。Email Routingはこの「受信転送だけ欲しい」というニーズに対し、以下を解決する。
+
+- 独自ドメインの任意エイリアス（`hello@`, `noreply+xxx@` 等）を、既存のGmail / iCloud / Outlookアカウントへ無料で転送。
+- MX / SPF / TXTレコードのCloudflare DNS側自動セットアップで、設定ミス起因の不達を回避。
+- Catch-all（受信箱全部受け）で、サインアップごとに使い捨てエイリアスを発行する運用が可能。
+- Email Workersにより「受信メールをコードで処理して、別アドレスへ転送・拒否・Slack通知」までを単一のWorkerランタイムで完結。
+- 個人事業・スタートアップ初期の「メール用にWorkspaceを月額課金するほどではない」フェーズの定石。
+
+## 主要機能（What）
+
+### Address Routing（カスタムアドレス → 宛先アドレス）
+受信側の「Custom address」（例：`hello@example.com`）と、転送先の「Destination address」（例：`me@gmail.com`）を1:1または1:Nで紐付けるルールベースの転送機能である。Destination addressは事前にCloudflareから送られる確認メールでVerificationを通す必要があり、未認証の宛先には転送が走らない。
+
+- マッチャ：完全一致（literal）／ Catch-all。
+- アクション：転送（forward）／ Worker実行（worker）／ ドロップ（drop）。
+- ルール上限：200件、Destination address上限：200件。
+
+### Catch-all
+ドメイン全体で「明示ルールにマッチしなかった全アドレス」をまとめて1つの宛先に流す機能である。サービスごとに `service-name@example.com` を発行する使い捨てエイリアス運用に向く。OFFにすると未定義アドレス宛は拒否（bounce）される。
+
+### MX records 自動セットアップ
+Email Routingを有効化すると、対象ZoneのMX 3レコード（`route1/2/3.mx.cloudflare.net`）とSPF（`v=spf1 include:_spf.mx.cloudflare.net ~all`）がDNSへ自動投入される。CloudflareをAuthoritative DNSとして使っていることが前提条件。
+
+### Email Workers
+受信メールをWorkers Runtime上の `email()` ハンドラで処理する機能である。`message.forward()` / `message.setReject()` / `message.reply()`（Reply-from制約あり）が利用でき、許可リスト・SPAMフィルタ・Slack通知・条件分岐転送などをコードで書ける。
+
+### Verification / Analytics
+Destination addressは確認メールでVerifyしないと使えない。受信通数・処理結果（forward / drop / reject）はAnalyticsで可視化される。Cloudflareは転送経路上でメッセージを保存しない（プライバシーファースト設計）。
+
+## アーキテクト視点：いつ選ぶか
+
+### 受信転送のみで十分なシーン
+- 個人ドメイン・LP用ドメインで `contact@` `hello@` を受けて、運用者の個人Gmailに集約したいだけのケース。
+- Cloudflare DNSを既に使っている組織で、Workspace契約までは要らないサブドメイン用（`status.example.com` の通知メール受け等）。
+- サインアップごとに使い捨てエイリアスを発行したいプライバシー重視の個人運用（Catch-all + Workerフィルタ）。
+- Webhookライクに「メール受信をトリガーにWorkerを起動したい」サーバーレスメール処理。
+
+### 適していないシーン
+- **送信が必要な業務**：Email Routingは受信専用で、SMTP送信機能を一切持たない。送信はResend / SendGrid / Amazon SES / Mailgun 等を別途契約する必要がある。
+- **グループウェア要件**：カレンダー・共有ドライブ・会議室予約・複数ユーザーのメールボックス共有が要るならGoogle Workspace / Microsoft 365が正解。
+- **メーリングリスト・大量配信**：Email Routingは1通ずつの転送であり、リスト管理（購読・解除・配信状況）は守備範囲外。
+- **法的なメール保管要件**：Cloudflareはメッセージを保存しないため、e-discovery・監査要件があるならExchange Online / Google VaultやSESの受信ログ＋S3保管が必要。
+- **添付25MiB超を想定する業務**：上限超過は配送失敗となる。
+
+## 競合・代替
+
+| 観点 | Cloudflare Email Routing | ImprovMX | ForwardEmail.net | Google Workspace | Microsoft 365 | Amazon SES（受信） |
+|---|---|---|---|---|---|---|
+| 主用途 | 受信転送 + Workersコード処理 | 受信転送SaaS | 受信転送SaaS（OSS） | フルメール+SaaS | フルメール+SaaS | 受信SMTPエンドポイント |
+| 送信 | 不可 | 別途SMTP Relayあり（有料） | あり（API/SMTP） | あり | あり | あり（送信本職） |
+| Catch-all | 標準 | 有料 | 標準 | 可（エイリアス） | 可（エイリアス） | ルールで実装 |
+| カスタムロジック | Email Workers（JS/TS） | 限定的 | Webhook / Regex | Apps Script | Power Automate | Lambda |
+| メールボックス | なし（転送のみ） | なし | なし | あり | あり | なし（S3保管） |
+| 料金 | 無料 | $9〜/月（Premium） | 無料〜$3/月 | $7.20〜/月 | $7.20〜/月 | $0.10/1,000通 + S3 |
+| DNS連携 | 自動（Cloudflare DNS） | 手動 | 手動 | 手動（ガイド付き） | 手動（ガイド付き） | 手動 |
+| 強み | Workers連携・無料・DNS自動 | UIシンプル・老舗 | OSS・透明性 | グループウェア最強 | Office連携 | AWS統合・ログ保管 |
+| 弱み | 送信不可・保管なし | 無料枠が薄い | UI・サポートは弱め | 高コスト | 高コスト | 受信は脇役・要設計 |
+
+Email RoutingはWorkersランタイムとの結合で「受信メール → サーバーレス処理」が書ける点が他社にはない差別化要因である。逆に「送信もしたい」「メールボックスが要る」要件には全く応えないので、SES / Resend / Workspaceとの組み合わせが前提になる。
+
+## 料金
+- **無料**：ルール200件・Destination address 200件・Catch-all・MX自動設定・Analyticsまで全機能を無料で利用可能。トラフィック従量課金もなし。
+- **Email Workers**：Workers側の料金体系（Free 100k req/day / Standard $5〜）に従う。受信メール1通＝1リクエスト相当。CPU / メモリ上限超過（`EXCEEDED_CPU`）は有料プランへ移行で緩和。
+
+事実上「Cloudflare DNSを使っていれば追加料金なしで導入できる」という点が最大の優位である。
+
+## CLI / API 例
+
+### REST API（Routing Rule 作成）
+```bash
+# Custom address → Destination address 転送ルール
+curl -X POST "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/email/routing/rules" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -d '{
+    "name": "hello -> me@gmail.com",
+    "enabled": true,
+    "matchers": [
+      {"type": "literal", "field": "to", "value": "hello@example.com"}
+    ],
+    "actions": [
+      {"type": "forward", "value": ["me@gmail.com"]}
+    ]
+  }'
+```
+
+### REST API（Destination Address 追加 → Verification送信）
+```bash
+curl -X POST "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/email/routing/addresses" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -d '{"email": "me@gmail.com"}'
+# → Cloudflareから確認メールが届くので、リンクをクリックしてVerify
+```
+
+### Email Worker（許可リスト + 転送）
+```ts
+// wrangler.toml 側で:
+//   [[routes]]
+//   pattern = "example.com"
+//   custom_domain = true
+//   ※ Email Routing側で「Email Worker action」として該当Workerをバインド
+
+export default {
+  async email(message: ForwardableEmailMessage, env: Env, ctx: ExecutionContext) {
+    const allowList = ["partner@trusted.example", "ops@trusted.example"];
+
+    if (!allowList.includes(message.from)) {
+      message.setReject("Address not allowed");
+      return;
+    }
+
+    // 通常転送
+    await message.forward("inbox@corp.example");
+
+    // 件名にタグがあればSlackへも通知
+    const subject = message.headers.get("subject") ?? "";
+    if (subject.includes("[ALERT]")) {
+      await fetch(env.SLACK_WEBHOOK, {
+        method: "POST",
+        body: JSON.stringify({ text: `Mail alert from ${message.from}: ${subject}` }),
+      });
+    }
+  },
+};
+```
+
+### Wrangler（Email Worker のデプロイ）
+```bash
+wrangler deploy
+# デプロイ後、ダッシュボードの Email → Routing rules で
+# Custom address のアクションを「Send to a Worker」にして当該Workerを選択
+```
+
+## 制限・注意点
+- **送信不可**：Email RoutingはMTA outboundを持たない。Worker内の `message.reply()` は受信メッセージへの応答に限定され、新規メールの起票はできない。任意宛先への送信はResend / SendGrid / Amazon SES / Mailgun を別途構成する。
+- **Reply-from制約**：`message.reply()` の `from` はEmail Routingで管理しているCustom addressに限られる。任意のFromで送ることはできない。
+- **MailChannels連携の終了**：旧来WorkersからMailChannels無料中継で送信するパターンは2024年に終了済みで、現在の標準解はResendまたはSESである。Email Routingの送信不可点はこの背景もある。
+- **メッセージサイズ上限25MiB**：超過分は受信側で配送失敗となる。大容量添付前提のワークフローは別経路を用意する。
+- **メッセージは保存しない**：転送経路上の保管は行わない設計のため、配送失敗したメールの再送・サルベージはできない。監査要件があるならWorker内でR2 / S3に明示的に書き出す実装が必要。
+- **Drop / Reject時のbounce**：明示ルール非マッチかつCatch-all OFFの場合は送信側にbounce。Workerで `setReject()` を返すと宛先不明として返送される。
+- **SPAM・添付**：Cloudflare側で基本的なSPAM判定はあるが、ユーザー側ではSPAMしきい値の調整UIが薄い。重要メールの誤判定対策として、転送先（Gmail等）側のフィルタとの二段構えが現実的。
+- **SPF / DKIM / DMARC**：MX切替時にCloudflareがSPFを `include:_spf.mx.cloudflare.net` で自動上書きする。送信用SaaS（SES等）併用時はSPFのincludeを手動で追記しないと送信側DMARCが落ちる。DKIMは送信側SaaSで設定、DMARCポリシーは `p=quarantine` 以上を別途宣言する運用が前提。
+- **上限**：ルール200件 / Destination address 200件。大規模なエイリアス運用はCatch-all + Worker側の動的判定で吸収する。
+- **Cloudflare DNSが前提**：他社DNSをAuthoritativeにしている場合は利用不可。MX自動設定の対象もCloudflare DNS Zoneに限られる。
+- **Email Workersのリソース**：無料プランではCPU / メモリ制限により大きなメールや重い処理で失敗しうる。`EXCEEDED_CPU` が出る場合はWorkers Paidへ。
+
+## 参考リンク
+- Email Routing 概要：https://developers.cloudflare.com/email-routing/
+- Limits：https://developers.cloudflare.com/email-routing/limits/
+- Email Workers：https://developers.cloudflare.com/email-routing/email-workers/
+- Email Workers Runtime API：https://developers.cloudflare.com/email-routing/email-workers/runtime-api/
+- Routing Rules API：https://developers.cloudflare.com/api/operations/email-routing-routing-rules-list-routing-rules
+- Setup（MX / SPF）：https://developers.cloudflare.com/email-routing/setup/email-routing-addresses/
+- Cloudflare Email Service（後継ブランド）：https://developers.cloudflare.com/email-service/
+- llms.txt：https://developers.cloudflare.com/email-routing/llms.txt
+
+---
+参照日: 2026-05-04

--- a/src/content/knowledge/web-development/cloudflare-docs/65-pipelines.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/65-pipelines.mdx
@@ -1,0 +1,198 @@
+---
+title: "Cloudflare Pipelines"
+description: "HTTPまたはWorkers binding経由で受け取ったイベントストリームを、SQLで検証・変換・整形し、Apache Iceberg / Parquet / JSON としてR2に書き出すCloudflare内で完結する Streaming ETL である。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 65
+---
+# Pipelines
+
+## 一行サマリ
+HTTPまたはWorkers binding経由で受け取ったイベントストリームを、SQLで検証・変換・整形し、Apache Iceberg / Parquet / JSON としてR2に書き出すCloudflare内で完結する Streaming ETL である。
+
+## 解決する課題（Why）
+Webアプリのクリックストリーム、Workers内で発生するカスタムイベント、IoTテレメトリ、モバイルSDKのイベントログを「とりあえず溜めて、あとで分析する」要件は、これまで Kafka + Kafka Connect + Spark Structured Streaming + AWS Glue + S3 + Athena といった多段スタックで実現されてきた。これは小さなチームには明らかに過剰投資であり、運用の足を引っ張る。Cloudflare Pipelines はこれを以下の点で解消する。
+
+- Workers / Pages / R2 と同じCloudflareアカウント内でストリーミングETLが完結し、外部のメッセージブローカー・実行基盤・スキーマレジストリを持ち込まなくてよい。
+- HTTPエンドポイントとWorkers bindingの両方で取り込みが可能で、エッジで生成したイベントをそのまま受け流せる（egressコストなし）。
+- 出力をR2上のApache Icebergテーブルにできるため、R2 Data Catalog経由でDuckDB / Spark / Trino / Snowflake から直接クエリでき、別途データウェアハウスへのコピーが不要になる。
+- Logpushが「Cloudflare自身が生成する既知のログ（HTTP / WAF / Gateway 等）を宛先に流す」だけなのに対し、Pipelines は「アプリ側で定義したカスタムイベントをスキーマ付きでETLする」用途に応える。両者は補完関係にある。
+
+## 主要機能（What）
+
+### Sources（取り込み）
+イベントを受け付ける入口層は2系統である。
+
+- **HTTP Ingest**：`https://{stream-id}.ingest.cloudflare.com` に JSON 配列をPOSTする。モバイルアプリ・SaaSのWebhook・ブラウザ計測タグなど、Cloudflare外部のクライアントから直接送信できる。認証トークン付きで保護する。
+- **Workers Binding**：`wrangler.toml` に pipeline binding を設定し、Worker から `env.MY_PIPELINE.send([...])` の形でイベントを投げる。エッジで動く Worker と同一データセンター内でingestされるため、レイテンシ・コストともに最小になる。
+
+両方とも内部的には Stream（耐障害バッファ付きキュー）に書き込まれ、Pipelinesがそこからpullする。
+
+### Transforms（SQL変換）
+Streams と Sinks の間に SQL ベースの変換ステージが入る。Pipelines は ingest 時点で以下を担う。
+
+- **Validation**：スキーマに合わない・必須フィールド欠損のレコードを弾く。
+- **Filter**：`WHERE event_type IN ('purchase', 'signup')` のような絞り込み。
+- **Transform / Enrich**：型変換、文字列加工、`headers` から国コードを抽出、UTC変換など。
+- **Projection**：出力先テーブルに必要なカラムだけ残す。
+
+「ingest時に一度SQLを通して整える」設計のため、後段のクエリ側で重い ETL を組まなくて済む。
+
+### Sinks（書き出し先）
+出力先は R2 の3形態が選べる。
+
+- **Apache Iceberg（R2 Data Catalog）**：R2 Data Catalog にIcebergテーブルとして登録される。スキーマ進化・タイムトラベル・partition pruning が効き、Spark / Trino / DuckDB / Snowflake からそのまま参照可能。
+- **Parquet on R2**：列指向圧縮ファイルとして書き出す。R2上を直接 DuckDB やAthena互換ツールでクエリする運用に向く。
+- **JSON on R2**：人間が読める形式で残したいログ・デバッグ用途、後段でJSON Linesをそのまま処理したいケース向け。
+
+### Schema
+`schema.json` でフィールド定義を持つ。型は `string` / `int64` / `float64` / `bool` / `timestamp` 等。`required: true` のフィールドが欠けたレコードは取り込み時に弾かれる。スキーマを与えることで Parquet / Iceberg 出力の列型が確定し、後段クエリの安定性が確保される。
+
+```json
+{
+  "fields": [
+    {"name": "user_id",    "type": "string",    "required": true},
+    {"name": "event_type", "type": "string",    "required": true},
+    {"name": "ts",         "type": "timestamp", "required": true},
+    {"name": "amount",     "type": "float64",   "required": false}
+  ]
+}
+```
+
+### Batching
+Pipelinesはイベントを単発で書き出さず、時間窓またはサイズ窓でバッチを束ねてから R2 オブジェクトとして書き出す。これにより R2 のClass A操作回数を抑え、Parquetの圧縮効率を高めている。バッチ間隔・最大サイズはsink設定で調整する。
+
+### Partitioning
+Iceberg / Parquet 出力には partition キー（`event_date` / `region` / `event_type` など）を指定でき、後段のクエリで partition pruning が効くようになる。時間ベース（hourly / daily）と任意カラムの両方が選べる。カラム値のカーディナリティが高すぎると小ファイルが乱立するため設計時に注意する。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- Workers / Pages 中心のアプリで、ユーザーアクション・APIリクエスト・ビジネスイベントを構造化ログとして蓄積したい場合。
+- モバイルアプリ・ブラウザSDKからのクリックストリームを安価に R2 / Iceberg に流し込み、DuckDB や Snowflake で後追い分析したい場合。
+- 既存の Kafka + Spark + Glue 構成が「小さなSaaSにはオーバースペック」になっており、Cloudflare 1社で完結する代替を探している場合。
+- Logpush では取れない「アプリ側のドメインイベント（注文確定 / 解約 / 支払い失敗 等）」をスキーマ付きで残したい場合。
+- R2 Data Catalog のIcebergテーブルを Snowflake / Trino から外部テーブルとして参照する Lakehouse 構成を組みたい場合。
+
+### 適していないシーン
+- Kafka topic に既存システム群が密結合しており、Cloudflareアカウント外のproducer / consumer が大量にいるケース。Pipelinesは単独のメッセージブローカーとしての互換性を提供しない。
+- 複数の異種ソース（オンプレDB CDC、SaaS API、IoT MQTT 等）を取り込んで複雑な join / window集計を行うフルスペックの Streaming ETL。Flink / Dataflow / Materialize の領域である。
+- 5MB/s（ストリーム単位）を恒常的に超える高スループットなテレメトリ。現在のbeta制限を超えるためEnterprise相談が必要。
+- 厳密な exactly-once セマンティクスや低レイテンシ（秒未満）の集計が業務要件に含まれるケース。Pipelinesはバッチ書き出し前提でデザインされている。
+- Cloudflareエッジを使っていない既存スタック（AWS / GCP内で完結）にわざわざ持ち込むケース。egress導線が増えるだけで利点が薄い。
+
+## 競合・代替
+
+| 観点 | Cloudflare Pipelines | AWS Kinesis Firehose | GCP Dataflow | Confluent Kafka | Estuary Flow | Materialize | Tinybird |
+|---|---|---|---|---|---|---|---|
+| 出自 | Cloudflare R2 / Workers連携 | AWS純正サーバーレスdelivery | GCP純正Apache Beamマネージド | Kafka商用ディストリビューション | Streaming ETL SaaS（Gazette由来） | Streaming SQL DB（Materialize Inc） | リアルタイム分析API（Tinybird） |
+| Sources | HTTP / Workers binding | Kinesis Streams / DirectPut / MSK | Pub/Sub / Kafka / Files / etc. | producer SDK 多数 | DB CDC / SaaS / Kafka | Kafka / Postgres / Webhook | Kafka / HTTP / S3 |
+| Sinks | R2（Iceberg / Parquet / JSON） | S3 / Redshift / OpenSearch / Splunk | BigQuery / GCS / Pub/Sub | Sink Connector多数 | Snowflake / BigQuery / S3 / Iceberg | Materialized View（自身がDB） | API endpoint（HTTP） |
+| 変換 | SQL（ingest時） | Lambda / 動的partition | Apache Beam（Java/Python） | ksqlDB / Kafka Streams | TypeScript / SQL | SQL（incremental view maintenance） | SQL（pipe） |
+| Iceberg | ネイティブ（R2 Data Catalog） | S3 Tables 経由で対応 | BigQuery Iceberg連携 | Tableflow（Iceberg化） | ネイティブ | 直接出力なし | 直接出力なし |
+| 料金モデル | beta無料 + R2課金 | データ量課金 + 変換課金 | vCPU時間 + データ | クラスタ + Cloud契約 | 接続数 + データ量 | レプリカ時間課金 | データ量 + APIリクエスト |
+| 得意領域 | Cloudflare内エッジイベント収集 | AWS内ログdelivery | 重ETL / 機械学習前処理 | エンタープライズ汎用ストリーミング | DB CDC中心のELT | リアルタイム集計クエリ | リアルタイムAPI公開 |
+| 弱み | beta / 高スループット未対応 / 多種ソース弱い | 変換は Lambda 必須 | 学習コストと運用が重い | 自前運用負荷・コスト | Cloudflareエッジとは独立 | データ取り込みは別途必要 | ストレージは内部固定 |
+
+Cloudflare Pipelines のポジションは「Cloudflareエッジで生成・受信したイベントを、最短経路でR2 Iceberg化する」一点に特化している。AWS / GCP内で完結するワークロードには Firehose / Dataflow が、汎用ストリーミングインフラには Kafka / Confluent が、リアルタイム集計には Materialize / Tinybird がそれぞれ妥当である。
+
+## 料金
+- **オープンベータ中**：Pipelines 自体の処理は無料。Workers Paid プラン（$5/月〜）への加入が前提。
+- **R2課金**：書き出し先としてのR2のストレージ容量・Class A操作（PUT等）は通常通り課金される。バッチサイズが小さすぎるとClass A操作が増えるため、partitionとbatch間隔の設計でコストを抑える。
+- **GA後（予定）**：「ingestされたデータ量・transform処理量・sinkへのdelivery量」に基づく従量課金が予告されている。料金体系変更前に30日以上の事前通知が約束されている。
+- **egressなし**：R2のegress無料はそのまま効くため、Snowflake / 外部DuckDBから読み出してもegress課金は発生しない。これがS3 Tablesに対する明確な経済的優位点である。
+
+## CLI / API 例
+
+### Pipeline をセットアップ
+```bash
+# 対話モードでstream / pipeline / sink を一括作成
+npx wrangler pipelines setup --name ecommerce-events
+
+# スキーマファイルを与えて作成
+npx wrangler pipelines setup --name ecommerce-events --schema ./schema.json
+```
+
+### HTTP Ingest（外部クライアントから）
+```bash
+curl -X POST https://{stream-id}.ingest.cloudflare.com \
+  -H "Authorization: Bearer ${PIPELINE_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '[
+    {"user_id":"u_001","event_type":"purchase","ts":"2026-05-04T10:00:00Z","amount":29.9},
+    {"user_id":"u_002","event_type":"signup",  "ts":"2026-05-04T10:00:01Z"}
+  ]'
+```
+
+### Workers Binding 経由
+```toml
+# wrangler.toml
+[[pipelines]]
+binding  = "EVENTS"
+pipeline = "ecommerce-events"
+```
+
+```typescript
+// src/index.ts
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const body = await req.json<{ user_id: string; event_type: string }>();
+    await env.EVENTS.send([
+      {
+        user_id:    body.user_id,
+        event_type: body.event_type,
+        ts:         new Date().toISOString(),
+      },
+    ]);
+    return new Response("ok");
+  },
+} satisfies ExportedHandler<Env>;
+```
+
+### スキーマ定義
+```json
+{
+  "fields": [
+    {"name": "user_id",    "type": "string",    "required": true},
+    {"name": "event_type", "type": "string",    "required": true},
+    {"name": "ts",         "type": "timestamp", "required": true},
+    {"name": "amount",     "type": "float64",   "required": false}
+  ]
+}
+```
+
+### Iceberg テーブルをDuckDBで読む
+```sql
+-- R2 Data Catalog の Iceberg REST 経由
+INSTALL iceberg;
+LOAD iceberg;
+ATTACH 'r2-catalog' AS catalog (TYPE ICEBERG, ENDPOINT '...');
+SELECT event_type, COUNT(*)
+FROM catalog.events.ecommerce
+WHERE event_date = DATE '2026-05-04'
+GROUP BY 1;
+```
+
+## 制限・注意点
+- **オープンベータ**である。SLAは未保証で、本番のミッションクリティカル用途は GA を待つ判断が無難。
+- ベータ時点の制限：1アカウントあたり stream / pipeline / sink 各 **20個**、ingestリクエストの最大ペイロード **5MB**、stream あたり最大ingestレート **5MB/s**。これを超えるユースケースは制限緩和申請が必要。
+- **Workers Paid プラン必須**：Free planではPipelinesを利用できない。
+- **リージョン**：Cloudflareのグローバルネットワーク上で動作するため明示的なリージョン指定はないが、R2バケットのlocation hint（WNAM / EEUR / APAC等）に依存する点に注意。データレジデンシー要件があるなら R2 Jurisdictional buckets と組合せる。
+- **batch / partition 設計**：partitionキーのカーディナリティが高すぎると小ファイルが乱立し、R2のClass A操作課金とクエリ性能の両方を悪化させる。日次partition + 必要に応じて事業ドメインで分ける程度に留めるのが定石。
+- **Logpushとの役割分担**：Cloudflare自身が出すHTTP / WAF / Gateway / Workers Trace等の既知ログは Logpush で R2 / S3 / Splunk に流す。Pipelines は「アプリ側で定義したカスタムイベント」専用と切り分けると運用が破綻しない。両者を一元化したい場合は Logpush先をR2にしてIceberg化する／Pipelinesに集約する／の二択になるが、現状は素直に併用するのが扱いやすい。
+- **exactly-once は保証されない**：at-least-once 前提で、後段クエリ側で `(user_id, event_id)` 等の自然キーでdedupする設計を入れておく。
+- **Schema変更**：フィールド追加は前方互換だが、型変更・必須化はIcebergテーブルのスキーマ進化ルールに従う。リリース前に検証必須。
+
+## 参考リンク
+- Cloudflare Pipelines トップ：https://developers.cloudflare.com/pipelines/
+- Getting started：https://developers.cloudflare.com/pipelines/getting-started/
+- 仕組み（How Pipelines work）：https://developers.cloudflare.com/pipelines/concepts/how-pipelines-work/
+- Limits：https://developers.cloudflare.com/pipelines/platform/limits/
+- Pricing：https://developers.cloudflare.com/pipelines/platform/pricing/
+- R2 Data Catalog：https://developers.cloudflare.com/r2/data-catalog/
+- Logpush（比較対象）：https://developers.cloudflare.com/logs/logpush/
+- Workers Pipelines binding：https://developers.cloudflare.com/workers/runtime-apis/bindings/
+
+---
+参照日: 2026-05-04

--- a/src/content/knowledge/web-development/cloudflare-docs/66-r2-data-catalog.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/66-r2-data-catalog.mdx
@@ -1,0 +1,202 @@
+---
+title: "Cloudflare R2 Data Catalog & R2 SQL"
+description: "R2バケット内のParquetをApache Icebergテーブルとして管理する「Iceberg REST Catalog」と、その上で動くサーバレスSQLエンジン「R2 SQL」をCloudflareがマネージドで提供する。エグレス無料のオブジェクトストレージをそのままレイクハウスの一次層に変える組合せである。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 66
+---
+# R2 Data Catalog & R2 SQL
+
+## 一行サマリ
+R2バケット内のParquetをApache Icebergテーブルとして管理する「Iceberg REST Catalog」と、その上で動くサーバレスSQLエンジン「R2 SQL」をCloudflareがマネージドで提供する。エグレス無料のオブジェクトストレージをそのままレイクハウスの一次層に変える組合せである。
+
+## 解決する課題（Why）
+データレイクをS3に置くと「ストレージは安いがクエリのたびにエグレスとリクエスト課金が積み上がる」「Glue Catalog / Athena / EMR / Snowflakeなど複数サービスを束ねないと分析できない」という構造問題から逃れにくい。Iceberg自体は仕様に過ぎず、カタログサーバ・テーブルメンテナンス（コンパクション、スナップショット失効）・クエリエンジンを別々に運用する必要があり、PoC段階の小規模チームには重い。Cloudflare R2 Data Catalog + R2 SQLは以下を解決する。
+
+- R2のゼロエグレスを活かして、外部クラウド・他リージョンからも追加課金なしで分析できるレイクハウス基盤を作る。
+- Iceberg REST Catalogをマネージドで提供し、自前でNessie / Polaris / Glueを立てる手間を省く。
+- 同じテーブルをSpark / Trino / DuckDB / PyIceberg / Snowflakeから並行アクセスでき、エンジン選択の自由度を確保する。
+- Cloudflare PipelinesでWorkers / Queuesからのストリームを直接Icebergテーブルに書き込み、ETLパイプラインを最小化する。
+- R2 SQLでBIユースケースの軽量クエリは追加サービス不要で完結させる。
+
+## 主要機能（What）
+
+### Iceberg REST Catalog
+R2バケット単位でカタログを有効化すると、Apache Iceberg REST Catalog仕様に準拠したエンドポイントが払い出される。Cloudflareが裏側でメタデータJSON・マニフェスト・スナップショットを管理し、クライアントは標準Icebergクライアント（pyiceberg、iceberg-spark-runtime、Trino iceberg connector等）から接続できる。
+
+- カタログ単位：R2バケットごとに1カタログ。Namespace（DB相当）とTable（テーブル）の2階層。
+- 認証：Cloudflare APIトークンをBearerとして渡す。Iceberg REST仕様の`/v1/config`、`/v1/namespaces`、`/v1/namespaces/{ns}/tables`等がそのまま使える。
+- ストレージ：Parquetファイル本体はR2バケット内にIceberg標準レイアウトで配置される。S3互換APIとIceberg APIの両方からアクセス可能。
+- スキーマ進化・タイムトラベル・パーティション進化などIceberg v2仕様の機能が利用できる。
+
+### Table maintenance
+Icebergで実運用すると不可避の「小ファイル問題」「孤児ファイル蓄積」「スナップショット肥大」をCloudflare側でバックグラウンド実行する。利用者は明示的にcompactionジョブを書く必要がない（ただしベータ段階では自動化範囲は段階的に拡大中）。
+
+### R2 SQL
+R2 Data Catalog上のIcebergテーブルをSQLで直接クエリするサーバレス分散エンジンである。Wrangler CLIまたはAPI経由で投げる。ファイルプルーニング・分散コンピュートを自動適用し、クエリごとにスキャン量に応じた課金（オープンベータ中は無料）。
+
+- インターフェース：`wrangler r2 sql query <warehouse> "<SQL>"` の単発クエリ実行が中心。BIツール向けJDBC/ODBCは現時点では未提供。
+- ユースケース：軽量な集計・直近データの確認・Workers Analytics連携。重い長時間ジョブはSpark / Trinoに振る使い分けが想定される。
+
+### コネクタ（Spark / DuckDB / Trino / PyIceberg / Snowflake）
+Iceberg REST Catalog標準準拠のため、各エンジンの公式コネクタがそのまま使える。
+
+- **PyIceberg**：`pyiceberg.catalog.load_catalog`に`type=rest`、`uri`、`token`を渡すだけで接続。ノートブック検証の最短経路。
+- **DuckDB**：`iceberg`拡張＋`ATTACH 'r2_catalog' AS catalog (TYPE iceberg, ENDPOINT '...')`でローカルから直接クエリ。
+- **Spark / Trino**：`iceberg-rest`カタログ設定でwarehouse URIとR2のS3互換アクセスキーを渡す。EMR / Databricks / 自前k8s Sparkどれからでも接続可能。
+- **Snowflake**：External Volume（S3互換としてR2を指定）＋ Iceberg Catalog Integration（REST）で外部Icebergテーブルを参照。
+
+### Cloudflare Pipelines連携
+Cloudflare Pipelines（Workers / Queues / HTTPからのストリームをバッチ化してR2に書き出すサービス）が、出力先としてR2 Data Catalogを直接サポートする。Workersのイベント → Pipelines → Icebergテーブル化、までをCloudflare内で完結できる。これによりKafka + Flink + Iceberg Sinkに相当する構成を、Cloudflareスタック単独で組める。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- 既にR2をオブジェクトストレージとして使っており、ログ・イベント・clickstreamを分析したいケース。エグレス無料で他クラウドのSparkクラスタからも引ける。
+- マルチクラウドでデータを共有したいが、AWS S3に置くとGCP / Azure側からの転送費用が重いケース。
+- Workers / Queues / Pipelinesでイベントパイプラインを組んでいる組織。Sink先としてIcebergテーブルが直結する。
+- BIではなく「Notebookでアドホックに探索」「DuckDB / PyIcebergで小回りに分析」が中心の小〜中規模チーム。
+- スタートアップ・PoC段階で、Snowflake / Databricksの最低契約額を払う前にレイクハウスを立てたいケース。
+
+### 適していないシーン
+- Snowflake / Databricks / BigQueryで既にエンタープライズ契約があり、UC（Unity Catalog）/ Polaris / BigLake metastoreによるガバナンスが要件化している組織。
+- 細かい行レベルセキュリティ・列マスキング・データリネージなどガバナンス機能が必須のケース。Cloudflareは現時点でテーブル単位のIcebergアクセスに留まる。
+- ストリーミング更新の遅延要件が秒オーダーのケース。Pipelinesはバッチ前提で、Iceberg側のコミット粒度も分単位が現実的。
+- ペタバイト級でクエリレイテンシSLAが厳しいワークロード。R2 SQLはまだベータで、本格BIにはSpark / Trino併用が前提。
+
+## 競合・代替
+
+| 観点 | R2 Data Catalog + R2 SQL | AWS S3 Tables | Snowflake Iceberg | Databricks UC | Tabular（買収済） | GCP BigLake | MotherDuck |
+|---|---|---|---|---|---|---|---|
+| 出自 | R2 + Workers Pipelines統合 | S3 + Athena統合 | DWH純血 | Spark / Lakehouse純血 | Iceberg設立メンバー製カタログ | BigQuery + GCS統合 | DuckDBクラウド |
+| カタログ | Iceberg REST（マネージド） | S3 Tables（独自＋REST互換） | Snowflake Catalog / Polaris OSS | Unity Catalog | Iceberg REST | BigLake metastore | DuckDB Catalog |
+| クエリエンジン | R2 SQL（ベータ）+ 外部Spark/Trino/DuckDB | Athena / EMR / Redshift | Snowflake | Photon / Spark SQL | エンジンは別 | BigQuery | DuckDB |
+| エグレス | ゼロ（最大の差別化） | リージョン外で課金 | コンピュート課金に内包 | 同左 | ストレージ依存 | 同左 | DuckDB側 |
+| ストリーミング書込 | Pipelines統合 | Firehose → S3 Tables | Snowpipe Streaming | DLT / Auto Loader | 別途Flink等 | Pub/Sub → BQ | 別途 |
+| ガバナンス | 弱（テーブル単位） | IAM + Lake Formation | 強 | 強（業界トップ級） | 中 | 中〜強 | 弱 |
+| 価格モデル | R2ストレージ + クエリ従量 | S3 + 各エンジン | Credit | DBU | エンジン依存 | スロット + ストレージ | 月額+クエリ |
+| 強み | エグレス無料・Workersスタック統合 | AWSネイティブ統合 | 成熟したDWH機能 | Lakehouse運用ノウハウ | OSS純度 | BQの分析力 | DuckDBの軽量さ |
+| 弱み | ベータ・ガバナンス追従途上 | AWSロックイン | 高コスト・クローズド | 高コスト | エンジンは別途必要 | GCPロックイン | スケール上限 |
+
+CloudflareのポジションはS3 Tables（AWS）に最も近いが、「エグレス無料 × Workers / Pipelinesからの直結」という2点で差別化される。Snowflake / Databricks水準のガバナンス・ML統合が要件の中核なら現時点では併用または代替が妥当である。
+
+## 料金
+
+- **R2ストレージ**：標準R2の単価（$0.015/GB/月）＋Class A/B操作。エグレスは引き続き無料。
+- **R2 Data Catalog**：パブリックベータ中は追加課金なし。GA時にCatalog API call課金（メタデータ操作単位）が導入される予定。
+- **R2 SQL**：オープンベータ中は無料（R2のストレージ・操作費のみ）。GA前に最低30日の予告期間を経て、スキャン量ベースの従量課金に移行予定。
+- **Pipelines連携**：Pipelines自体の料金（取込量／処理時間）に従う。Iceberg書き出し自体に追加料金はかからない。
+
+「ベータ中はR2の標準コストだけで回る」のが現状最大のメリットであり、本番採用前にGA価格表の確認とクエリ量見積もりが必須である。
+
+## CLI / API 例
+
+### Catalog作成（Wrangler）
+```bash
+# R2バケットにData Catalogを有効化
+wrangler r2 bucket catalog enable my-lakehouse
+
+# Catalog情報の確認（warehouse URI、エンドポイント、トークン作成手順を表示）
+wrangler r2 bucket catalog get my-lakehouse
+
+# Iceberg REST用のAPIトークンを発行（Dashboard or API）
+# token は Bearer として各エンジンに渡す
+```
+
+### PyIcebergから接続
+```python
+from pyiceberg.catalog import load_catalog
+
+catalog = load_catalog(
+    "r2_catalog",
+    **{
+        "type": "rest",
+        "uri": "https://catalog.cloudflarestorage.com/<account_id>/my-lakehouse",
+        "warehouse": "my-lakehouse",
+        "token": "<CF_API_TOKEN>",
+    },
+)
+
+catalog.create_namespace("analytics")
+table = catalog.load_table("analytics.events")
+df = table.scan(row_filter="event_date = '2026-05-01'").to_pandas()
+```
+
+### DuckDBから接続
+```sql
+INSTALL iceberg;
+LOAD iceberg;
+
+ATTACH 'my-lakehouse' AS r2lake (
+    TYPE iceberg,
+    ENDPOINT 'https://catalog.cloudflarestorage.com/<account_id>/my-lakehouse',
+    TOKEN '<CF_API_TOKEN>'
+);
+
+SELECT event_type, COUNT(*) AS n
+FROM r2lake.analytics.events
+WHERE event_date >= DATE '2026-05-01'
+GROUP BY event_type
+ORDER BY n DESC;
+```
+
+### Sparkカタログ設定
+```bash
+spark-sql \
+  --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.5.0 \
+  --conf spark.sql.catalog.r2lake=org.apache.iceberg.spark.SparkCatalog \
+  --conf spark.sql.catalog.r2lake.type=rest \
+  --conf spark.sql.catalog.r2lake.uri=https://catalog.cloudflarestorage.com/<account_id>/my-lakehouse \
+  --conf spark.sql.catalog.r2lake.warehouse=my-lakehouse \
+  --conf spark.sql.catalog.r2lake.token=<CF_API_TOKEN> \
+  --conf spark.sql.catalog.r2lake.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
+  --conf spark.sql.catalog.r2lake.s3.endpoint=https://<account_id>.r2.cloudflarestorage.com \
+  --conf spark.sql.catalog.r2lake.s3.access-key-id=<R2_ACCESS_KEY> \
+  --conf spark.sql.catalog.r2lake.s3.secret-access-key=<R2_SECRET_KEY>
+```
+
+### R2 SQLクエリ
+```bash
+# Wrangler経由で単発クエリ
+wrangler r2 sql query my-lakehouse \
+  "SELECT event_type, COUNT(*) AS n
+     FROM analytics.events
+    WHERE event_date >= DATE '2026-05-01'
+    GROUP BY event_type
+    ORDER BY n DESC
+    LIMIT 100"
+```
+
+### Pipelines → Iceberg Sink（概念）
+```bash
+# Pipelineを作成してR2 Data Catalogのテーブルへ書き出す
+wrangler pipelines create events-pipeline \
+  --sink-type r2-iceberg \
+  --catalog my-lakehouse \
+  --namespace analytics \
+  --table events \
+  --partition-by event_date
+```
+
+## 制限・注意点
+- 2026年5月時点、R2 Data CatalogもR2 SQLもパブリック／オープンベータ。プロダクション本格採用はGAアナウンスとSLA明記を待つのが安全。
+- Icebergは現時点でv2仕様準拠。ブランチ／タグなどv3相当機能の実装範囲は今後拡張予定。
+- Table maintenance（compaction、スナップショット失効、孤児ファイル削除）の自動化範囲はベータ段階で段階的に拡大中。長期運用では自前監視と必要に応じたSpark `RewriteDataFiles`手動実行が現実解。
+- R2 SQLはJDBC/ODBC・BI直結に未対応。Tableau / LookerからはSpark / Trino / DuckDB経由でカタログにつなぐ構成になる。
+- 認可粒度はカタログ単位のAPIトークンが基本で、行レベル・列レベルセキュリティはエンジン側（Trino / Sparkのポリシー、Snowflakeのマスキング）で担保する必要がある。
+- R2のリージョン特性（Cloudflareのloc-hint指定）はストレージ局所性に効くが、カタログAPI自体はグローバルエンドポイント前提。レイテンシ要件があるなら同居エンジンの配置を検討。
+- 同一テーブルをR2 SQLと外部Sparkで並行書込する場合は、Icebergの楽観ロックとリトライ前提で設計する。書込窓口を1本化したほうが運用は楽。
+
+## 参考リンク
+- R2 Data Catalog 概要：https://developers.cloudflare.com/r2/data-catalog/
+- R2 SQL 概要：https://developers.cloudflare.com/r2-sql/
+- R2 ドキュメント：https://developers.cloudflare.com/r2/
+- Cloudflare Pipelines：https://developers.cloudflare.com/pipelines/
+- Apache Iceberg REST Catalog Spec：https://iceberg.apache.org/spec/
+- PyIceberg：https://py.iceberg.apache.org/
+- DuckDB Iceberg拡張：https://duckdb.org/docs/extensions/iceberg
+- Iceberg Spark Quickstart：https://iceberg.apache.org/docs/latest/spark-getting-started/
+
+---
+参照日: 2026-05-04

--- a/src/content/knowledge/web-development/cloudflare-docs/67-radar.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/67-radar.mdx
@@ -1,0 +1,200 @@
+---
+title: "Cloudflare Radar"
+description: "Cloudflareのグローバルネットワーク（Anycast 300+ PoP）と1.1.1.1パブリックDNSリゾルバから観測したトラフィック・攻撃・ルーティング・DNS・メールの集計データを、ダッシュボードとAPIで公開する\"インターネットの天気予報\"である。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 67
+---
+# Radar
+
+## 一行サマリ
+Cloudflareのグローバルネットワーク（Anycast 300+ PoP）と1.1.1.1パブリックDNSリゾルバから観測したトラフィック・攻撃・ルーティング・DNS・メールの集計データを、ダッシュボードとAPIで公開する"インターネットの天気予報"である。
+
+## 解決する課題（Why）
+インターネットは単一の事業者が管理する閉じたシステムではなく、AS（自律システム）・IXP・ISP・CDN・パブリッククラウドが緩く連携した分散ネットワークである。「いまブラジルで通信障害が起きているのか」「特定ASからのトラフィックが急減した原因は何か」「IPv6普及率は本当に上がっているのか」「自社サービスのレイテンシ悪化は世界全体の傾向なのか」といった問いに答える一次データは、各事業者の観測スコープに閉じていることが多い。Cloudflare Radarはこれを以下の用途で公開データセットとして利用可能にする。
+
+- グローバルなネットワーク事象（障害・攻撃・ルーティング異常）の早期検知。
+- 国・AS・業界別のトラフィック傾向把握による市場分析・競合調査。
+- 脅威インテリジェンス（DDoS規模・標的国・攻撃ベクトル分布）の参照。
+- IPv6 / HTTP/3 / TLS 1.3 / Post-Quantum暗号などプロトコル普及率の継続観測。
+- 学術研究・報道・SLA調査における引用可能な一次ソース。
+
+## 主要機能（What）
+
+### Traffic Trends
+HTTPリクエスト・NetFlows（L3/L4トラフィック）を国・AS・デバイス種別・IPバージョン・Botクラス別に時系列で可視化する層である。ベースラインからの逸脱を自動検出し、急増・急減を「Internet weather report」としてダッシュボード上部に表示する。
+
+- 切り口：Country / AS / Device type（Desktop / Mobile / Other）/ IP version / Bot class（Likely Human / Likely Automated / Verified Bot）/ HTTP version。
+- 時間粒度：直近1時間〜2年。直近24h・7d・28dが既定の比較窓。
+- 用途：特定国でのサービス障害判定、モバイル比率の地域差分析、Bot比率の時間帯変動把握。
+
+### Quality（Internet Quality）
+スピードテストツール（speed.cloudflare.com）由来のデータを集計し、回線品質を国・AS別に可視化する層である。Median / p25 / p75のbandwidth・latency・jitter・loaded latency（Bufferbloat指標）を提供する。
+
+- 用途：ISPの品質ランキング、地域別ブロードバンド普及度比較、Bufferbloatの実測分布。
+
+### Security & Attacks
+Cloudflareが緩和したL3/L4 DDoSとL7（HTTPアプリケーション層）攻撃を、攻撃元・標的・ベクトル・規模で分解して公開する層である。
+
+- L3/L4：SYN Flood / UDP Flood / DNS Amplification / Mirai系などのベクトル別シェア、Tbps級攻撃のピーク観測。
+- L7：Mitigation技法別（WAF / DDoS Managed Rules / IP Reputation / Access Rules）の遮断比率、業界別標的分布。
+- Bot分析：Verified Bot（Googlebot等）と未検証Botの比率、Bot vs Humanの時系列。
+
+### Routing（BGP）
+インターネット上のBGPルーティング異常を観測する層である。RPKI Valid/Invalid/NotFound比率、BGP Hijack疑いのアナウンス、Prefix起源変更（MOAS: Multi-Origin AS）、AS関連性などをダッシュボード化している。
+
+- 用途：自社AS / 顧客ASのRPKI検証カバレッジ確認、ルートリーク・ハイジャックの早期検知、IXP参加状況の把握。
+
+### DNS（1.1.1.1由来）
+Cloudflare Public Resolver（1.1.1.1 / 1.0.0.1）に届いたDNSクエリを匿名化集計したデータセットである。生IPは保持せず、国・ASレベルに匿名化された統計のみを公開する。
+
+- Domain ranking：人気ドメインの世界・国別ランキング（Alexa後継としてCloudflare Domain Rankingが利用される）。
+- Top domains by category：Social Media / News / Adult / Gambling 等カテゴリ別Top。
+- DNSSEC・DoH（DNS over HTTPS）/ DoT利用率、Query type分布、応答コード比率。
+
+### Internet Outages / Annotations
+国・AS単位の通信障害（Internet shutdowns / Cable cut / Power outage / Cyberattack）を、トラフィック急減検出と公開情報の組合せで記録するタイムラインである。Annotationは政府主導のシャットダウン、ケーブル切断、選挙時の遮断などをラベル付けして公開する。
+
+- 用途：報道・政策研究、SLA交渉時の根拠データ、海底ケーブル障害の影響範囲推定。
+
+### Email Routing Stats
+Cloudflareが処理したメール（Email Routing経由・受信メール）から、SPF / DKIM / DMARCのpass率、悪性メール比率、送信元国・ASのシェアを公開する層である。
+
+- 用途：DMARC普及度の地域差分析、なりすまし送信元の傾向把握。
+
+### Adoption & End User Experience
+プロトコル・技術普及率の継続観測。IPv6 adoption（国・AS別）、HTTP/3 / QUIC、TLS 1.3、Post-Quantum KEM（X25519MLKEM768）の利用比率を時系列で提供する。
+
+- 用途：自社サービスのプロトコル更新計画、業界レポート用のベンチマーク。
+
+### AS data
+AS単位のサマリ（トラフィック規模、IPv6カバレッジ、RPKI状況、隣接AS、地理分布）を提供する。AS Lookupとして個別AS番号で詳細を引ける。
+
+### URL Scanner
+任意URLの安全性・接続性・配信構成を解析するスタンドアロンツールである。スクリーンショット・DOM・リクエストツリー・SSL証明書・Geo配信・脅威判定までを返す。Radar APIから`/url-scanner/scan`で叩ける。
+
+### Datasets
+研究用に公開されているダウンロード可能データセット群。Domain Ranking CSV、AS関連性データ、Outage履歴、IPv6/HTTP普及率時系列など。CC BY-NC 4.0ライセンスで配布される。
+
+### API
+すべてのRadarカテゴリは`api.cloudflare.com/client/v4/radar/*`配下のREST APIから取得可能である。Cloudflare APIトークン（Account → Radar → Read）で認証し、無料tierとして全プラン共通で利用できる。
+
+### MCP Server
+RadarデータをClaude / 他LLMから直接参照するためのModel Context Protocolサーバーが公式提供されている。`radar.cloudflare.com/mcp`系のエンドポイントをClaude Desktop等に登録すると、自然言語で「日本の直近24時間のHTTPトラフィック傾向」を聞くだけで集計値を返せる。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- リサーチャー・記者・アナリストが、引用可能な一次データを無料で参照したい用途。CC BY-NC 4.0で論文・記事への引用が許可されている。
+- SOC・脅威インテリチームのDDoSベクトル傾向把握、攻撃元AS / 国の補助情報。
+- ネットワーク運用者の障害判定（「自社視点で観測した遅延が世界的傾向か、自社網起因か」の切り分け）。
+- 製品開発者のプロトコル採用判断（IPv6・HTTP/3・TLS 1.3普及率の継続モニタリング）。
+- SLA交渉・キャリア選定時の客観データ提供（特定国・ASの品質ランキング）。
+- 経営層向けに「インターネット全体の動向」をダッシュボード化したい広報・経営企画用途。
+
+### 適していないシーン
+- 自社サービスのRUM（Real User Monitoring）・APM・固有メトリクス。Radarはあくまでグローバル集計値であり、自社固有のユーザー体験は測れない。Datadog RUM / New Relic / Cloudflare自身のWeb Analytics・Browser Insightsを使う。
+- リアルタイム（秒〜分単位）の障害アラート用途。Radarの集計粒度は数分〜時間単位で、即応的なインシデント検知用ではない。
+- 商用での再販・有料サービス組込み（CC BY-NC 4.0は非商用ライセンス）。商用利用はCloudflareへの個別問い合わせが必要。
+- Cloudflareトラフィックを通らないクローズドネットワーク・特定地域専用網の分析。観測点バイアスから外れる。
+
+## 競合・代替
+
+| 観点 | Cloudflare Radar | Akamai mPulse Reports | Google Internet Stats | IODA | Ookla Speedtest Insights | Wayback Outages | SimilarWeb |
+|---|---|---|---|---|---|---|---|
+| 出自 | CDN / Anycast網・1.1.1.1 | CDN（Akamai網） | パブリッククラウド・Search | 学術（Georgia Tech） | スピードテスト専業 | アーカイブ非公式 | Web Analytics専業 |
+| Traffic | 標準（HTTP / NetFlows） | 一部公開 | 限定公開（透明性レポート） | × | × | × | サイト訪問数推計 |
+| Outages | タイムライン・Annotation充実 | 限定 | 一部地域 | 強み（学術研究グレード） | △ | 限定 | × |
+| Routing / BGP | RPKI / BGP異常 | × | × | △ | × | × | × |
+| Quality | speed.cloudflare.com由来 | × | △ | × | 最強（世界スピードテスト） | × | × |
+| DDoS / Attack | L3-L7・ベクトル別 | △（年次レポート中心） | △（透明性レポート） | × | × | × | × |
+| API | 全カテゴリ無料tier | 限定 | 限定 | あり（学術用） | 有料 | × | 有料 |
+| ライセンス | CC BY-NC 4.0 | 商用 | 商用 | 学術 | 商用 | 非公式 | 商用 |
+| 強み | カバー範囲の広さ・無料・更新頻度 | Akamai網からの視点 | Google視点の補助データ | 学術的厳密性・障害DB | 回線速度の標準指標 | アーカイブ性 | マーケ向けWeb指標 |
+| 弱み | Cloudflare観測網バイアス | 公開範囲が限定的 | 不定期更新・断片的 | UI簡素・速度なし | DDoS / Routingなし | 構造化されない | ネットワーク層は対象外 |
+
+Radarの差別化は「広いカバレッジ × 無料公開 × API化 × 更新頻度（リアルタイム〜数分遅延）」の4点である。Ooklaは回線速度の業界標準として併用、IODAは障害の学術的精査で併用、というのが実務的な棲み分けになる。
+
+## 料金
+
+- **ダッシュボード**：完全無料・登録不要。`radar.cloudflare.com`に直接アクセスして全カテゴリ閲覧可能。
+- **API**：全Cloudflareプラン（Free含む）で利用可能、追加料金なし。Cloudflare APIトークン（Account → Radar → Read権限）で認証する。
+- **データライセンス**：CC BY-NC 4.0（クレジット表記必須・非商用）。商用利用や大量データ取得はCloudflare営業に個別相談。
+- **Datasetsダウンロード**：無料。Domain Ranking等のCSVは定期更新。
+- **MCP Server**：無料。Claude Desktop等のMCPクライアントから利用可能。
+- **Rate Limit**：公式ドキュメントで明示されたAPI rate limitはなく、Cloudflare APIの一般的な制限（1300 req/5min前後）に準じる。大量問い合わせはAccount単位で逓減する可能性がある。
+
+## CLI / API 例
+
+### APIトークン作成
+ダッシュボード「My Profile → API Tokens → Create Custom Token」で、`Account → Radar → Read`権限のみのトークンを発行する。
+
+### HTTPトラフィック傾向（直近7日・日本）
+```bash
+curl -s "https://api.cloudflare.com/client/v4/radar/http/timeseries?dateRange=7d&location=JP&format=json" \
+  --header "Authorization: Bearer ${RADAR_TOKEN}" | jq '.result.serie_0.timestamps | length'
+```
+
+### DNS Top Domains（カテゴリ：News、グローバルTop10）
+```bash
+curl -s "https://api.cloudflare.com/client/v4/radar/ranking/top?limit=10&date=2026-05-01&domainCategory=News" \
+  --header "Authorization: Bearer ${RADAR_TOKEN}" | jq '.result.top_0[]'
+```
+
+### IPv6 Adoption（国別ランキング、直近28日）
+```bash
+curl -s "https://api.cloudflare.com/client/v4/radar/http/summary/ip_version?dateRange=28d&format=json" \
+  --header "Authorization: Bearer ${RADAR_TOKEN}" | jq '.result.summary_0'
+```
+
+### Internet Outages（直近30日・全世界）
+```bash
+curl -s "https://api.cloudflare.com/client/v4/radar/annotations/outages?dateRange=30d&format=json" \
+  --header "Authorization: Bearer ${RADAR_TOKEN}" | jq '.result.annotations[] | {location, eventType, startDate, endDate}'
+```
+
+### L3/L4 DDoS攻撃ベクトル分布
+```bash
+curl -s "https://api.cloudflare.com/client/v4/radar/attacks/layer3/summary/protocol?dateRange=7d&format=json" \
+  --header "Authorization: Bearer ${RADAR_TOKEN}" | jq '.result.summary_0'
+```
+
+### URL Scanner（任意URLの安全性スキャン）
+```bash
+# スキャン投入
+curl -s -X POST "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/urlscanner/v2/scan" \
+  --header "Authorization: Bearer ${RADAR_TOKEN}" \
+  --header "Content-Type: application/json" \
+  --data '{"url": "https://example.com"}' | jq '.uuid'
+
+# 結果取得
+curl -s "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/urlscanner/v2/result/${UUID}" \
+  --header "Authorization: Bearer ${RADAR_TOKEN}" | jq '.result.task'
+```
+
+## 制限・注意点
+- **Cloudflare観測点バイアス**：データソースはCloudflareのCDN網と1.1.1.1リゾルバである。Cloudflareを利用していないサイト・ISPの内部トラフィック・中国本土の閉域網などは観測対象外、もしくは過小評価される。グローバル傾向の代理指標として読む必要がある。
+- **サンプリング・正規化**：HTTPトラフィックは絶対値ではなく、ベースライン比の相対値（％）で表示されることが多い。ベースライン期間の選択次第で印象が変わるため、APIで生時系列を取って独自に解釈することが推奨される。
+- **DNSデータの匿名化**：1.1.1.1のクエリは個人特定可能な形では公開されない。国・AS粒度の集計のみで、特定ユーザーの行動追跡には使えない（仕様上の制約であり、プライバシー保護でもある）。
+- **API rate limit**：明示値はないが、Cloudflare API共通の制限（5分あたり1300リクエスト前後）が暗黙に適用される。大量バックフィルは時間を分散するか、Datasetsダウンロードで一括取得する。
+- **ライセンス**：CC BY-NC 4.0は非商用限定。商用ダッシュボード・有料SaaSへの組込みは別途契約が必要。Attribution（出典記載）は常に必須。
+- **データ遅延**：リアルタイムを謳うが、実際は数分〜数十分のラグがある。SOCのリアルタイム検知用ではなく、傾向分析・事後調査用と捉える。
+- **Outage Annotationの粒度**：国レベル・AS レベルの粒度で、都市・建物単位の障害は取れない。政府主導のシャットダウンは公開情報ベースで人手ラベル付けされるため、未公表の遮断は反映が遅れることがある。
+- **Domain Ranking**：Alexaの代替として広く使われるが、1.1.1.1のクエリベースであり、CloudflareDNSを使わないユーザー層（中国本土・特定企業ネットワーク）の嗜好は反映されにくい。
+
+## 参考リンク
+- Cloudflare Radar（ダッシュボード）：https://radar.cloudflare.com/
+- Radar Developer Docs：https://developers.cloudflare.com/radar/
+- Radar API Reference：https://developers.cloudflare.com/api/operations/radar-get-http-timeseries
+- Radar 初回API リクエスト：https://developers.cloudflare.com/radar/get-started/first-request/
+- Radar Concepts（Aggregation / Bot classes / Confidence / Normalization）：https://developers.cloudflare.com/radar/concepts/
+- Radar Datasets：https://developers.cloudflare.com/radar/investigate/radar-datasets/
+- URL Scanner：https://developers.cloudflare.com/radar/investigate/url-scanner/
+- Radar MCP Server：https://developers.cloudflare.com/agents/model-context-protocol/
+- llms.txt（ドキュメント索引）：https://developers.cloudflare.com/radar/llms.txt
+- Cloudflare Domain Ranking：https://radar.cloudflare.com/domains
+- Cloudflare Blog（Radar関連）：https://blog.cloudflare.com/tag/cloudflare-radar/
+
+---
+参照日: 2026-05-04

--- a/src/content/knowledge/web-development/cloudflare-docs/68-realtime.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/68-realtime.mdx
@@ -1,0 +1,248 @@
+---
+title: "Cloudflare Realtime (SFU / TURN / RealtimeKit)"
+description: "Cloudflare Realtimeは、WebRTCの3層インフラ（メディア中継のRealtime SFU、NAT/FW越えのRealtime TURN、プリビルドUI付きSDKのRealtimeKit＝旧Dyte）をAnycast網の上に統合提供し、ビデオ会議・ライブ配信・ゲーム音声・IoT遠隔監視のリアルタイム通信を、自前のSFU運用やリージョン分散の苦労なしに数百都市規模で展開できる「Real-time Serverless」プラットフォームである。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 68
+---
+# Realtime (SFU / TURN / RealtimeKit)
+
+## 一行サマリ
+Cloudflare Realtimeは、WebRTCの3層インフラ（メディア中継のRealtime SFU、NAT/FW越えのRealtime TURN、プリビルドUI付きSDKのRealtimeKit＝旧Dyte）をAnycast網の上に統合提供し、ビデオ会議・ライブ配信・ゲーム音声・IoT遠隔監視のリアルタイム通信を、自前のSFU運用やリージョン分散の苦労なしに数百都市規模で展開できる「Real-time Serverless」プラットフォームである。
+
+## 解決する課題（Why）
+WebRTCをプロダクション運用する場合、SFU（Selective Forwarding Unit）の自前構築・リージョン分散・TURN中継・NAT越え失敗率・録画ストレージ・話者文字起こしまで、垂直に積み上げる必要がある。EC2にmediasoupやpionを立てるところまでは1人で書けるが、シンガポール・東京・フランクフルトに分散配置し、最寄りエッジに引き寄せ、参加者100人を越えても落ちないようにする時点で専任のWebRTCエンジニアが必要になる。Cloudflare Realtimeはこの状況を以下のように解決する。
+
+- Realtime SFUがCloudflareの数百都市にデプロイ済みのAnycast SFUとして動き、参加者は最寄りエッジに自動接続される（リージョン選択コードゼロ）。
+- Realtime TURNがturn.cloudflare.comというAnycast単一エンドポイントで、企業ファイアウォール越えのリレーをグローバル提供する（追加インフラ不要）。
+- RealtimeKit（旧Dyte買収）が、ビデオ会議UIコンポーネント・録画・文字起こし・ブレイクアウトルームをSDK1行レベルで提供し、Zoom/Whereby代替のアプリを最短で立ち上げられる。
+- Workers / Durable Objects と組み合わせて、入退室イベント・モデレーション・ライブ翻訳をエッジで処理できる（メディアパスとシグナリング/制御パスが同じCloudflareネットワーク内に閉じる）。
+- SFU出力1,000GB/月までの無料枠＋$0.05/GBという、AgoraやTwilio Videoの分課金より圧倒的に予測しやすい料金体系を提供する。
+
+## 主要機能（What）
+
+### Realtime SFU
+WebRTCメディアサーバーの中核。クライアントがCloudflareのAnycast IPに対してWebRTC PeerConnectionを張り、`session` → `tracks`（push/pull）→ `datachannels`という3階層のREST APIで操作する。
+
+- **Session**：1クライアント1セッション。`POST /apps/{app_id}/sessions/new` でセッションIDを発行し、SDP offer/answerを交換する。
+- **Tracks**：そのセッションに対して「Pushする（送信）」「Pullする（他セッションのトラックを購読）」を個別に登録する。SimulcastとSVC（Scalable Video Coding）に対応し、購読者ごとに異なる解像度・ビットレートを選択的に転送する（=SFUの本質）。
+- **DataChannels**：WebRTCの任意データチャネルもSFU経由でファンアウトでき、ゲーム同期・チャット・カーソル共有等のリアルタイムデータを「メディアと同じ経路」で扱える。
+- **WebRTC CDN モード**：1対多配信に最適化したモードで、ライブ配信（数千〜数万視聴者）を低レイテンシで配信する。SFU/CDNハイブリッド構成も可能。
+
+### Realtime TURN
+WebRTCのNAT/FW越えリレー。`turn.cloudflare.com`という単一ホスト名がAnycastで解決され、世界中どこからでも最寄りCloudflareエッジに着地する。
+
+- 対応プロトコル：STUN/TURN over UDP（3478, 代替53）、TURN over TCP（3478, 代替80）、TURN over TLS（5349, 代替443）。443/TLSのおかげで、企業ファイアウォール下でも貫通できる。
+- 短期credentialをAPI経由で発行（HMAC方式）。ICE serverに渡すだけで標準WebRTCライブラリが自動的に利用する。
+- Realtime SFUと組み合わせて使う場合、TURN利用分は無料（SFU側の帯域課金に統合される）。
+- 単独利用（自前SFU・他社SFUとの組み合わせ）の場合は$0.05/GBの帯域課金。
+
+### RealtimeKit（旧Dyte）
+2024年買収のDyteをCloudflareブランドに統合した、ビデオ会議向けプリビルドSDK。
+
+- **UI Kit**：React / Vue / Angular / Web Components / iOS / Android / React Native / Flutter向けのコンポーネントライブラリ。`<DyteMeeting />`相当の1コンポーネント貼るだけで会議UIが立ち上がる。
+- **Core SDK**：UIなしでメディア・参加者・録画を制御するためのクライアントSDK。独自UIを組む場合のレイヤ。
+- **REST API**：ミーティング作成、参加者管理、録画・録画ファイルダウンロード、Webhook配信。
+- **付帯機能**：録画（クラウド録画→ストレージ保存）、ライブ文字起こし、ブレイクアウトルーム、投票、バーチャル背景、チャット。Zoom/Whereby代替として必要なものが揃う。
+- バックエンドはRealtime SFUの上に乗っており、SFUの恩恵（Anycast・分散）をそのまま受ける。
+
+### Recording / Transcription
+クラウド録画はRealtimeKit側で標準提供。録画ファイルはR2など任意のストレージに払い出し可能で、後段でWorkers AIによるサマライズ・Workers AI Whisperでの文字起こし再処理にもつなげられる。ライブ文字起こしはミーティング中にリアルタイム配信される。
+
+### Workers / Durable Objects 連携
+シグナリング・認可・モデレーションをWorkersで実装し、Durable Objectsで部屋単位の状態（参加者リスト・発言権・モデレーション状態）を保持するパターンが標準。SFUのメディアと制御プレーンが同じCloudflare網に閉じるため、レイテンシも経路コストも最小化される。Orange Meetsという公式デモアプリ（GitHub）がこの構成の参考実装になっている。
+
+### Anycast / グローバル分散
+全機能がCloudflareの300+都市Anycast網の上に乗る。利用者は「リージョンを選ぶ」概念がなく、最寄りエッジが自動的に応答する。中国本土からの接続のみ別扱い（Anycast対象外）である点に注意。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- 自前のビデオ会議・ウェビナー・教育プロダクトをゼロから作るケース。RealtimeKitで2週間でMVPを立ち上げ、必要に応じてSFU直叩きにレイヤダウンできる。
+- 既存アプリにビデオ通話・音声通話を「機能の一部として」埋め込みたいSaaS（顧客サポート、医療相談、家庭教師マッチング等）。SDK埋め込みで完結する。
+- マルチパーティのライブ配信（数百〜数万視聴者の低レイテンシ配信）。WebRTC CDNモードで構築する。
+- ゲーム音声チャット・チームボイス。SFUのDataChannelでゲーム状態同期、メディアトラックで音声を流すワンストップ構成が可能。
+- IoT・遠隔監視のRTSPに代わる現代的なリアルタイム映像配送（カメラ→SFU→ダッシュボード）。
+- 既にCloudflareにWorkers / R2 / D1 / Durable Objectsで投資済みで、「制御プレーンとメディアを同一ベンダに寄せたい」組織。
+
+### 適していないシーン
+- 既にAgora / Twilio Video / 100ms / LiveKit / Vonage Videoに大規模投資済みで、SDK・録画・分析の運用フローが固まっているケース。乗り換えコストに見合わない。
+- 中国本土ユーザー比率が高いプロダクト。CloudflareのAnycastは中国本土を含まないため、AgoraやTencent RTCの方が筋が良い。
+- 1対1のシンプルなP2P通話で、TURN中継すらほぼ不要なケース。素のWebRTC + 公開STUNサーバーで足りる。
+- E2EE（End-to-End Encryption）が法令・契約上の絶対要件で、SFUがメディアを復号できる構成が許されないケース。SFUは原理的にメディアを中継するため、Insertable Streamsベースの追加実装が必要になる。
+- レイテンシ要件が極限（50ms 未満 global）で、WebRTC+SFUの中継で発生する数十msすら許容できない超低遅延ゲーム配信。専用UDPプロトコル＋ピア直結が必要になる。
+- オンプレ完結要件（医療・防衛・金融の一部）。Cloudflare上のマネージドSFUを通せない以上、選択肢に入らない。
+
+## 競合・代替
+
+| 観点 | Cloudflare Realtime | Agora.io | Twilio Video | 100ms | Daily.co | LiveKit | Amazon IVS Real-Time | Vonage Video |
+|---|---|---|---|---|---|---|---|---|
+| SFU提供形態 | Anycast SFU + TURN | リージョナルSD-RTN | リージョナルSFU（2024 EOL予定→Programmable Video縮小） | リージョナルSFU | リージョナルSFU | OSS（自前ホスト）+ Cloud | AWSリージョナル | リージョナルSFU |
+| プリビルドUI SDK | RealtimeKit（旧Dyte） | 公式UI Kit | 限定 | Prebuilt SDK | Daily Prebuilt | Components | UI Kit | Video API SDK |
+| 録画 / 文字起こし | RealtimeKitに統合 | 別途課金 | 別途課金 | 標準提供 | 標準提供 | 別途追加 | 別途S3保存 | 別途課金 |
+| グローバル展開 | 300+都市 Anycast | 200+データセンター | AWS依存 | 主要リージョン | 主要リージョン | 自前次第/Cloud | AWSリージョン | リージョナル |
+| 中国本土 | 非対応 | 強い | 限定 | 限定 | 限定 | 自前次第 | 限定 | 限定 |
+| 料金モデル | SFU $0.05/GB（1TB無料）+ RealtimeKit分課金 | 分課金（参加者×分） | 分課金 | 分課金 | 分課金 | OSSは自前帯域、Cloud分課金 | 分+帯域 | 分課金 |
+| Workers/エッジ統合 | 同一ネットワーク内で完結 | 別ベンダ連携 | 別ベンダ連携 | 別ベンダ連携 | 別ベンダ連携 | 自前 | AWS Lambda連携 | 別ベンダ連携 |
+| OSS自前ホスト | 不可（マネージド） | 不可 | 不可 | 不可 | 不可 | 可（Apache 2.0） | 不可 | 不可 |
+
+Cloudflare Realtimeの差別化は「Anycast SFU」「Workers/R2/Durable Objectsとのゼロ距離統合」「帯域ベースの単純料金」の3点。一方、分課金で参加者数を確実にコスト予測したいエンタープライズや、中国対応必須のプロダクトはAgoraに分がある。LiveKitは自前ホスト要件があるなら最有力代替。
+
+## 料金
+
+- **Realtime SFU**：月1,000GB（=1TB）の出力まで無料。それ以降は$0.05/GB（Cloudflareエッジから視聴者方向への帯域）。受信は無課金。
+- **Realtime TURN**：Realtime SFUと併用時は無料。単独利用（自前SFU・サードパーティSFU経由）の場合は$0.05/GB（CloudflareエッジからTURNクライアント方向）。
+- **RealtimeKit**：参加者×分単位の課金（具体単価はRealtimeKitダッシュボードで個別確認）。録画・文字起こしは追加課金枠。
+- **Workers / R2 / Durable Objects**：シグナリング・録画ストレージとして使う場合は各サービスの通常料金が別途加算される（例：R2は$0.015/GB-月、エグレス無料）。
+
+WebRTCの一般的な大原則として「動画を流す方向＝下り＝視聴者側」で帯域が伸びるので、グループ会議よりライブ配信型の方が課金が膨らみやすい。Simulcast/SVCで購読者の解像度を下げる設計が直接コスト削減になる。
+
+## CLI / API 例
+
+### TURN credentials 発行（curl）
+```bash
+# RealtimeアプリのTURN keyを使い、短期TURN credentialを発行
+curl -X POST "https://rtc.live.cloudflare.com/v1/turn/keys/$TURN_KEY_ID/credentials/generate-ice-servers" \
+  -H "Authorization: Bearer $TURN_KEY_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{ "ttl": 86400 }'
+# → { "iceServers": { "urls": [...], "username": "...", "credential": "..." } }
+```
+
+クライアント側ではこれをそのままRTCPeerConnectionのiceServersに渡す。
+
+```js
+const pc = new RTCPeerConnection({
+  iceServers: [
+    {
+      urls: [
+        "stun:stun.cloudflare.com:3478",
+        "turn:turn.cloudflare.com:3478?transport=udp",
+        "turns:turn.cloudflare.com:5349?transport=tcp",
+      ],
+      username: TURN_USER,
+      credential: TURN_CRED,
+    },
+  ],
+});
+```
+
+### Realtime SFU セッション作成 → トラック push
+```bash
+# 1) 新規セッション作成
+curl -X POST "https://rtc.live.cloudflare.com/v1/apps/$APP_ID/sessions/new" \
+  -H "Authorization: Bearer $APP_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data "{\"sessionDescription\": {\"type\":\"offer\",\"sdp\":\"<LOCAL_SDP_OFFER>\"}}"
+# → { "sessionId": "abc123", "sessionDescription": {"type":"answer","sdp":"..."} }
+
+# 2) このセッションでローカルトラックをpush（送信）
+curl -X POST "https://rtc.live.cloudflare.com/v1/apps/$APP_ID/sessions/abc123/tracks/new" \
+  -H "Authorization: Bearer $APP_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "sessionDescription": {"type":"offer","sdp":"<RENEGOTIATION_OFFER>"},
+    "tracks": [
+      { "location": "local", "mid": "0", "trackName": "camera-video" },
+      { "location": "local", "mid": "1", "trackName": "mic-audio"   }
+    ]
+  }'
+
+# 3) 別セッションのリモートトラックをpull（購読）
+curl -X POST "https://rtc.live.cloudflare.com/v1/apps/$APP_ID/sessions/xyz789/tracks/new" \
+  -H "Authorization: Bearer $APP_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "tracks": [
+      { "location": "remote", "sessionId": "abc123", "trackName": "camera-video" }
+    ]
+  }'
+```
+
+### RealtimeKit SDK 初期化（Web）
+```ts
+import { DyteProvider, useDyteClient } from "@dytesdk/react-web-core";
+import { DyteMeeting } from "@dytesdk/react-ui-kit";
+
+function App({ authToken }: { authToken: string }) {
+  const [meeting, initMeeting] = useDyteClient();
+
+  useEffect(() => {
+    initMeeting({
+      authToken,                 // バックエンドでREST API経由で発行
+      defaults: { audio: true, video: true },
+    });
+  }, [authToken]);
+
+  return (
+    <DyteProvider value={meeting}>
+      <DyteMeeting meeting={meeting!} mode="fill" />
+    </DyteProvider>
+  );
+}
+```
+
+バックエンド側（Workers）でミーティング作成 + 参加者authToken発行：
+
+```ts
+// Cloudflare Workers
+export default {
+  async fetch(req, env) {
+    // 1) ミーティング作成
+    const meeting = await fetch("https://api.realtime.cloudflare.com/v2/meetings", {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${btoa(`${env.RTK_ORG_ID}:${env.RTK_API_KEY}`)}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ title: "Sales Call", record_on_start: false }),
+    }).then(r => r.json());
+
+    // 2) 参加者をadd → authTokenを得る
+    const participant = await fetch(
+      `https://api.realtime.cloudflare.com/v2/meetings/${meeting.data.id}/participants`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Basic ${btoa(`${env.RTK_ORG_ID}:${env.RTK_API_KEY}`)}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name: "shogo",
+          preset_name: "group_call_host",
+          custom_participant_id: "user_001",
+        }),
+      },
+    ).then(r => r.json());
+
+    return Response.json({ authToken: participant.data.token });
+  },
+};
+```
+
+## 制限・注意点
+- **中国本土からの接続はAnycast対象外**。中国向けプロダクトでは別経路（中国国内のWebRTCベンダ）を併用する必要がある。
+- **TURN allocationごとのレート制限**：新規IP接続>5/秒、パケット>5-10kpps、帯域>50-100Mbps を超えるとパケットドロップが発生する。1人のクライアントから巨大トラフィックを流す用途（4Kマルチストリーム配信元など）は要確認。
+- **E2EEは標準では非対応**。SFUは原理的にメディアを復号して再パケット化するため、E2EE要件があればInsertable Streams + アプリ層暗号化を自前で実装する必要がある。
+- **録画ストレージ**：RealtimeKitの録画はR2等に払い出すまで保持期間に上限がある。長期保管は外部ストレージへのコピーをWebhookで自動化する設計が必要。
+- **API rate limit**：Realtime SFUのセッション作成・トラック登録APIにはアカウント単位のレート上限がある。瞬間的な大量入室（数千人が同時接続）には事前のキャパシティ調整・段階的入室の実装が必要。
+- **DataChannel経由の任意データ転送はSFUの帯域に計上される**。チャットや座標同期を高頻度で流すと、メディア帯域とは別に課金が伸びる点に注意。
+- **Dyte→RealtimeKitリブランド過渡期**：SDKパッケージ名やAPIホストが`@dytesdk/*` / `api.dyte.io` から `@cloudflare/realtimekit*` / `api.realtime.cloudflare.com` 系へ移行中。最新の公式ドキュメントを参照しないと古いエンドポイントを引いて詰まる。
+- **WebRTCそのものの落とし穴**は当然全部残る：エコー・ハウリング、コーデックネゴ失敗、企業FWでの443/TLS強制、モバイルのバックグラウンド時のメディア停止、Safari固有のオートプレイ制約等。Cloudflareがインフラを巻き取っても、クライアント側の実装品質は別論点。
+- **料金の実測差**：1,000GB/月の無料枠は「数十人規模の社内会議用途」では十分だが、ライブ配信1万人視聴クラスではすぐに溶ける。ビットレートを下げる（720p→540p、Opus 24kbps）だけで体感品質を保ったままコストが半減することも多い。
+
+## 参考リンク
+- Cloudflare Realtime トップ：https://developers.cloudflare.com/realtime/
+- Realtime SFU：https://developers.cloudflare.com/realtime/sfu/
+- Realtime TURN：https://developers.cloudflare.com/realtime/turn/
+- RealtimeKit：https://developers.cloudflare.com/realtime/realtimekit/
+- SFU API リファレンス：https://developers.cloudflare.com/realtime/sfu/api-reference/
+- Orange Meets デモ（公式リファレンス実装）：https://github.com/cloudflare/orange
+- Cloudflare Calls → Realtime リブランド経緯：https://blog.cloudflare.com/cloudflare-realtime-and-realtimekit/
+- Dyte 買収アナウンス：https://blog.cloudflare.com/cloudflare-acquires-dyte/
+- Realtime llms.txt：https://developers.cloudflare.com/realtime/llms.txt
+- Workers との連携パターン：https://developers.cloudflare.com/workers/
+
+---
+参照日: 2026-05-04

--- a/src/content/knowledge/web-development/cloudflare-docs/69-registrar.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/69-registrar.mdx
@@ -1,0 +1,200 @@
+---
+title: "Cloudflare Registrar"
+description: "Cloudflareアカウントで管理するドメインを、レジストリ卸価格＋ICANN手数料の実費（at-cost）だけで登録・更新・移管できる、マークアップなし・WHOIS Privacy標準・DNSSECワンクリックのドメインレジストラである。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 69
+---
+# Registrar
+
+## 一行サマリ
+Cloudflareアカウントで管理するドメインを、レジストリ卸価格＋ICANN手数料の実費（at-cost）だけで登録・更新・移管できる、マークアップなし・WHOIS Privacy標準・DNSSECワンクリックのドメインレジストラである。
+
+## 解決する課題（Why）
+従来の主要レジストラ（GoDaddy / Namecheap / お名前.com 等）は、卸価格に独自マークアップを乗せ、WHOIS Privacy・DNSSEC・Registry Lockなどを別料金オプションとして販売するビジネスモデルが定着している。さらに「初年度激安・更新時に通常価格へ跳ね上がる更新トラップ」「自動更新を切るとサイトが落ちる事故」「移管時のトランスファーロック解除や認証コード発行が有料・遅延」といった摩擦が常態化している。Cloudflare Registrarはこれを以下のように整理する。
+
+- レジストリ卸価格＋ICANN手数料（年$0.18）以外のマークアップを取らない。初年度・更新で価格が変わらない。
+- WHOIS Privacy（登録者情報の代理表示）を標準提供、追加料金なし。
+- DNSSECをダッシュボードからワンクリック有効化、追加料金なし。
+- Cloudflare DNS / WAF / Pages / Workersと同一アカウントで完結し、ネームサーバ管理の二重運用が不要。
+- 自動更新が標準ON。支払い手段が有効なら更新を逃さない。
+
+ただし「Cloudflare DNSをネームサーバとして使うこと」が前提で、TLDも限定（.jp / .co.jp 等は対象外）であるため、すべてのドメインを集約できるわけではない。
+
+## 主要機能（What）
+
+### At-cost pricing
+レジストリ卸価格＋ICANN手数料（gTLDで$0.18/年）のみを請求する仕組みである。Cloudflareは登録手数料・更新手数料を上乗せしない。
+
+- 価格はTLDごとにレジストリ卸価格に連動するため、レジストリ側の値上げで変動する。Cloudflare独自のマークアップ・キャンペーン価格・更新時の値上げは存在しない。
+- 「初年度$1で2年目から$20」のような引き込み価格は採用していない。1年目から正規卸価格である。
+- 課金は契約しているCloudflareアカウントの支払い手段（クレジットカード / PayPal）に紐づき、ドメイン単独の請求書ではなく月次請求に統合される。
+
+### Domain Transfer（他社からの移管）
+他社レジストラからCloudflare Registrarへ移管するフローである。発生作業30分程度、完了まで最大10日（多くは5営業日以内）が目安となる。
+
+- 旧レジストラ側でTransfer Lockを解除し、Auth Code（EPP code / authinfo / transfer code）を発行。
+- Cloudflareダッシュボード「Registrar → Transfer Domains」で対象ドメインとAuth Codeを入力。
+- 旧レジストラからの確認メール承認、または自動承認（規定期間経過）で移管が完了する。
+- ICANN規定により「登録から60日未満のドメイン」「直近60日以内に移管したドメイン」は移管不可。Registrant情報変更直後の60日ロックも同様に適用される。
+- Shopify / Wix / Squareなどネームサーバ変更を許可しないプラットフォーム経由の登録は、いったん別レジストラに移管し60日待機してからCloudflareへ、という二段階移管が必要。
+
+### Registry Lock（Custom Domain Protection）
+レジストリ階層でドメインをロックし、UIからの変更を一切受け付けないオプションである。「侵害されたCloudflareアカウントからのドメインハイジャック」を防ぐ最後の砦に位置する。
+
+- Enterpriseプラン限定で、高価値ドメインのみが対象。Cloudflareアカウントチームへの個別相談で有効化される。
+- 有効化後はネームサーバ変更・コンタクト変更・移管などすべての変更がout-of-band認証（事前に取り決めた手動プロセス）を経由する。ダッシュボードからは操作インターフェース自体が消える。
+- 対応TLDは「レジストリがRegistry Lockをサポートしているもの」に限られる。.com / .net / .org など主要gTLDが中心。
+- 価格はEnterprise契約に内包。個別見積もり。
+
+### WHOIS Privacy（標準）
+登録者情報をWHOIS / RDAP公開情報から代理表示（redaction）する機能である。GoDaddy等で年$10〜$20の追加課金が一般的なオプションを、Cloudflareは無料・標準ONで提供する。
+
+- gTLDではTechnical / Administrative / Registrant連絡先がCloudflareの代理アドレスに置き換わる。
+- ccTLDはレジストリ規約により挙動が異なる（.us は法的に開示必須）。
+- 法執行・知財侵害の正式なWHOIS開示要請は、CloudflareのWHOIS request窓口経由で対応される。
+
+### Auto-renew
+新規登録・移管完了後、自動更新がデフォルトで有効になる。
+
+- 失効リスクの高いドメインを「うっかり期限切れ」で失う事故を防ぐ設計。
+- 個別ドメインで明示的にOFFにすると、期限到来でCloudflareは更新しない。
+- 支払い手段の有効性確認はアカウント単位で行われ、失敗すると全ドメインの更新が滞る。
+
+### DNSSEC ワンクリック有効化
+ダッシュボード「DNS → Settings → DNSSEC」からの操作だけでDSレコードがレジストリ側に登録される。Cloudflare DNSをネームサーバとして使っている前提なので、KSK/ZSK鍵管理はCloudflare側に任せる形となる。
+
+### Registrar API
+ドメイン検索・空き確認・新規登録までをCloudflare API v4経由で実行できる（2026-05時点でβ）。
+
+- 認証はBearerトークン（`CLOUDFLARE_API_TOKEN`）。
+- 対応エンドポイント：`/registrar/domain-search`、`/registrar/domain-check`、`/registrar/registrations`。
+- 未対応：更新・移管・コンタクト更新・ロック操作。これらは引き続きダッシュボード操作。
+
+### 対応TLD
+公式に「400以上のTLDをサポート」と表記されている。主要gTLD（.com / .net / .org / .io / .dev / .app / .ai 等）と一部ccTLD（.us / .uk / .co / .me / .tv 等）が中心。
+
+- IDN（国際化ドメイン名・アクセント記号や非ラテン文字を含むドメイン）は非対応。
+- 一部ccTLDはレジストリ規約により新規登録不可・移管のみ可能、または逆のパターンがある。
+- .us は米国居住・法人要件（Nexus要件）がある。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- Cloudflare DNS / Pages / Workers / Zero Trustをすでに使っており、ドメイン管理だけ別レジストラに残っている組織。ネームサーバ運用が一本化される。
+- WHOIS Privacy・DNSSEC・自動更新を「全ドメインで強制」したい運用。標準ONなので運用コストが下がる。
+- 個人開発者・スタートアップで、複数の.dev / .io / .ai ドメインを長期保有したい場合。マークアップなしの効果が累積する。
+- 移管トラップ・更新時の価格跳ね上がりを排除したい中規模Web事業者。
+- IaC（Terraform / Pulumi）でDNSとアプリを管理しており、ドメイン契約だけが手動運用になっているケース。少なくとも更新・自動更新の運用負荷は消える。
+
+### 適していないシーン
+- .jp / .co.jp / .cn / .de など Cloudflare Registrarが対応していないTLDを主軸に運用している組織。お名前.com / Gandi / Namecheap等の併用が必須。
+- ドメインを大量バルク登録（100ドメイン超を一括取得・転売）するドメイナーやSEOアフィリエイト運用。Cloudflareは投機的な大量登録を想定しておらず、API側にも更新・移管エンドポイントが揃っていない。
+- 登録者情報をどうしても自社管理のWHOIS代理サービス（プロキシ業者）に固定したい場合。Cloudflareの代理表示は変更できない。
+- Cloudflare DNS以外のネームサーバ（Route53 / NS1 / Akamai 等）を使い続けたいケース。Cloudflare Registrar はCloudflare DNSとセットでの利用が前提。
+- IDN・特殊TLD・新興ccTLDを主に扱うケース。
+
+## 競合・代替
+
+| 観点 | Cloudflare Registrar | AWS Route 53 Domains | Squarespace Domains（旧Google Domains） | Namecheap | GoDaddy | Gandi | Porkbun |
+|---|---|---|---|---|---|---|---|
+| 価格モデル | At-cost（卸＋ICANN手数料のみ） | 卸近辺＋小マークアップ | 一律価格・WHOIS Privacy標準 | 初年度安・更新時上昇 | 初年度安・更新時大幅上昇 | 中価格帯・固定 | 低価格帯・透明性高い |
+| WHOIS Privacy | 標準・無料 | 標準・無料 | 標準・無料 | 標準（Free WhoisGuard） | 有料オプション中心 | 標準・無料 | 標準・無料 |
+| DNSSEC | ワンクリック・無料 | 対応・無料 | 対応 | 対応 | 対応 | 対応 | 対応 |
+| Registry Lock | Enterpriseのみ・無料 | 非提供 | 非提供 | 非提供 | 有料 | 一部TLDで有料 | 非提供 |
+| 対応TLD数 | 400+（主要gTLD中心、.jp等不可） | 多数（.jp含む） | Squarespace移行で限定的 | 500+ | 500+ | 750+（最広） | 500+ |
+| バルク登録 | 不向き | 可 | 可 | 可（バルク機能あり） | 可 | 可 | 可 |
+| API成熟度 | 検索・登録のみβ | 安定・更新まで対応 | 限定 | 限定 | 限定 | 安定 | 安定 |
+| 強み | マークアップなし・Cloudflare統合 | AWSアカウント統合・自動化 | UI完成度・移行先がSquarespace | 価格・サポート・UI | TLD網羅性・サポート | TLD網羅性・倫理運営 | 価格・透明性 |
+| 弱み | 対応TLD限定・DNS固定 | UI古い・価格はat-costではない | Squarespace移行で先行き不透明 | 更新トラップ | 更新時の値上がり・営業電話 | UIが質素 | サポート規模 |
+
+Cloudflare Registrarは「価格透明性 × Cloudflareプラットフォーム統合」に最適化されており、競合より一歩抜けている。ただし対応TLDと運用前提（DNSをCloudflareに寄せる）に強い縛りがあるため、全ドメインを集約するのは現実には難しい。.jpを含むポートフォリオは Gandi / Route53 / お名前.com との併用が現実解。
+
+## 料金
+
+- **登録費用**：レジストリ卸価格＋ICANN手数料（gTLDで$0.18/年）。マークアップ・登録手数料・サービス手数料はゼロ。
+- **更新費用**：登録費用と同額。初年度割引・更新時値上げは存在しない。
+- **移管費用**：移管時に1年分の更新が自動で発生し、その費用のみ請求される（ICANN仕様）。Cloudflare側の移管手数料はゼロ。
+- **WHOIS Privacy**：無料・標準。
+- **DNSSEC**：無料・標準。
+- **Registry Lock（Custom Domain Protection）**：Enterprise契約に内包、個別見積もり。
+- **Cloudflareアカウントプラン**：Free / Pro / Business / EnterpriseいずれでもRegistrar機能は使える。プランを上げてもRegistrar価格には影響しない。
+
+参考価格（2026-05時点、レジストリ卸変動あり）：.com $9.77 / 年、.net $11.61 / 年、.io $34.80 / 年、.dev $12.18 / 年、.app $13.59 / 年、.ai $80前後 / 年。
+
+## CLI / API 例
+
+### Cloudflare API（v4）でドメイン検索・空き確認・登録
+```bash
+# 環境変数
+export CLOUDFLARE_API_TOKEN="..."
+export ACCOUNT_ID="..."
+
+# キーワードからドメイン候補を検索
+curl --request GET \
+  --url "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/registrar/domain-search?q=acme%20corp&limit=5" \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+
+# 個別ドメインの空き・価格を確認
+curl --request POST \
+  --url "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/registrar/domain-check" \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  --header "Content-Type: application/json" \
+  --data '{"domains": ["acmecorp.dev", "acmecorp.io"]}'
+
+# 新規登録（アカウントの既定支払い手段に課金される）
+curl --request POST \
+  --url "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/registrar/registrations" \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  --header "Content-Type: application/json" \
+  --data '{"domain_name": "acmecorp.dev"}'
+```
+
+### 既存ドメインの状態取得（コンタクト・ロック・自動更新）
+```bash
+# アカウント配下のドメイン一覧
+curl --request GET \
+  --url "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/registrar/domains" \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+
+# 単一ドメインの詳細（auto_renew, transfer_lock, contacts, registry_statuses 等）
+curl --request GET \
+  --url "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/registrar/domains/acmecorp.dev" \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+```
+
+### 移管・更新・ロック操作
+ダッシュボード操作が前提。Auth Code発行・Transfer Lockのトグル・自動更新切り替えは「Registrar → 該当ドメイン → Configuration」配下に集約されている。APIは2026-05時点で更新・移管・ロック操作・コンタクト更新が未提供。
+
+## 制限・注意点
+- Cloudflare DNSをネームサーバとして使うのが必須。他社DNS（Route53 / NS1 / Akamai 等）に向けたままRegistrarだけ使うことはできない。
+- 対応TLDは400+だが、日本主要TLDの.jp / .co.jp / .ne.jp / .or.jp は対象外。中国 .cn、ドイツ .de なども非対応。これらは別レジストラで運用継続が必要。
+- IDN（アクセント記号付き・非ラテン文字ドメイン）は登録不可。
+- Premium TLD（レジストリ側でプレミアム価格設定されているドメイン名）は登録できない、または別途プレミアム価格が適用される場合がある。
+- 新規登録の支払いは有効なクレジットカード / PayPalが必要。一部の地域では決済が制限される。
+- ICANN規定により、登録60日未満・移管60日未満のドメインは他社へ転出できない。Registrant情報変更直後も同様。
+- Shopify / Wix / Squareで取得したドメインはネームサーバ変更を許可しないため、別レジストラ経由＋60日待機の二段階移管が必要。
+- Registrar APIはβで、更新・移管・ロック操作・コンタクト更新は未対応。完全自動化はできない。
+- 自動更新が前提設計のため、支払い手段切れ・カード期限切れの監視を運用に組み込む必要がある。アカウント単位で更新が止まるリスクがある。
+- Registry Lock（Custom Domain Protection）はEnterprise限定、対応TLDも限定。Free / Pro / Businessでは利用できない。
+- WHOIS開示要請に対する応答ポリシーはCloudflareの規定に従う。法的開示要請のSLAをコントロールしたい組織は別途検討が必要。
+- バルク登録・転売目的のドメイナー運用は想定外。利用規約・運用フロー両面で不向き。
+
+## 参考リンク
+- Cloudflare Registrar（製品ページ）：https://developers.cloudflare.com/registrar/
+- Supported TLDs：https://developers.cloudflare.com/registrar/top-level-domains/
+- Transfer domain to Cloudflare：https://developers.cloudflare.com/registrar/get-started/transfer-domain-to-cloudflare/
+- Transfer out from Cloudflare：https://developers.cloudflare.com/registrar/account-options/transfer-out-from-cloudflare/
+- Inter-account transfer：https://developers.cloudflare.com/registrar/account-options/inter-account-transfer/
+- WHOIS redaction：https://developers.cloudflare.com/registrar/account-options/whois-redaction/
+- WHOIS requests：https://developers.cloudflare.com/registrar/whoisrequests/
+- Enable DNSSEC：https://developers.cloudflare.com/registrar/get-started/enable-dnssec/
+- Custom Domain Protection（Registry Lock）：https://developers.cloudflare.com/registrar/custom-domain-protection/
+- Registrar API guide：https://developers.cloudflare.com/registrar/registrar-api/
+- API reference：https://developers.cloudflare.com/api/resources/registrar/
+- Troubleshooting：https://developers.cloudflare.com/registrar/troubleshooting/
+- Registrar llms.txt：https://developers.cloudflare.com/registrar/llms.txt
+
+---
+参照日: 2026-05-04

--- a/src/content/knowledge/web-development/cloudflare-docs/70-sandbox-sdk.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/70-sandbox-sdk.mdx
@@ -1,0 +1,182 @@
+---
+title: "Cloudflare Sandbox SDK"
+description: "AIエージェントが生成した任意コードを安全に実行するための、Cloudflare Containers + Workers + Durable Objectsで構成された永続的・隔離型のLinuxサンドボックスSDKである。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 70
+---
+# Sandbox SDK
+
+## 一行サマリ
+AIエージェントが生成した任意コードを安全に実行するための、Cloudflare Containers + Workers + Durable Objectsで構成された永続的・隔離型のLinuxサンドボックスSDKである。
+
+## 解決する課題（Why）
+LLMにコードを書かせるところまでは安価に実現できるが、「そのコードを安全に走らせる場所」が抜けると、エージェントは推論にとどまり実際の作業を完結できない。ローカル実行は信頼境界を壊し、共有VMはマルチテナント分離が甘く、自前のFirecracker/gVisorクラスタは運用コストが重い。Cloudflare Sandbox SDKはこの「AIに渡してよい任意コード実行環境」を、Workersから一行で呼び出せるマネージドDurable Objectとして提供する。
+
+- LLM出力の任意シェルコマンド・任意Python/JavaScriptコードを、ホストとも他テナントとも隔離した環境で実行する。
+- 永続ファイルシステムと長時間バックグラウンドプロセスを、エージェントの「自分のPC」として持たせる。
+- 開発サーバを立ててプレビューURLで人間にレビューさせる、テストを走らせて結果を読む、といった開発者の作業ループをエージェントが模倣できるようにする。
+- egress proxy経由で資格情報をエージェントから隠したまま外部APIに認証する、という「鍵を渡さず仕事をさせる」運用を成立させる。
+- Cloudflareネットワーク内に閉じることで、Workersからの呼び出しレイテンシ・課金・ログ・ID管理を統一する。
+
+## 主要機能（What）
+
+### Shell実行（exec / Streaming output）
+`sandbox.exec()` で任意のシェルコマンドを実行し、stdout / stderr / exit codeを取得する。`execStream()`系APIでは出力をリアルタイムでストリーミングでき、長時間ビルド・テスト・学習ジョブの進捗をWorkersから人間やLLMにそのまま流せる。タイムアウト管理と非ゼロ終了コードのハンドリングは標準で組み込まれている。
+
+### ファイルシステム
+コンテナ内に永続的なLinuxファイルシステムを持ち、`writeFile` / `readFile` / `mkdir` / `deleteFile` 等で操作する。inotifyベースのファイル監視も提供されており、エージェントが「ファイルが変わったら次のステップに進む」イベント駆動ループを書ける。R2 / S3 / GCSをマウントして大容量データやモデルファイルを共有することも可能である。
+
+### Code Interpreter（Python / JS / TS の永続実行）
+セッションをまたいで変数・import・状態が残るコードインタプリタを持つ。Jupyterノートブック相当のセル実行体験で、データ分析・機械学習エージェント用途に向く。チャート・テーブルなどのリッチ出力もそのまま扱える。
+
+### Port Preview / 公開URL
+コンテナ内で起動したHTTPサーバを `exposePort()` で公開し、Cloudflareが発行するプレビューURLで外部から到達できるようにする。Vite/Next.jsの開発サーバをエージェントに立てさせて、人間がブラウザで動作確認する、という開発ループを成立させる。`.workers.dev`はワイルドカードサブドメインを張れないため、本番運用ではカスタムドメイン設定が前提となる。
+
+### PTY / WebSocket Terminal
+擬似端末をWebSocket経由で開けるため、xterm.jsを噛ませれば人間がブラウザからエージェントのコンテナに直接ログインしてデバッグできる。「リクエスト・レスポンス型のexec」では捌けない対話的シェル（vim / REPL / curses系TUI）もそのまま動く。
+
+### 永続化 / Snapshots
+コンテナのディスク状態をスナップショットとして取得し、R2にtieredキャッシュで保存する。リージョン跨ぎの暖機起動が現実的な時間で済むため、エージェントが何時間にも渡って同じワーキングコピーで作業し続けるユースケースに耐える。スリープからの復帰・別リージョンへの再配置でも作業ツリーは保持される。
+
+### Egress Proxy（信頼境界）
+サンドボックスから外向き通信は、Cloudflare側のプログラマブルegress proxyを通る。OAuthトークンやAPIキーはこのproxyに保持され、ネットワークレイヤで宛先ドメイン別に注入される。エージェント本体は資格情報を一切見ないため、プロンプトインジェクションでトークンを漏らされる経路を物理的に塞げる。
+
+### Workers Binding / Durable Objects 連携
+SandboxはDurable Objectとしてバインドされ、Workersから `getSandbox(env.Sandbox, "session-id")` で取り出す。同じIDで再取得すれば同じコンテナに戻れるため、ユーザー単位・セッション単位の永続環境が自然に書ける。Durable Objectsのrouting特性をそのまま流用できる点がE2BやModal Sandboxesに対する構造的な強みである。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- LLMを核にした「コードを書いて走らせて結果を読む」エージェント（Code Interpreter / SWEエージェント / データ分析Bot）。
+- ユーザーごとにIDE的な永続ワークスペースを払い出すSaaS（オンラインIDE、教育プラットフォーム、Replit的サービス）。
+- すでにCloudflare Workers / Durable Objects / R2上にアプリを載せており、追加のクラウドアカウントを増やさずにサンドボックスを足したいケース。
+- 任意コード実行を「自社で持つ」ことのコンプライアンス上の重さを避けたい中小〜中堅のエージェントSaaS。
+- Egress proxyで資格情報をエージェントから隠す要件があるケース（カスタマー資格でAPIを叩く必要があるが、LLMには渡したくない）。
+
+### 適していないシーン
+- GPUを必須とする推論・学習ワークロード。Sandboxは現時点でCPUコンテナのみであり、GPUインスタンスは別途Workers AI / Containers GPU系を検討する。
+- 数万並列のバッチ処理・MapReduce的ワークロード。同時実行枠はかなり緩和されたとはいえ、Spark / Dataflow / Batch系の代替にはならない。
+- 数百ms以下のスタートアップが必須のリクエスト型コード実行。素のWorkers isolateやDynamic Workersのほうが2桁速い。
+- 「外部に出さないオンプレ」要件。Cloudflareネットワーク前提のため、データ主権要件が厳しい組織には合わない。
+- 既存のKubernetes / Firecrackerクラスタの運用ノウハウがあり、自社で握りたい組織。
+
+## 競合・代替
+
+| 観点 | Cloudflare Sandbox SDK | E2B | Modal Sandboxes | Daytona | CodeSandbox CDE | Replit Agent | Anthropic Code Execution |
+|---|---|---|---|---|---|---|---|
+| 出自 | Workers / Containers / DO | エージェント向けサンドボックス専業 | Pythonデータ・AI実行基盤 | OSS Dev Environment Manager | オンラインIDE発のCDE | オンラインIDE / エージェント | Claude tool（Anthropic API） |
+| 隔離単位 | Container（Durable Object単位） | Firecracker microVM | gVisor / Firecracker | Docker / k8s | Firecracker microVM | Repl（NixOSベース） | Anthropic管理サンドボックス |
+| 永続化 | R2スナップショット・FS永続 | スナップショット | Volume / 永続ファイルシステム | Workspace永続 | 標準 | 標準 | セッション内のみ |
+| GPU | 不可 | 一部対応 | 強力（A100/H100） | 環境次第 | 限定 | 限定 | 不可 |
+| Port Preview | あり（ワイルドカードDNS必要） | あり | あり | あり | あり | あり | なし |
+| Workers / エッジ統合 | 一級市民 | 別クラウド | 別クラウド | 別クラウド | 別クラウド | 別クラウド | API経由 |
+| 信頼境界（資格情報） | Egress proxyで分離 | アプリ層次第 | アプリ層次第 | アプリ層次第 | アプリ層次第 | アプリ層次第 | Anthropic側で管理 |
+| 強み | DO routing・WorkersネイティブAPI・egress proxy | エージェント専用UX・成熟 | GPU・データ系の太いランタイム | OSSで自社運用可能 | IDE体験・CDE | エージェントUX一体型 | Claudeから即座に使える |
+| 弱み | GPUなし・Beta機能あり | 自前クラウドで分離管理 | エッジ統合は弱い | マネージド色は薄い | エージェント用途は二次的 | 外部から呼びにくい | 永続化・カスタマイズが弱い |
+
+CloudflareのSandbox SDKは「Workersアプリの一部としてサンドボックスをバインドできる」点と「egress proxyで資格情報をエージェントから引き剥がす」点が他社と差別化される。一方、GPUワークロードや巨大データ処理ではModal、エージェント側UXの成熟度ではE2Bが先行している。
+
+## 料金
+- Workers Paidプラン（$5/月〜）が前提。Workers / Durable Objectsの通常課金に加え、Cloudflare Containersの「Active CPU Pricing」（コンテナがCPUを使った時間にのみ課金、アイドル時間は無課金）が積み上がる。
+- インスタンスタイプは lite / basic / standard / large 系のサイズが選べ、それぞれメモリ・vCPU・並列上限が異なる。GAタイミングで同時実行枠は大幅に拡張されており、liteは概ね1.5万、basicは6千、それより大きいサイズで1千以上が標準で用意される。
+- スナップショットの保存はR2の通常ストレージ・オペレーション課金が乗る。長時間アイドル後の暖機復帰で帯域・操作費が発生する点に注意。
+- Egress proxyを通る外向きトラフィックはWorkersの通常egressに準じ、超過分はバンドル次第で従量。
+- 開発・検証用途であれば、Free + 短時間検証の組み合わせで月数ドルレンジに収まる。AIエージェントSaaSとして本番展開する場合は、ユーザーあたりCPU秒数 × Active CPU単価で見積もるのが筋である。
+
+## CLI / API 例
+
+### wrangler.toml
+```toml
+name = "agent-sandbox"
+main = "src/index.ts"
+compatibility_date = "2026-04-01"
+
+[[containers]]
+class_name   = "Sandbox"
+image        = "./Dockerfile"
+instance_type = "basic"
+max_instances = 50
+
+[[durable_objects.bindings]]
+class_name = "Sandbox"
+name       = "Sandbox"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["Sandbox"]
+```
+
+### Worker 側コード（最小例）
+```ts
+import { getSandbox } from "@cloudflare/sandbox";
+export { Sandbox } from "@cloudflare/sandbox";
+
+type Env = { Sandbox: DurableObjectNamespace };
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const url = new URL(req.url);
+    const sandbox = getSandbox(env.Sandbox, "user-42-session");
+
+    if (url.pathname === "/run") {
+      // 1) シェル実行
+      const r = await sandbox.exec(`python3 -c "print(2 + 2)"`);
+      // 2) FS書き込み
+      await sandbox.writeFile("/workspace/hello.txt", "Hello, Sandbox!");
+      // 3) FS読み出し
+      const f = await sandbox.readFile("/workspace/hello.txt");
+      return Response.json({ stdout: r.stdout, exit: r.exitCode, file: f });
+    }
+
+    if (url.pathname === "/preview") {
+      // 4) コンテナ内でdev serverを起動し、Port Previewで公開
+      await sandbox.exec("npm --prefix /workspace/app run dev &");
+      const { url: previewUrl } = await sandbox.exposePort(3000);
+      return Response.json({ previewUrl });
+    }
+
+    return new Response("ok");
+  },
+};
+```
+
+### Streaming output
+```ts
+const stream = await sandbox.execStream("pytest -q");
+for await (const chunk of stream.stdout) {
+  controller.enqueue(chunk); // ReadableStreamに流してSSEでLLMやUIに転送
+}
+```
+
+### Code Interpreter（永続コンテキスト）
+```ts
+const ctx = await sandbox.createCodeContext("python");
+await sandbox.runCode(ctx, "import pandas as pd; df = pd.read_csv('/data/x.csv')");
+const summary = await sandbox.runCode(ctx, "df.describe().to_json()");
+```
+
+## 制限・注意点
+- 2026年4月時点でCore機能はGAだが、egress proxy / PTY / 一部スナップショット制御などはまだBeta扱いのものがある。APIシグネチャは v1.x で固まりつつあるが、SDKのChangelogは確認しておく。
+- GPUは現時点で非対応。GPUが必要なら Workers AI（Cloudflareホストモデル）か外部のModal / RunPod系と組み合わせる。
+- `exposePort()` で発行されるプレビューURLは、`*.workers.dev` ではなく自社のカスタムドメイン＋ワイルドカードDNSが必要。本番設計では最初から専用サブドメインを切る。
+- 同時実行は `max_instances` と各インスタンスタイプの並列上限で律速される。AIエージェントSaaSとして展開する場合、ユーザーあたり1コンテナ前提のスケール上限を必ず計算する。
+- Durable ObjectsのID単位でコンテナが固定されるため、特定ユーザーのセッションが特定リージョンにピン留めされる。グローバルレイテンシ均一化を期待してはいけない。
+- Egress proxy経由で資格情報を注入する場合、ドメイン別ポリシーの設計を最初に固めておかないと、エージェントが資格情報のスコープを越えて使い始めるリスクがある（プロンプトインジェクションでの権限昇格）。
+- スナップショットは便利だが、機密データを含んだままR2に残るためライフサイクル管理（保持期間・削除）はアプリ側で運用する。
+- ローカル開発時は `wrangler dev` でDocker経由のコンテナを起動する。CIでのE2Eテストは、コンテナビルド時間とR2モック有無を踏まえて設計する。
+
+## 参考リンク
+- Sandbox SDK Docs（Overview）：https://developers.cloudflare.com/sandbox/
+- Getting Started：https://developers.cloudflare.com/sandbox/get-started/
+- GitHub `cloudflare/sandbox-sdk`：https://github.com/cloudflare/sandbox-sdk
+- Blog: Agents have their own computers with Sandboxes GA：https://blog.cloudflare.com/sandbox-ga/
+- Blog: Sandboxing AI agents, 100x faster（Dynamic Workers）：https://blog.cloudflare.com/dynamic-workers/
+- Blog: Project Think：https://blog.cloudflare.com/project-think/
+- Product page: Cloudflare Sandboxes：https://workers.cloudflare.com/product/sandboxes
+- Cloudflare Containers Pricing：https://developers.cloudflare.com/containers/platform-details/pricing/
+- InfoQ: Cloudflare Sandboxes Reach GA：https://www.infoq.com/news/2026/04/cloudflare-sandboxes-ga/
+
+---
+参照日: 2026-05-04

--- a/src/content/knowledge/web-development/cloudflare-docs/71-secrets-store.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/71-secrets-store.mdx
@@ -1,0 +1,245 @@
+---
+title: "Cloudflare Secrets Store"
+description: "APIキー・トークン・DB接続文字列などの機密情報をCloudflareアカウント単位で一元的に暗号化保管し、Workers / AI Gateway などからbinding経由で参照する集中型シークレット管理サービスである。Worker単位で分散していたシークレットを「アカウント・スコープ」に引き上げ、複数Worker間の共有・更新・監査を一元化する。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 71
+---
+# Secrets Store
+
+## 一行サマリ
+APIキー・トークン・DB接続文字列などの機密情報をCloudflareアカウント単位で一元的に暗号化保管し、Workers / AI Gateway などからbinding経由で参照する集中型シークレット管理サービスである。Worker単位で分散していたシークレットを「アカウント・スコープ」に引き上げ、複数Worker間の共有・更新・監査を一元化する。
+
+## 解決する課題（Why）
+従来のCloudflare Workersでは、`wrangler secret put`によるWorker-scopedなシークレット管理（Workers Variables and Secrets）が標準であり、シークレットはWorkerごとに独立して保管されていた。これは小規模構成では十分だが、組織が成長すると次の問題が顕在化する。
+
+- 同じAPIキー（例：Stripe / OpenAI / Slack Webhook）を複数のWorkerで使うとき、Workerごとに同一値を`wrangler secret put`する必要があり、ローテーション時に取りこぼしが発生する。
+- どのWorkerにどのシークレットが入っているのかをアカウント横断で把握する手段がなく、棚卸し・離任者対応・コンプライアンス監査のコストが高い。
+- Worker-scopedシークレットは値そのものを後から取得できない（書き込み専用）ため、開発者が「どの値が設定されているか」を確認する手段がなく、ローテーション漏れの温床になる。
+- IaC化したい場合も、Worker単位でWrangler操作を繰り返す必要があり、シークレットの「単一の正本」を持てない。
+
+Cloudflare Secrets Storeはこれをアカウント・スコープの中央リポジトリ化することで解決する。Workerからは`store_id` + `secret_name`で参照し、ローテーションはStore側で1回行えば全Workerに即座に反映される。Audit Logsで作成・更新・削除・参照の履歴がアカウント単位で追跡可能になり、RBACで権限分離もできる。
+
+## 主要機能（What）
+
+### Account-scopeのSecret管理
+シークレットは`Store`という論理コンテナに格納され、Storeはアカウント単位で作成する。1アカウントあたり最大100シークレット（オープンベータ時点）が保持でき、各シークレット値は最大64 KiB（65,536 bytes）。Storeはダッシュボード・wrangler・REST API・Terraformから操作可能で、すべてのCloudflareデータセンターに暗号化された状態でレプリケートされる（中国ネットワークは現時点で対象外）。
+
+### Workers Binding
+`wrangler.toml`（または`wrangler.jsonc`）に`secrets_store_secrets`を宣言することで、Worker側からは通常のenv変数のように`env.<BINDING>.get()`で値を取得できる。binding時に`store_id`と`secret_name`を指定するため、Worker本体のデプロイをやり直さなくてもStore側で値を更新すれば次の実行から新しい値が反映される（=ローテーション時にWorker再デプロイ不要）。
+
+```toml
+[[secrets_store_secrets]]
+binding = "OPENAI_API_KEY"
+store_id = "<STORE_ID>"
+secret_name = "openai-prod"
+```
+
+### AI Gateway BYOK（Bring Your Own Keys）連携
+AI Gateway側からSecrets Storeに登録した各種AIプロバイダキー（OpenAI / Anthropic等）を`cf-aig-byok-alias`ヘッダで参照する仕組みが標準提供されている。これによりAI Gatewayの設定UIに直接APIキーを書かずに済み、複数キーのエイリアス切り替え（例：`default` / `team-a` / `team-b`）も実現できる。
+
+### Rotation（ローテーション）
+ローテーションは「Store側で値を更新する」だけで完了する。Worker再デプロイは不要で、binding経由の参照は次のリクエストから新しい値を返す。シークレット名（`secret_name`）は維持したまま、値だけを差し替えるのが基本パターン。複数のWorkerで同じ`secret_name`を参照していれば、1回の更新で全箇所が一括ローテーションされる。
+
+### Audit Logs
+アカウント標準のAudit Logs基盤と統合され、以下が記録される。
+
+- **Access**：シークレット値・メタ情報の参照
+- **Create**：新規作成（`duplicate`経由の場合は`duplicated_from_id`フィールド付き）
+- **Update**：メタ情報・値の更新（値そのものを更新した場合は`value_modified: true`が立つ）
+- **Delete**：削除
+
+これによりコンプライアンス監査（SOC2 / ISO 27001）で求められる「機密情報の操作履歴」をCloudflareプレーン内で完結させられる。
+
+### Access Control / RBAC
+4つの専用ロールが提供されており、開発者・運用者・閲覧者で権限を分離できる。
+
+| ロール | 値・メタの編集 | 値・メタの閲覧 | binding作成 | AI Gateway連携作成 |
+|---|---|---|---|---|
+| Super Administrator | 可 | 可 | 可 | 可 |
+| Secrets Store Admin | 可 | 可 | 不可 | 不可 |
+| Secrets Store Deployer | 不可 | メタのみ | 可 | 可 |
+| Secrets Store Reporter | 不可 | メタのみ | 不可 | 不可 |
+
+API Tokenスコープは`Account Secrets Store Edit`（編集）と`Account Secrets Store Read`（メタ閲覧）の2種類。CIから値を更新したい場合はEditを、参照棚卸し用途ならReadのみを発行する設計が原則。
+
+### REST API
+ダッシュボード操作はすべてREST APIにマップされており、IaC・CI連携が可能である。
+
+- `POST /accounts/{account_id}/secrets_store/stores` — Store作成
+- `GET /accounts/{account_id}/secrets_store/stores` — Store一覧
+- `POST /accounts/{account_id}/secrets_store/stores/{store_id}/secrets` — Secret作成（複数まとめて投入可）
+- `GET /accounts/{account_id}/secrets_store/stores/{store_id}/secrets` — Secret一覧
+- `PATCH /accounts/{account_id}/secrets_store/stores/{store_id}/secrets/{secret_id}` — 値・メタ更新（ローテーションの正攻法）
+- `POST /accounts/{account_id}/secrets_store/stores/{store_id}/secrets/{secret_id}/duplicate` — 別名複製（環境分離向け）
+- `DELETE /accounts/{account_id}/secrets_store/stores/{store_id}/secrets/{secret_id}` — 削除
+- `GET /accounts/{account_id}/secrets_store/quota` — クォータ確認
+
+### vs Workers Secrets（worker-scoped）
+| 観点 | Secrets Store（account-scoped） | Workers Secrets（worker-scoped） |
+|---|---|---|
+| スコープ | アカウント単位 | Worker単位 |
+| 共有 | 複数Workerから`store_id`+`secret_name`で共有可 | 共有不可（同値を各Workerに別途投入） |
+| ローテーション | Store側で1回更新→全Workerに即反映 | Workerごとに`wrangler secret put`を再実行 |
+| 値の閲覧 | メタ情報の参照可（権限次第） | 書き込み後は閲覧不可（write-only） |
+| Audit | アカウント標準のAudit Logsで一元管理 | 限定的（デプロイログ程度） |
+| RBAC | 専用ロール4種で分離 | アカウント全体の権限に従属 |
+| 適性 | 複数Workerで共有・本格運用 | 単一Worker・PoC・個人開発 |
+| Binding形式 | `[[secrets_store_secrets]]` | `[vars]` / `wrangler secret put` |
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- 同一APIキー（OpenAI / Anthropic / Stripe / Slack Webhook 等）を複数のWorkerやAI Gatewayで共有しているケース。ローテーション工数が桁で減る。
+- SOC2 / ISO 27001等のコンプライアンス監査で「機密情報のアクセス・変更ログ」「権限分離の証跡」が要件になっている組織。
+- 開発・ステージング・本番環境を別Worker（または別namespace）で構成しており、環境間で同じ正本シークレットを安全に複製したいケース。`duplicate` APIで明示的に派生関係を残せる。
+- AI Gatewayと組み合わせてAIプロバイダキーをチーム単位でエイリアス管理したい組織。BYOKフローが標準連携される。
+- IaC（Terraform / Pulumi）でCloudflare資産を管理しており、シークレットの単一の正本を持ちたいケース。
+
+### 適していないシーン
+- 単一Workerだけで完結し、シークレットも1〜2件しかない個人プロジェクト。`wrangler secret put`で十分で、Storeを別途設計するメリットが薄い。
+- アカウントあたり100件・値64 KiBの上限を超える、KMSキー本体・大規模クライアント証明書の保管。これらはAWS KMS / GCP KMS / HashiCorp Vault のHSM連携領域に寄せる。
+- 中国ネットワーク（Cloudflare China Network）で配信するWorkerが必須要件のケース。現時点で対象外。
+- HSM裏付けのキー操作（署名・暗号化API）が必要なケース。Secrets Storeは「値の保管・参照」が役割で、KMSのような演算プリミティブは提供しない。
+- ベータ段階のため本番のクリティカル経路（決済・認証の主要キー）を即座に全寄せするのは慎重に評価すべき。GA前提のSLAが必要ならVault / AWS Secrets Managerを並行運用する設計が無難。
+
+## 競合・代替
+
+| 観点 | Cloudflare Secrets Store | HashiCorp Vault | AWS Secrets Manager | GCP Secret Manager | Azure Key Vault | Doppler | 1Password Connect |
+|---|---|---|---|---|---|---|---|
+| 出自 | Cloudflare統合（Workers / AI Gateway） | OSS / Enterprise シークレット基盤の事実上の標準 | AWS マネージドシークレット | GCP マネージドシークレット | Azure マネージドキー / シークレット / 証明書 | DevOps向けSaaS（環境変数中心） | 1Password基盤の開発者向け配信 |
+| スコープ | アカウント単位 | namespace / path | アカウント / リージョン | プロジェクト | Vault単位 | Project / Config | Vault単位 |
+| 配信先 | Workers / AI Gateway（binding） | あらゆる経路（CLI / SDK / Agent） | AWSサービス全般 / SDK | GCPサービス全般 / SDK | Azureサービス全般 / SDK | あらゆるランタイム（Doppler CLI） | あらゆるランタイム（Connect Server） |
+| ローテーション | Store側更新で即時反映 | Dynamic Secrets / Lease | Lambda連携で自動ローテ | バージョン管理＋手動・自動 | バージョン管理＋自動 | Webhook / Integration | 手動寄り |
+| HSM / KMS | 非対応（暗号化方式は未公開） | Transit / Vault Enterprise HSM | KMS統合 | KMS統合 | HSM統合 | 非対応 | 非対応 |
+| Audit | アカウント Audit Logs統合 | 詳細監査ログ | CloudTrail | Cloud Audit Logs | Azure Monitor | あり | あり |
+| 料金最低帯 | Open Beta（無料） | OSS無料 / Enterprise有料 | $0.40 / secret / 月＋API課金 | $0.06 / version / 月＋API課金 | 標準は$0.03 / 10K操作 | Free（小規模） | Business以上の追加費用 |
+| 強み | Workers / AI Gatewayへのゼロ運用統合 | 機能網羅性・Dynamic Secrets | AWS統合の深さ | GCP統合の深さ | Azure統合・HSM | DX良好・多ランタイム対応 | パスワード基盤との一体運用 |
+| 弱み | KMSなし・件数100件・Beta | セルフホスト運用負荷 | コスト・AWS外配信は工夫要 | アクセス制御がIAMに従属 | 学習コスト | DevOps外用途は弱い | 開発者基盤としてはニッチ |
+
+Secrets Storeの位置づけは「Cloudflareプレーン上にWorkers / AI Gatewayと統合された軽量なAccount-scopedシークレット倉庫」であり、Vault / AWS Secrets Manager / GCP Secret Manager / Azure Key Vault が担う「マルチクラウド汎用シークレット基盤」「Dynamic Secrets」「HSM裏付け」の用途とは正面競合しない。Cloudflareエッジ上のワークロードに限れば、bindingの容易さと再デプロイ不要なローテーションで運用コストを大きく下げられるため、Cloudflare中心構成では第一選択になる。
+
+## 料金
+オープンベータ（Open Beta）期間中は無料で利用できる。Cloudflare公式ドキュメントには現時点で価格表は掲載されておらず、GA後の課金モデル（per-secret / per-API call）も明示されていない。同種サービスの相場（AWS Secrets Manager: $0.40/secret/月 + API課金、GCP Secret Manager: $0.06/version/月 + API課金）を踏まえると、GA後はストア件数とAPI呼び出し回数の従量帯が想定される。本番投入前にCloudflareダッシュボードの`Secrets Store → Plans`またはアカウントマネージャに最新の単価を必ず確認すること。
+
+## CLI / API 例
+
+### wrangler でStoreとSecretを作成
+```bash
+# Storeを作成（remote=本番リソース）
+npx wrangler secrets-store store create "prod-shared" --remote
+
+# Storeの一覧
+npx wrangler secrets-store store list
+
+# Secretを作成（scopes=workers でWorker binding向けに登録）
+npx wrangler secrets-store secret create <STORE_ID> \
+  --name openai-prod \
+  --scopes workers \
+  --remote
+# 値はプロンプトで標準入力から
+```
+
+### wrangler.toml にbindingを宣言
+```toml
+name = "ai-gateway-proxy"
+main = "src/index.ts"
+compatibility_date = "2026-04-01"
+
+[[secrets_store_secrets]]
+binding = "OPENAI_API_KEY"
+store_id = "<STORE_ID>"
+secret_name = "openai-prod"
+
+[[secrets_store_secrets]]
+binding = "ANTHROPIC_API_KEY"
+store_id = "<STORE_ID>"
+secret_name = "anthropic-prod"
+```
+
+### Workerコードからの参照
+```ts
+export interface Env {
+  OPENAI_API_KEY: SecretsStoreSecret;
+  ANTHROPIC_API_KEY: SecretsStoreSecret;
+}
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    // .get() は非同期。値はその場で復号されメモリ上に展開される
+    const apiKey = await env.OPENAI_API_KEY.get();
+
+    const upstream = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: await req.text(),
+    });
+
+    return new Response(upstream.body, {
+      status: upstream.status,
+      headers: upstream.headers,
+    });
+  },
+};
+```
+
+### REST APIでSecretをローテーション
+```bash
+# 値を差し替え（再デプロイ不要で全bindingに反映）
+curl -X PATCH \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{"value": "sk-new-rotated-key", "scopes": ["workers"]}' \
+  "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/secrets_store/stores/$STORE_ID/secrets/$SECRET_ID"
+
+# Storeのクォータ確認（残件数）
+curl -s -H "Authorization: Bearer $CF_API_TOKEN" \
+  "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/secrets_store/quota" \
+  | jq .
+
+# stagingにduplicateして派生関係を残す
+curl -X POST \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{"name": "openai-staging", "scopes": ["workers"]}' \
+  "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/secrets_store/stores/$STORE_ID/secrets/$SECRET_ID/duplicate"
+```
+
+### AI Gateway BYOK連携（参考）
+```bash
+# AI Gateway経由のリクエストでaliasを指定
+curl https://gateway.ai.cloudflare.com/v1/<ACCOUNT_ID>/<GATEWAY>/openai/chat/completions \
+  -H "Authorization: Bearer $CF_AIG_TOKEN" \
+  -H "cf-aig-byok-alias: team-a" \
+  -H "Content-Type: application/json" \
+  --data '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}'
+```
+
+## 制限・注意点
+- **オープンベータ**段階のため、SLA・GA後の料金・後方互換性が確定していない。クリティカル経路（決済・本番認証）への全面移行は慎重に評価する。
+- アカウントあたりの**シークレット件数は100件**（ベータ時点）、1値あたり**64 KiB**まで。これを超える要件はVault / AWS Secrets Managerに寄せる。
+- **KMS / HSM連携は未提供**。署名・暗号化APIなどキー演算プリミティブが必要な用途には不向き。Secrets Storeはあくまで「値の保管・参照」のレイヤである。
+- **Cloudflare China Network 非対応**。中国向け配信を必須とするWorkerは併用設計が必要。
+- 暗号化方式の詳細（鍵管理階層・カスタマーマネージドキーの可否）は公式ドキュメントで明示されておらず、「すべてのCloudflareデータセンターに暗号化保存」という記述に留まる。法令・契約上の要求がある場合は事前にCloudflare営業へ確認する。
+- シークレット名にスペース不可、`scopes`（現時点で実用的なのは`workers`）の指定が必要。binding時の`store_id`と`secret_name`はWorkerデプロイ時に検証されるため、タイポはデプロイ失敗で即時に検知される。
+- `env.BINDING.get()`は**非同期**呼び出し。同期的なグローバル定数参照のように扱うとTypeScript / 実行時の双方でハマる。値は呼び出しごとにキャッシュされる挙動を前提に、ホットパスでは関数内に閉じて再利用する。
+- Worker-scoped Secrets（`wrangler secret put`）は引き続き利用可能で、両者は併存できる。段階的移行する場合は「共有が必要なものから順にStoreへ寄せる」のが安全。
+- ローテーション時、古い値を参照していたコネクション・キャッシュが残ると一時的にエラーが出る場合がある。アプリ側でリトライ・401時の再取得ロジックを持たせるのが堅牢。
+- Audit Logsの保持期間はアカウントプランに依存（Enterprise以外は短い）。長期保管が要件ならLogpushでオブジェクトストレージ・SIEMへ転送する設計を併用する。
+
+## 参考リンク
+- Secrets Store Overview：https://developers.cloudflare.com/secrets-store/
+- Workers Integration：https://developers.cloudflare.com/secrets-store/integrations/workers/
+- Manage Secrets：https://developers.cloudflare.com/secrets-store/manage-secrets/
+- Access Control（RBAC）：https://developers.cloudflare.com/secrets-store/access-control/
+- Audit Logs：https://developers.cloudflare.com/secrets-store/audit-logs/
+- REST API（secrets_store）：https://developers.cloudflare.com/api/resources/secrets_store/
+- AI Gateway BYOK：https://developers.cloudflare.com/ai-gateway/configuration/bring-your-own-keys/
+- llms.txt（ドキュメント全体インデックス）：https://developers.cloudflare.com/secrets-store/llms.txt
+
+---
+参照日: 2026-05-04

--- a/src/content/knowledge/web-development/cloudflare-docs/72-workers-for-platforms.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/72-workers-for-platforms.mdx
@@ -1,0 +1,294 @@
+---
+title: "Cloudflare Workers for Platforms / Cloudflare for SaaS"
+description: "エンドユーザー（=自社プラットフォームの顧客）が書いたコードと、エンドユーザーが持ち込んだカスタムドメインを、自社のSaaS基盤に安全に乗せるための2製品である。Workers for Platformsはマルチテナントの「コード実行」を、Cloudflare for SaaSはマルチテナントの「ドメイン/SSL終端」をCloudflareエッジ上で代行する。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 72
+---
+# Workers for Platforms / Cloudflare for SaaS
+
+## 一行サマリ
+エンドユーザー（=自社プラットフォームの顧客）が書いたコードと、エンドユーザーが持ち込んだカスタムドメインを、自社のSaaS基盤に安全に乗せるための2製品である。Workers for Platformsはマルチテナントの「コード実行」を、Cloudflare for SaaSはマルチテナントの「ドメイン/SSL終端」をCloudflareエッジ上で代行する。
+
+## 解決する課題（Why）
+ShopifyやWebflow、Notion、ローコード/ノーコード、AIエージェントマーケットプレイスのようなマルチテナントSaaSを作る際、必ずぶつかる2つの壁がある。
+
+ひとつ目は「顧客のコードをどう動かすか」。各テナントが書いたJavaScript / TypeScript / WASMを安全に隔離し、テナント単位でCPU・サブリクエスト・メモリ制限を掛け、ログ/メトリクスをテナントID付きで吐き、AI生成コードのような信頼できないコードもサンドボックス化したい。FaaS（Lambda / Cloud Run）でテナントごとに関数を作る運用は数百テナントで破綻し、コールドスタート・関数数上限・IAMの複雑度が一気に重くなる。
+
+ふたつ目は「顧客のドメインをどう載せるか」。`shop.customer-brand.com` のように顧客の独自ドメインを自社SaaSに向けさせ、SSL証明書を自動発行・自動更新し、HTTPSの可用性をSaaS事業者側で保証したい。さらに金融・ヘルスケア向けにmTLS、エンタープライズ向けにApex（ルートドメイン）プロキシ、規制業種向けに自社IPレンジ（BYOIP）まで要求される。Let's Encrypt + 手動運用では数千テナント規模で確実に事故る。
+
+Workers for PlatformsとCloudflare for SaaSは、この2つの壁をCloudflareエッジに丸ごと押し出して解決する。
+
+- Workers for Platformsはdispatch namespace上で「親Worker（Dispatch Worker）→ 顧客Worker（User Worker）→ 共通の外向きWorker（Outbound Worker）」の3層を構成し、テナントコード実行・隔離・観測・送信ポリシーを一括で扱う。
+- Cloudflare for SaaSは顧客ドメインを `CNAME → customers.saas.example.com` で受け取り、Cloudflareがホストネーム検証・SSL証明書発行更新・SNIルーティング・mTLS・Apex proxying・BYOIPを代行する。
+- 両者を組み合わせると「顧客の独自ドメインで、顧客のコードを、Cloudflareエッジで実行する」マルチテナントSaaSが、自前のFaaS基盤・自前の証明書管理・自前のフロントロードバランサーなしで成立する。
+
+## 主要機能（What）
+
+### Workers for Platforms
+
+#### Dispatch namespace
+顧客Workerをまとめて格納する論理コンテナ。1つのSaaS事業者が `production` / `staging` のように複数namespaceを持ち、各namespace配下にテナント単位のUser Workerを並べる。`wrangler dispatch-namespace create` で作成し、Dispatch Workerからnamespace bindingで参照する。
+
+#### Dispatch Worker
+リクエストを最初に受ける親Worker。HostヘッダーやURLパス、JWT、テナントIDから対応するUser Workerを選び、`env.DISPATCHER.get(scriptName).fetch(request)` で動的にディスパッチする。認証・レート制限・課金カウント・テナント識別など「全テナント共通の前処理」をここに集約する。
+
+#### User Worker
+顧客自身（またはAI、テンプレートビルダー）が書いてアップロードする個別Worker。dispatch namespaceに `wrangler deploy --dispatch-namespace <ns>` でアップロードされ、Dispatch Workerから動的に呼ばれる。各User Workerは独立したIsolateで実行され、他テナントのKV・DO・環境変数・メモリには一切アクセスできない。Custom Limits（CPU時間・サブリクエスト数）をテナント単位で設定でき、暴走テナントが基盤を巻き込まない。
+
+#### Outbound Worker
+User Workerが外向き（fetch）するすべてのリクエストを横取りする「egress proxy Worker」。User Workerから直接外部APIを叩かれる代わりに、いったんOutbound Workerを経由させ、許可ドメインのallowlist、PII除去、共通ヘッダー注入、テナントIDのアウトバウンドログ、レート制限を掛けられる。AI生成コードを動かす前提なら事実上必須。
+
+#### Static Assets
+User Workerに静的ファイル（HTML / CSS / JS / 画像）をバンドルでき、Cloudflareエッジで直接配信される。テナントごとのテーマ・ビルド成果物をUser Workerと一緒にデプロイし、Origin不要のフルスタックSaaSが組める。
+
+#### Tags
+User Workerに任意のメタデータタグ（`customer_id:1234`、`plan:enterprise`、`region:apac`）を付与でき、API/wranglerからタグでフィルタリング・一括削除・観測対象の絞り込みが可能。テナント解約時に `tag=customer_id:1234` でまとめて削除、といった運用が一発で打てる。
+
+#### Custom Limits
+User Worker単位でCPU時間・サブリクエスト数の上限を上書きできる。Freeプランのテナントは50ms、Enterpriseテナントは300msのように、課金プランに応じた制限をプラットフォーム側から強制する。
+
+#### Observability
+全namespace横断でログ・メトリクス・トレースを収集し、Datadog / Splunk / Grafana / Logpushで吐ける。テナントIDタグと組み合わせ、どのテナントが何msのCPUを食ったかをそのまま課金システムに流せる。
+
+### Cloudflare for SaaS
+
+#### Custom Hostnames
+SaaS顧客の独自ドメイン（例：`shop.customer-brand.com`）を受け入れる中核機能。顧客側のDNSで `CNAME shop → customers.saas.example.com` を立てさせ、Cloudflareがホストネーム検証（CNAMEまたはHTTPトークン）→ 証明書発行 → ルーティングまで自動化する。SaaS事業者は API 1本（`POST /custom_hostnames`）で登録するだけで、SNI/Hostヘッダー単位のルーティングが裏で出来上がる。
+
+#### SSL for SaaS
+Custom Hostnameごとに自動発行されるTLS証明書。デフォルトはLet's Encrypt / Google Trust Services経由のDV証明書を自動発行・自動更新する。Enterpriseでは持ち込み証明書（BYO certificate）、CSR提出、CA選択、ワイルドカードカスタムホストネーム、Advanced Certificate Manager相当の機能が解放される。SaaS事業者側で「証明書が切れた」という事故を物理的に起こさないのが最大の価値。
+
+#### Fallback Origin
+すべてのCustom Hostname宛トラフィックの最終転送先となるオリジン1つ。プロキシ化されたA / AAAA / CNAMEで指定する。実運用ではこのfallback originをDispatch Worker（Workers for Platforms）にしておくのが定石で、ホスト名→テナント解決をWorker側で完結させる。
+
+#### Apex Proxying
+顧客が `customer-brand.com` のようなルートドメイン（apex / zone apex）をそのまま向けたい場合に使う。通常CNAMEはapexに張れないため、CloudflareがANAME相当のフラット化を行いCloudflareアドレスを返す。Enterprise限定アドオン。
+
+#### mTLS（Authenticated Origin Pulls / Client Certificates）
+2系統ある。(1) エッジ↔オリジン間mTLSで、SaaS事業者のオリジンに「Cloudflareから来た」ことを保証する Authenticated Origin Pulls。(2) エンドユーザー↔エッジ間mTLSで、Custom Hostnameごとにクライアント証明書検証を有効化し、API利用者ごとに証明書発行する。金融・医療・B2BのAPI SaaSで頻出。
+
+#### BYO Certificate
+顧客自身が用意したEV / OV証明書、またはSaaS事業者がDigiCertやEntrustで発行した証明書をアップロードして使う。Enterprise限定。規制業種・監査要件で「DV不可」のケースで必要になる。
+
+#### BYOIP（Bring Your Own IP）
+SaaS事業者が保有する/24以上のIPv4レンジ、または/48以上のIPv6レンジをCloudflareにBGPアナウンスさせる。顧客側ファイアウォールのIP allowlistにSaaS事業者のIP帯を登録するエンタープライズ要件、自社ブランドのIP評価維持、規制でCloudflare共有IPが使えない国・業種で必須となる。Enterpriseアドオン。
+
+## アーキテクト視点：いつ選ぶか
+
+### Workers for Platforms
+
+#### 適しているシーン
+- ノーコード / ローコード / CMS / ECビルダーが、テナント独自のサーバーロジック（カスタムチェックアウト、独自ルーティング、A/Bテストルール）をエッジで動かしたい。
+- AIエージェントマーケットプレイスやLLMツールホスティングで、ユーザー生成コード（あるいはLLM生成コード）をサンドボックス化して動かしたい。Outbound Workerで外向き先を制限する前提とセットで強力。
+- Shopify / Wix / Squarespace相当のSaaSで、テナントごとのEdge Functionsを提供する機能を後付けしたい。
+- 既にCloudflare Workersで自社プロダクトを動かしており、その上にテナント拡張機構を乗せたい。
+
+#### 適していないシーン
+- テナントが数十程度で、各テナントの拡張も限定的な規模。普通のWorkers + 環境変数 + KVで十分で、$25/月のWorkers for Platforms契約は過剰。
+- Node.js互換 / 長時間実行 / 大きなメモリが必要なワークロード。Workers Isolateの30秒CPU上限・128MBメモリでは足りない。Containers / Cloud Run / ECSが本筋。
+- 顧客コードが「信頼できる社内チームが書く」だけのケース。隔離不要なら通常のmulti-tenant Worker構成で良い。
+
+### Cloudflare for SaaS
+
+#### 適しているシーン
+- B2B / B2Cで「顧客が独自ドメインで自社サービスにアクセスする」体験を提供する全SaaS（EC、CMS、LMS、フォーラム、メールマーケ、サポートポータル、ヘルプセンター）。
+- 数千〜数万テナント規模でSSL証明書の自動更新を絶対に事故らせたくない。
+- 規制業種顧客にmTLS / BYO certificate / BYOIPを売り物として提供したい。
+- 既存のCustom Hostname自前実装（ACME自動化＋HAProxyでSNIルーティング）を運用負債として捨てたい。
+
+#### 適していないシーン
+- ドメインを自社で完全管理し、サブドメイン（`customer.saas.example.com`）方式で十分なケース。Cloudflare for SaaSのコストとEnterprise要件は不要で、普通のCloudflareゾーン + ワイルドカード証明書で足りる。
+- 顧客が極めて少数（数社）で、運用チームが手動証明書管理を許容できる。
+- 全テナントが同じドメイン階層を共有し、テナント識別がパスベース（`/tenant-a/`）で完結する場合。
+
+## 競合・代替
+
+| 観点 | Workers for Platforms | Cloudflare for SaaS | Vercel Spaces / Multi-tenant | Netlify Multi-tenant | Fastly Compute@Edge | AWS App Runner + ACM | Approximated.app |
+|---|---|---|---|---|---|---|---|
+| 主目的 | 顧客コードの実行隔離 | 顧客ドメイン/SSL代行 | 顧客プロジェクトのホスティング | 顧客サイトのホスティング | エッジ実行 | コンテナホスティング | Custom Hostname特化 |
+| マルチテナント設計 | Dispatch Worker明示モデル | Custom Hostname API | プロジェクト単位 | サイト単位 | 単一サービス内で実装 | サービス単位 | API一本 |
+| カスタムドメイン規模 | （別途SaaS要） | 数万〜無制限 | 数千 | 数千 | （別途実装） | ACM上限あり | 数千〜 |
+| SSL自動化 | （SaaS側） | 完全自動 / BYO / mTLS | Let's Encrypt自動 | Let's Encrypt自動 | 別途 | ACM | Let's Encrypt自動 |
+| 顧客コード実行 | Isolate（強隔離） | なし | Edge Functions | Edge Functions | 強隔離（Wasm） | コンテナ（VM境界） | なし |
+| AI生成コード適性 | Outbound Workerで本職 | 該当せず | 限定的 | 限定的 | 可能だが事例少 | 可能だが起動遅い | 該当せず |
+| Apex proxying | （SaaS側） | Enterpriseアドオン | 一部対応 | 一部対応 | 個別実装 | Route 53 ALIAS | 対応 |
+| BYOIP | （SaaS側） | Enterpriseアドオン | 不可 | 不可 | 可能（契約） | 一部対応 | 不可 |
+| mTLS | Worker側で実装可 | エッジで提供 | 限定的 | 限定的 | 可能 | NLBで実装 | 不可 |
+| 価格モデル | $25/月+従量 | プラン+ホスト名$0.10/月 | プロジェクト課金 | サイト課金 | 従量 | 時間/リクエスト課金 | 月額固定 |
+| Enterprise契約 | 不要（Standardから可） | 標準/Pro/Business/Enterprise | あり | あり | あり | AWS契約 | あり |
+
+VercelやNetlifyの「マルチテナントホスティング」は、SaaS事業者が自社プラットフォームを売る用途には機能が薄く、課金モデルもエンドユーザーごとに線形コストが乗る。AWS App Runner + ACMはコンテナ前提で起動が遅く、数千テナントの自動証明書発行ではACMの上限に引っかかりやすい。Approximated.appはCustom Hostname部分だけを切り出した特化サービスで、コード実行は持たない。Fastly Compute@EdgeはWasm隔離が強力だがdispatch namespace相当の「顧客Workerを動的にデプロイする」モデルは事業者側で組む必要がある。
+
+Cloudflareの強みは、「コード実行（Workers for Platforms）」と「ドメイン/SSL（Cloudflare for SaaS）」を別製品として独立して買え、両者を組み合わせるとマルチテナントSaaSのフロントエンドがほぼ完成する点にある。
+
+## 料金
+
+### Workers for Platforms
+- **Standard**：$25/月。月2000万リクエスト・6000万CPU-ms・1000スクリプト含み、超過分は100万リクエストあたり$0.30、CPU 100万msあたり$0.02、追加スクリプト1個あたり$0.02。Enterprise契約は不要で、課金が立てば誰でも使える。
+- **Custom Limits**：テナント単位でCPU/subrequest上限を設定する機能自体に追加課金はない。
+- **Subrequest**：課金対象外。Outbound Worker経由の外向きfetchも個別課金されない。
+- **Dispatch chain**：Dispatch Worker → User Worker → Outbound Workerの一連の呼び出しで「1リクエスト」としてカウントされる。
+
+### Cloudflare for SaaS
+- **Free / Pro / Business**：含み100ホスト名、超過は1ホスト名あたり$0.10/月。最大50,000ホスト名まで自助で扱える。
+- **Enterprise**：個別見積もり、50,000超のホスト名対応、Apex proxying / BYOIP / Custom certificates / CSR / CA選択 / ワイルドカードカスタムホストネーム / Custom metadataがアドオンで追加可能（具体額は非公開）。
+- **DV証明書発行**：自動発行・自動更新自体に追加課金なし。
+
+「数千テナントのSaaSをFree/Proベースで運用し、ホスト名$0.10/月だけがマージナルコスト」という構造は、独自ACME自動化＋自前ロードバランサーと比べて圧倒的に安い。Workers for Platformsと組み合わせても、$25/月＋ホスト名$0.10×N＋従量という極めて読みやすいコスト曲線になる。
+
+## CLI / API 例
+
+### Workers for Platforms：dispatch namespace 作成・User Worker デプロイ
+```bash
+# namespace作成
+npx wrangler dispatch-namespace create production
+
+# Dispatch Worker（自社管理）
+npx wrangler deploy --name dispatcher
+
+# User Worker をテナントcustomer-1234として namespace にデプロイ
+npx wrangler deploy \
+  --name customer-1234 \
+  --dispatch-namespace production \
+  --tag customer_id:1234 \
+  --tag plan:enterprise
+
+# タグ条件で一括削除（テナント解約時）
+npx wrangler dispatch-namespace delete-scripts production \
+  --tag customer_id:1234
+```
+
+Dispatch Worker側のコード例（要点のみ）：
+```ts
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const tenant = resolveTenant(request); // Hostヘッダー等から
+    const userWorker = env.DISPATCHER.get(tenant, {}, {
+      outbound: { tenant_id: tenant }, // Outbound Workerに渡される
+      limits: { cpuMs: 50 },
+    });
+    return userWorker.fetch(request);
+  },
+};
+```
+
+### Cloudflare for SaaS：Custom Hostname 登録
+```bash
+# 顧客ドメイン shop.customer-brand.com を登録、DV証明書を自動発行
+curl -X POST "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/custom_hostnames" \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "hostname": "shop.customer-brand.com",
+    "ssl": {
+      "method": "http",
+      "type": "dv",
+      "settings": {
+        "min_tls_version": "1.2",
+        "ciphers": ["ECDHE-ECDSA-AES128-GCM-SHA256"],
+        "http2": "on"
+      },
+      "bundle_method": "ubiquitous"
+    },
+    "custom_metadata": {
+      "tenant_id": "1234",
+      "plan": "enterprise"
+    }
+  }'
+
+# ホストネーム検証ステータス確認
+curl -X GET "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/custom_hostnames/$HOSTNAME_ID" \
+  -H "Authorization: Bearer $CF_API_TOKEN"
+```
+
+### Cloudflare for SaaS：mTLS（Custom Hostnameごとのクライアント証明書検証）
+```bash
+# クライアントCAを zone にアップロード
+curl -X POST "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/client_certificates" \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "certificate": "-----BEGIN CERTIFICATE-----\n...",
+    "private_key": "-----BEGIN PRIVATE KEY-----\n..."
+  }'
+
+# Custom Hostname に mTLS を有効化
+curl -X PATCH "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/custom_hostnames/$HOSTNAME_ID" \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "ssl": {
+      "settings": {
+        "tls_1_3": "on",
+        "min_tls_version": "1.2"
+      },
+      "type": "dv",
+      "method": "http"
+    },
+    "ssl_settings": { "client_certificate": true }
+  }'
+```
+
+### Terraform（cloudflare provider v5）
+```hcl
+resource "cloudflare_workers_for_platforms_dispatch_namespace" "prod" {
+  account_id = var.account_id
+  name       = "production"
+}
+
+resource "cloudflare_custom_hostname" "tenant_1234" {
+  zone_id  = var.zone_id
+  hostname = "shop.customer-brand.com"
+
+  ssl = {
+    method         = "http"
+    type           = "dv"
+    bundle_method  = "ubiquitous"
+    wildcard       = false
+    settings = {
+      min_tls_version = "1.2"
+      http2           = "on"
+    }
+  }
+
+  custom_metadata = {
+    tenant_id = "1234"
+    plan      = "enterprise"
+  }
+}
+```
+
+## 制限・注意点
+- **Workers for PlatformsはStandardプランから利用可能**だが、$25/月の固定費がベース。テナント数が極めて少ないPoC段階では、通常のWorkers + KVの方が安い。
+- **User Workerサイズ・CPU・メモリ制限はWorker本体と同じ**：圧縮後10MB、CPU 30秒（リクエストの場合）、メモリ128MB。Node.js全機能は使えず、`nodejs_compat` フラグで限定APIのみ。
+- **Outbound Workerは「全外向きfetchを横取り」**するため、設計を誤るとレイテンシ倍増・タイムアウト連鎖の温床になる。Outbound Worker内でさらに外部APIを呼ぶ際の二重カウント・二重タイムアウトに注意。
+- **Custom Hostnameの証明書発行レート**：1zoneあたり / 1日あたりの発行レートに上限があり、初回大量移行（数万テナント一括）では分割登録が必要。Enterprise契約でレート緩和を依頼するのが定石。
+- **DV証明書発行は顧客DNSに依存**：顧客側で `CNAME` 設定が誤っているとhostname validation pendingのまま証明書が発行されず、ステータス監視と顧客への通知UIをSaaS側で必ず作る。
+- **Apex proxyingはEnterpriseアドオン**：Pro/Businessプランでは顧客のapex（`customer-brand.com`）を直接向ける運用は不可で、サブドメイン誘導しかできない。エンタープライズ顧客の要望が出る前提なら最初からEnterpriseで設計する。
+- **BYOIPはBGP・LOA・RPKIの実務が必須**：単に契約すれば使えるわけではなく、IRR登録・LOA作成・ROA登録・段階的なBGPアナウンスが伴う。Cloudflare側との共同オペレーションが数週間単位で発生する。
+- **mTLS（Client Certificates）はSNI単位の証明書プール管理**：失効CRL/OCSPの設計、クライアント証明書発行フロー、ローテーション、失効時のテナント通知をSaaS側でフルに作り込む必要がある。
+- **Custom metadataはEnterpriseアドオン**：`custom_metadata` をWorkerから読み取れる便利機能だが、有償アドオン扱い。代替としてDispatch Worker側でテナントID→メタデータをKVで引く設計が現実的。
+- **Workers for PlatformsとCloudflare for SaaSは独立製品**：両方契約しないと「顧客ドメインで顧客コードを動かす」フルセットにはならない。料金見積もりで漏れやすい。
+- **両製品ともWorker / Custom Hostnameの上限値はEnterpriseで緩和できる**ものの、Free/Pro/Business段階で50,000ホスト名・1,000スクリプトを超える設計は早めにEnterprise相談に切り替える。
+- **Static Assets配信はUser Worker単位**：テナントごとに静的アセットを別バンドルでデプロイするとストレージとデプロイ時間が膨らむ。共通テーマはR2 + Cache APIに寄せる設計が安全。
+
+## 参考リンク
+- Workers for Platforms 概要：https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/
+- Workers for Platforms Get started：https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/get-started/configuration/
+- Workers for Platforms Pricing：https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/platform/pricing/
+- Outbound Workers：https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/configuration/outbound-workers/
+- Custom Limits：https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/configuration/custom-limits/
+- Cloudflare for SaaS 概要：https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/
+- Cloudflare for SaaS Get started：https://developers.cloudflare.com/cloudflare-for-saas/start/getting-started/
+- Cloudflare for SaaS Plans：https://developers.cloudflare.com/cloudflare-for-saas/plans/
+- Custom Hostnames API：https://developers.cloudflare.com/api/operations/custom-hostname-for-a-zone-create-custom-hostname
+- mTLS for SaaS：https://developers.cloudflare.com/cloudflare-for-saas/security/mtls/
+- Apex Proxying：https://developers.cloudflare.com/cloudflare-for-saas/start/advanced-settings/apex-proxying/
+- BYOIP：https://developers.cloudflare.com/byoip/
+- Terraform `cloudflare_custom_hostname`：https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/custom_hostname
+- Terraform `cloudflare_workers_for_platforms_dispatch_namespace`：https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/workers_for_platforms_dispatch_namespace
+
+---
+参照日: 2026-05-04

--- a/src/content/knowledge/web-development/cloudflare-docs/73-zaraz.mdx
+++ b/src/content/knowledge/web-development/cloudflare-docs/73-zaraz.mdx
@@ -1,0 +1,182 @@
+---
+title: "Cloudflare Zaraz"
+description: "GA4・Meta Pixel・TikTok Pixelなどの3rd-partyタグをブラウザではなくCloudflareエッジ（Worker）側で実行することで、ページのJavaScriptバンドルとサードパーティドメインへのリクエストを排し、Core Web Vitalsとプライバシーの両方を改善するサーバーサイド・タグマネージャである。"
+category: "web-development"
+subcategory: "cloudflare"
+createdAt: 2026-05-10
+sortOrder: 73
+---
+# Zaraz
+
+## 一行サマリ
+GA4・Meta Pixel・TikTok Pixelなどの3rd-partyタグをブラウザではなくCloudflareエッジ（Worker）側で実行することで、ページのJavaScriptバンドルとサードパーティドメインへのリクエストを排し、Core Web Vitalsとプライバシーの両方を改善するサーバーサイド・タグマネージャである。
+
+## 解決する課題（Why）
+Google Tag Manager（GTM）に代表される従来型のタグマネージャは、計測タグ・広告ピクセル・チャットボットの増加に応じてブラウザでロードするJSバンドルが肥大化し、結果としてLCP / INP / CLSを悪化させる。さらにサードパーティドメインに対する直接リクエストはAdblockerやITP / ETPで遮断され、計測の歩留まりも年々下がっている。Cloudflare Zarazはこれをエッジ実行モデルで置き換え、以下を解決する。
+
+- GA4 / Meta Pixel / TikTokなどのタグをCloudflare WorkerのCloud側で実行し、ブラウザ側のJSロードを最小化（多くは1ファイル数KBの`zaraz/i.js`のみ）。
+- サードパーティドメインへのリクエストを廃し、すべて自ドメイン（`/cdn-cgi/zaraz/...`）経由に集約。Adblocker・ITPの影響を抑え、計測の歩留まりを回復。
+- Consent Management Platform（CMP）を標準提供し、GDPR / ePrivacy対応のクッキー同意モーダルを設定UIから生成。
+- IPマスキング・ハッシュ化など、サーバーサイド経由ならではのプライバシー処理を集中管理。
+- Cloudflare上でホスティングしている場合、追加スクリプト埋め込み不要で自動注入される。
+
+## 主要機能（What）
+
+### Tools Library
+Zaraz Dashboardが提供するManaged Component（事前定義されたタグ）のカタログである。GA4 / Google Ads / Meta Pixel / Meta CAPI（Conversions API）/ TikTok Pixel / X (Twitter) / LinkedIn Insight / Microsoft Clarity / HubSpot / Hotjar / Intercom / Crisp など、主要な計測・広告・チャット系ツールがネイティブ対応している。各ツールはダッシュボードのフォームに測定IDやAPIキーを入れるだけで稼働する。
+
+- **Server-side（Conversions API系）対応**：Meta CAPIなど、本来サーバー間通信が必要なツールも、Zarazがサーバー側からEvent送信を行うため別途エンドポイント実装は不要。
+- **追加トークン・API Secret管理**：Zarazのツール設定UIでSecretを保管し、ブラウザに露出させない。
+
+### Triggers & Actions
+タグが「いつ」「何を」送るかを定義する仕組みである。
+
+- **Triggers**：Page Load / Click / Form Submission / Element Visibility / カスタムイベント（`zaraz.track('event_name', {...})`）など、発火条件を宣言的に設定。
+- **Actions**：Pageview / Event / E-commerce の3種に分類。各ツールごとにどのTriggerでどのActionを送るかをマトリクス的に紐付ける。
+- **Auto-actions**：GA4等の主要ツールではTrigger設定なしでもPageviewを自動送信する省力モードを提供。
+
+### Consent API / Consent Management Platform
+GDPR・ePrivacy指令に準拠したクッキー同意モーダルをノーコードで生成・運用する仕組みである。
+
+- **Purposes**：「広告計測」「行動分析」「機能向上」のような目的単位で同意を管理し、各ツールをいずれかのPurposeに紐付ける。
+- **Consent storage**：ユーザーの同意状態はファーストパーティCookieにJSON形式で保存される（purpose → true / false / undefined のマップ）。
+- **`zaraz.consent` API**：`zaraz.consent.set({...})` / `zaraz.consent.get(purposeId)` / `zaraz.showConsentModal()`等で、独自UIから同意状態を制御可能。
+- **未同意トリガーのキャッシュ**：同意前に発生したイベントは保留され、同意取得後にまとめて発火する。
+
+### Custom HTML / Managed Components SDK
+Tools Libraryに無いタグを独自に持ち込む経路である。
+
+- **Custom HTML Action**：従来のGTMライクに任意のHTML / JSスニペットを発火条件に応じてブラウザ側に注入。
+- **Custom Managed Component**：[Managed Components仕様](https://managedcomponents.dev/)に従って実装したコンポーネントをアップロードすれば、ブラウザを経由せずWorker内で完結するタグを自作できる。
+- **Workers Integration**：Cloudflare Worker内から`env.ZARAZ.track()`相当のbinding経由でサーバー側イベントを発火させ、Zarazに集約してから各ツールに配信できる。
+
+### Web Analytics 連携
+Cloudflare Web Analytics（プライバシーフレンドリーなRUM）とZarazは同じCloudflareプレーンで動作し、Zaraz経由でWeb Analyticsのイベントを送る・両方を同一ドメイン上で配信するといった統合運用が可能。Web Analyticsは`zaraz/...`の同一パスから配信されるため、Adblocker耐性を共有する。
+
+### Privacy 機能
+- **IPマスキング**：エッジでクライアントIPを匿名化（最後のオクテットを切り落とす等）してから3rd-partyに転送。
+- **Hashing**：Email / 電話番号などのPIIをSHA-256でハッシュ化してからMeta CAPI等へ送信する組み込み変換。
+- **Cookie書き換え**：3rd-party Cookieをファーストパーティ化（Zaraz経由で発行）し、ITP / ETPの寿命短縮を回避。
+
+## アーキテクト視点：いつ選ぶか
+
+### 適しているシーン
+- すでにCloudflareでZone（DNS / CDN）を運用しており、Webサイトの計測・広告タグをまとめてエッジに寄せたいケース。Workersの追加実装なしで自動注入される。
+- Core Web Vitals（特にLCP / INP）を改善する必要があるEC・メディアサイト。GTM由来の数十KB〜数百KBのJSをほぼゼロにできる。
+- Meta CAPI / Google Ads Enhanced Conversions など、サーバーサイド計測を本格導入したいが、別途タグサーバー（Stape等）を立てたくない組織。
+- GDPR / ePrivacy対応で同意モーダルを早急に整備したいヨーロッパ向けサービス。
+- Adblocker耐性を高めて計測歩留まりを上げたいD2C・広告運用の現場。
+
+### 適していないシーン
+- Cloudflareをプロキシとして通していない（DNSのみ運用）サイト。`/cdn-cgi/zaraz/`が利用できないため恩恵が薄い。
+- GTMで数百のカスタムタグ・トリガー資産を蓄積済みで、移行コストが高い大企業。Tools Library外のタグはCustom HTMLかManaged Component自作が必要。
+- 複数CDN・複数クラウド構成で、特定ベンダーへのタグ集約を避けたい組織。
+- Tealium iQ / Segment レベルのCDP的データルーティング・大規模オーディエンス管理が要件の組織。Zarazはタグマネージャ寄りで、CDPフル機能は持たない。
+
+## 競合・代替
+
+| 観点 | Cloudflare Zaraz | Google Tag Manager | Segment (Twilio) | RudderStack | Tealium iQ | Snowplow |
+|---|---|---|---|---|---|---|
+| 出自 | エッジWorker型タグマネージャ | クライアントサイドTM標準 | CDP / イベントルーティング | OSS版Segment | エンタープライズTM / CDP | OSS Behavioral Data Platform |
+| 実行場所 | Cloudflare Edge（Worker） | ブラウザ（GTM Server-side別） | サーバー（マネージド） | サーバー（OSS / Cloud） | ブラウザ + Server-side | 自前収集パイプライン |
+| ブラウザJS負荷 | 極小（数KB） | 大（数十〜数百KB） | 中（analytics.js） | 中 | 中〜大 | 中 |
+| Consent管理 | 標準同梱（CMP） | Consent Mode連携 | 別CMP前提 | 別CMP前提 | Tealium ConsentManager | 別CMP前提 |
+| 料金最低帯 | Free（月100K events） | Free | Free（1K MTU） | Free（OSS）/ Cloud有料 | 要見積もり | OSS無料 / SaaSは有料 |
+| 強み | エッジ統合・自動注入・CWV改善 | 普及度・ナレッジ量 | 統合先の多さ・CDPライク | OSSで自社ホスト可 | エンタープライズの成熟度 | 生データオーナーシップ |
+| 弱み | Tools Library外は自作必要 | バンドル肥大・Adblock影響 | コスト急増（MTU課金） | 運用負荷（OSS自前） | 高コスト・複雑 | 実装・運用の重さ |
+
+ZarazはGTMの「ブラウザJS実行」「Adblockに弱い」という弱点を構造的に解消する点で独自である。一方、Segment / RudderStack / Snowplowが担う「複数SaaSへのイベントFan-out」「データウェアハウスへの永続化」のレイヤとは目的が異なるため、CDP的用途では併用設計になることが多い。
+
+## 料金
+
+- **Free**：月10万events（Cloudflareアカウントあたり）まで無料。Tools Library・Triggers・Consent管理・Auto-actionsを含む基本機能は全て利用可能。
+- **Pro / Business（Workers Paid同様の従量帯）**：月100万events以上の規模で、超過分は$0.50 / 100K events 程度の従量課金（最新の単価はダッシュボードのBilling表示を参照）。Custom Managed ComponentやWorkers Bindingを本格活用するなら本帯以上が前提。
+- **Enterprise**：月数千万events〜のスケール、契約単位のEvent単価交渉、専用サポート、SLA、Audit Logの長期保管。大規模ECや広告主はここで設計する。
+
+events数の数え方は「ZarazがTrigger経由で発火したAction1件＝1event」が基本である。Pageviewの自動取得もevent数に算入されるため、`zaraz.track()`を細かく呼びすぎると無料枠を早く消費する点に注意する。最新の上限・単価はCloudflareダッシュボードの`Zaraz → Settings → Billing`で実数を必ず確認すること。
+
+## CLI / API 例
+
+### 設定の取得（REST API）
+ZarazにはCloud APIが用意されており、ダッシュボード設定をJSONとしてエクスポート・インポートできる。CI／環境間移送に有用。
+
+```bash
+# ZoneのZaraz設定（Tools / Triggers / Actions）を取得
+curl -s -H "Authorization: Bearer $CF_API_TOKEN" \
+  "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/settings/zaraz/config" \
+  | jq .
+
+# 設定を別環境（staging→prod）に流し込み
+curl -s -X PUT \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data @zaraz-config.json \
+  "https://api.cloudflare.com/client/v4/zones/$PROD_ZONE_ID/settings/zaraz/config"
+```
+
+### ブラウザからのEvent発火
+```html
+<script>
+  // カスタムイベント
+  zaraz.track('signup_completed', { plan: 'pro', amount: 29 });
+
+  // ユーザー属性のセット（Eコマースでの顧客紐付け）
+  zaraz.set('user_id', 'u_12345');
+
+  // E-commerce専用アクション
+  zaraz.ecommerce('Order Completed', {
+    order_id: 'o_98765',
+    total: 12800,
+    products: [{ sku: 'SKU-1', price: 6400, quantity: 2 }],
+  });
+
+  // 同意モーダルを再表示（フッタの「Cookie設定」リンクから呼ぶ等）
+  zaraz.showConsentModal();
+</script>
+```
+
+### Worker から zaraz.track()（Workers Integration）
+```ts
+// wrangler.toml で zaraz binding を有効化していれば、Worker側からも発火可能
+export default {
+  async fetch(req: Request, env: Env) {
+    // 例：A/B振り分け結果を計測
+    await env.ZARAZ.track('experiment_assigned', {
+      experiment: 'pricing-v2',
+      variant: 'B',
+    });
+    return new Response('ok');
+  },
+};
+```
+
+### Consent状態の取得
+```js
+// Purpose IDは Zaraz Dashboard で確認できる
+const analyticsConsent = zaraz.consent.get('analytics');
+if (analyticsConsent === true) {
+  // 同意済みの場合のみ独自計測を追加発火
+  zaraz.track('extra_analytics_event', {});
+}
+```
+
+## 制限・注意点
+- 月間event数の上限はプラン依存であり、`zaraz.track()`を細かく呼びすぎると無料枠（10万/月）を即座に消費する。重要イベントに絞って設計するのが原則。
+- Tools Libraryに無いタグはCustom HTMLかCustom Managed Componentで持ち込む必要があり、後者は[Managed Components仕様](https://managedcomponents.dev/)の理解が前提。Custom HTMLを多用するとサーバーサイド実行の利点が薄れる。
+- Auto-injectが有効でもCloudflareプロキシを経由しないドメイン（`gray cloud`）では`/cdn-cgi/zaraz/i.js`が配信されない。マルチサブドメイン構成では各Zoneでプロキシ設定を確認する。
+- サーバーサイド実行ゆえに、リアルタイム性を要求する一部の広告タグ（クリック単位の即時応答が必要な系）では数十〜数百msのエッジ往復遅延がボトルネックになることがある。Conversion計測のような非同期用途が本来の対象。
+- Consent未取得状態のイベントはキャッシュされて同意後に一括送信されるが、ユーザーが拒否を選んだ場合は破棄される。Adverse Selection的に「決して送られないevent」が常に発生する点は、レポート設計時に考慮する。
+- Audit / 詳細な実行ログはダッシュボード保持期間に依存。長期分析が要件ならLogpush（Enterprise）かWeb Analytics / Workers Analytics Engineへの自前出力を検討する。
+- IPマスキングやHashingは個別ツールごとの設定であり、デフォルトで全ツールに自動適用されるわけではない。プライバシー要件があるなら各タグ単位で明示的に有効化する。
+
+## 参考リンク
+- Zaraz Overview：https://developers.cloudflare.com/zaraz/
+- Get started：https://developers.cloudflare.com/zaraz/get-started/
+- Web API（track / set / ecommerce）：https://developers.cloudflare.com/zaraz/web-api/
+- Consent management：https://developers.cloudflare.com/zaraz/consent-management/
+- Managed Components仕様：https://managedcomponents.dev/
+- Cloudflare Zaraz product page：https://www.cloudflare.com/application-services/products/zaraz/
+- llms.txt（ドキュメント全体インデックス）：https://developers.cloudflare.com/zaraz/llms.txt
+
+---
+参照日: 2026-05-04

--- a/src/data/knowledge.ts
+++ b/src/data/knowledge.ts
@@ -116,6 +116,12 @@ export const subcategories: Partial<
       description:
         "Google Workspace 連携のサーバーレス JavaScript 実行環境。Spreadsheet / Gmail / Calendar の自動化",
     },
+    {
+      slug: "cloudflare",
+      label: "Cloudflare",
+      description:
+        "Connectivity Cloud 思想のエッジネットワーク。Workers / R2 / D1 / Durable Objects / Zero Trust / WAF / DNS をアーキテクト判断軸で整理",
+    },
   ],
 };
 

--- a/src/data/knowledgeTiers.ts
+++ b/src/data/knowledgeTiers.ts
@@ -340,6 +340,44 @@ export const knowledgeTiers: KnowledgeTierRegistry = {
       sortOrderStart: 90,
     },
   ],
+  /**
+   * Cloudflare の tier 構成は、knowledge-vault 側で整理された
+   * Tier 1: 開発者プラットフォーム中核 / Tier 2: Zero Trust /
+   * Tier 3: Network & Edge / Tier 4: その他 の 4 階層に、
+   * Overview / CLI を Getting Started として加えた構成。
+   */
+  "web-development/cloudflare": [
+    {
+      order: 1,
+      label: "Getting Started",
+      description: "Connectivity Cloud の全体像と CLI ツール群",
+      sortOrderStart: 0,
+    },
+    {
+      order: 2,
+      label: "Tier 1: 開発者プラットフォーム中核",
+      description: "Workers / Pages / R2 / D1 / KV / Durable Objects / Queues / Workers AI / AI Gateway / Vectorize / Hyperdrive / Stream / Images / Tunnel / Turnstile / Access / Workflows",
+      sortOrderStart: 10,
+    },
+    {
+      order: 3,
+      label: "Tier 2: Zero Trust",
+      description: "Browser Isolation / Gateway / DLP / CASB / DEX / Email Security",
+      sortOrderStart: 30,
+    },
+    {
+      order: 4,
+      label: "Tier 3: Network & Edge",
+      description: "WAF / DDoS / Rate Limiting / Bot Management / Argo / Magic Transit / Spectrum / Load Balancing / API Shield / Cache / Waiting Room",
+      sortOrderStart: 40,
+    },
+    {
+      order: 5,
+      label: "Tier 4: その他",
+      description: "DNS / Registrar / Email Routing / Containers / Radar / Pipelines / Secrets Store / Sandbox SDK / Workers for Platforms / Zaraz など",
+      sortOrderStart: 60,
+    },
+  ],
 };
 
 /** カテゴリ × サブカテゴリの tier 定義を取得 */

--- a/tests/data/knowledge.test.ts
+++ b/tests/data/knowledge.test.ts
@@ -48,11 +48,11 @@ describe("knowledge サブカテゴリデータ", () => {
     ]);
   });
 
-  it("web-development サブカテゴリに supabase / vercel / gas が含まれていること", () => {
+  it("web-development サブカテゴリに supabase / vercel / gas / cloudflare が含まれていること", () => {
     const webDev = subcategories["web-development"];
     expect(webDev).toBeDefined();
     const slugs = webDev?.map((s) => s.slug).sort();
-    expect(slugs).toEqual(["gas", "supabase", "vercel"]);
+    expect(slugs).toEqual(["cloudflare", "gas", "supabase", "vercel"]);
   });
 
   it("すべてのサブカテゴリに slug / label / description が存在すること", () => {


### PR DESCRIPTION
## Summary
Cloudflare のサービス群を「いつ・なぜ採用するか」のアーキテクト判断軸で整理した 50 章のナレッジを Web 開発カテゴリ配下に公開する。素材は knowledge-vault で先行整理されていたものを、本サイトの MDX フォーマットに変換し、tier グルーピングを適用した。

## 内訳

### Getting Started（2 章）
- 00 Cloudflare とは — Connectivity Cloud という思想
- 01 CLI ツール群（Wrangler / cf CLI / Terraform / Pulumi）

### Tier 1: 開発者プラットフォーム中核（17 章）
Workers / Pages / R2 / D1 / KV / Durable Objects / Queues / Workers AI / AI Gateway / Vectorize / Hyperdrive / Stream / Images / Tunnel / Turnstile / Access / Workflows

### Tier 2: Zero Trust（6 章）
Browser Isolation / CASB / DEX / DLP / Email Security / Gateway

### Tier 3: Network & Edge（11 章）
API Shield / Argo Smart Routing / Bot Management / Cache / DDoS / Load Balancing / Magic Transit & WAN / Rate Limiting / Spectrum / WAF / Waiting Room

### Tier 4: その他（14 章）
AI Search / Analytics & Logs / Containers / DNS / Email Routing / Pipelines / R2 Data Catalog / Radar / Realtime / Registrar / Sandbox SDK / Secrets Store / Workers for Platforms / Zaraz

## 共通テンプレート
各記事は以下の見出し構成で統一:
**一行サマリ / 解決する課題 / 主要機能 / アーキテクト視点（適しているシーン・適していないシーン）/ 競合・代替（AWS・GCP 等との比較表）/ 料金 / CLI 例 / 制限 / 参考リンク**

ツールの「使い方」ではなく「システム構築時の選定肢」として参照することを目的としている。

## 変更ファイル
- src/data/knowledge.ts: web-development サブカテゴリに cloudflare を追加
- src/data/knowledgeTiers.ts: web-development/cloudflare に 5 tier を追加
- src/content/knowledge/web-development/cloudflare-docs/: 50 mdx 新規作成

合計 +9,263 行 / 52 ファイル。

## Test plan
- [x] npm run check 0 errors / 0 warnings
- [x] npm run build 成功（dist 配下に 50 ページ生成確認）
- [x] tier 見出し（Getting Started / Tier 1 / Tier 2 / Tier 3 / Tier 4）が記事詳細ページのサイドバーで描画されることを HTML レベルで確認
- [ ] レビュー時に開発サーバーで本文の事実関係（料金・制限値の最新性）を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)