### PR TITLE
feat: Knowledge Base UI Phase 1 - 3カラム化・右TOC追従・左ナビ折りたたみ

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -5,8 +5,11 @@ import tailwindcss from "@tailwindcss/vite";
 import cloudflare from "@astrojs/cloudflare";
 import rehypeExternalLinks from "rehype-external-links";
 
+const proc = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process;
+const isTest = proc?.env?.VITEST === "true" || proc?.env?.NODE_ENV === "test";
+
 export default defineConfig({
-  adapter: cloudflare(),
+  ...(isTest ? {} : { adapter: cloudflare() }),
   markdown: {
     shikiConfig: {
       theme: "one-dark-pro",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "resend": "^6.10.0",
         "tailwind-merge": "^3.2.0",
         "tailwindcss": "^4.1.4",
+        "tocbot": "^4.36.8",
         "typescript": "^5.8.3",
         "zod": "^4.3.6"
       },
@@ -7225,6 +7226,12 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/tocbot": {
+      "version": "4.36.8",
+      "resolved": "https://registry.npmjs.org/tocbot/-/tocbot-4.36.8.tgz",
+      "integrity": "sha512-TpN+Z2YP4DTboeZ3GkUjzkjmG5NhJhXTVuH9EWQ/F4HgONVje9GZ8eNZE4kk88umV5o7hm3faS+eF/7qYwsP2w==",
+      "license": "MIT"
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "resend": "^6.10.0",
     "tailwind-merge": "^3.2.0",
     "tailwindcss": "^4.1.4",
+    "tocbot": "^4.36.8",
     "typescript": "^5.8.3",
     "zod": "^4.3.6"
   },

--- a/src/components/knowledge/ArticleSidebar.astro
+++ b/src/components/knowledge/ArticleSidebar.astro
@@ -52,19 +52,41 @@ const hasTiers = groups.some((g) => g.tier !== null);
   </a>
   {
     hasTiers ? (
-      <div class="space-y-5">
+      <div class="space-y-2">
         {groups.map((group) =>
           group.articles.length > 0 ? (
-            <div>
-              {group.tier && (
-                <h3 class="text-[11px] font-bold uppercase tracking-wide text-foreground/80 mb-2 flex items-center gap-2">
-                  <span class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-teal-500/10 text-teal-600 text-[10px] font-semibold">
+            <details
+              class="knowledge-sidebar-group group/tier"
+              open={
+                group.tier === null ||
+                group.articles.some((a) => a.slug === currentSlug)
+              }
+            >
+              <summary class="flex items-center gap-2 cursor-pointer select-none py-1.5 text-[11px] font-bold uppercase tracking-wide text-foreground/80 hover:text-teal-600 transition-colors list-none">
+                <svg
+                  class="w-3 h-3 transition-transform duration-200 group-open/tier:rotate-90 flex-shrink-0"
+                  viewBox="0 0 12 12"
+                  fill="none"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M4 3l4 3-4 3"
+                    stroke="currentColor"
+                    stroke-width="1.5"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+                {group.tier && (
+                  <span class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-teal-500/10 text-teal-600 text-[10px] font-semibold flex-shrink-0">
                     {group.tier.order}
                   </span>
-                  {group.tier.label}
-                </h3>
-              )}
-              <ol class="space-y-1 border-l border-border">
+                )}
+                <span class="flex-1">
+                  {group.tier ? group.tier.label : "記事一覧"}
+                </span>
+              </summary>
+              <ol class="mt-2 ml-1.5 space-y-1 border-l border-border">
                 {group.articles.map((article) => {
                   const isCurrent = article.slug === currentSlug;
                   return (
@@ -85,7 +107,7 @@ const hasTiers = groups.some((g) => g.tier !== null);
                   );
                 })}
               </ol>
-            </div>
+            </details>
           ) : null,
         )}
       </div>
@@ -116,3 +138,14 @@ const hasTiers = groups.some((g) => g.tier !== null);
     )
   }
 </nav>
+
+<style>
+  /* Safari など details summary のデフォルトマーカー除去 */
+  .knowledge-sidebar-group summary::-webkit-details-marker {
+    display: none;
+  }
+  .knowledge-sidebar-group summary::marker {
+    display: none;
+    content: "";
+  }
+</style>

--- a/src/components/knowledge/ArticleToc.astro
+++ b/src/components/knowledge/ArticleToc.astro
@@ -1,0 +1,154 @@
+---
+import type { MarkdownHeading } from "astro";
+import { getTocHeadings, type TocItem } from "@/utils/headings";
+
+interface Props {
+  headings: readonly MarkdownHeading[];
+  label?: string;
+}
+
+const { headings, label = "この記事の目次" } = Astro.props;
+const items: TocItem[] = getTocHeadings(headings);
+const hasItems = items.length > 0;
+---
+
+{
+  hasItems && (
+    <nav
+      aria-label={label}
+      class="knowledge-toc text-sm"
+      data-knowledge-toc
+    >
+      <p class="flex items-center gap-2 text-xs font-semibold text-foreground/70 mb-4">
+        <svg
+          class="w-4 h-4"
+          viewBox="0 0 16 16"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M2 3.5h12M2 8h12M2 12.5h8"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+          />
+        </svg>
+        目次
+      </p>
+      <ul class="knowledge-toc__list">
+        {items.map((item) => (
+          <li class="knowledge-toc__item">
+            <a
+              href={`#${item.slug}`}
+              class="knowledge-toc__link"
+              data-toc-link={item.slug}
+            >
+              {item.text}
+            </a>
+            {item.children.length > 0 && (
+              <ul class="knowledge-toc__list is-child">
+                {item.children.map((child) => (
+                  <li class="knowledge-toc__item">
+                    <a
+                      href={`#${child.slug}`}
+                      class="knowledge-toc__link is-child"
+                      data-toc-link={child.slug}
+                    >
+                      {child.text}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}
+
+<script>
+  import tocbot from "tocbot";
+
+  const SELECTOR = "[data-knowledge-toc]";
+
+  const init = () => {
+    const tocEl = document.querySelector(SELECTOR);
+    if (!tocEl) return;
+    const content = document.querySelector(".knowledge-prose");
+    if (!content) return;
+
+    tocbot.destroy();
+    tocbot.init({
+      tocSelector: SELECTOR + " > ul",
+      contentSelector: ".knowledge-prose",
+      headingSelector: "h2, h3",
+      hasInnerContainers: false,
+      collapseDepth: 6,
+      scrollSmooth: true,
+      scrollSmoothOffset: -80,
+      headingsOffset: 80,
+      activeLinkClass: "knowledge-toc__link--active",
+      listClass: "knowledge-toc__list",
+      linkClass: "knowledge-toc__link",
+      listItemClass: "knowledge-toc__item",
+      orderedList: false,
+    });
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+
+  document.addEventListener("astro:page-load", init);
+</script>
+
+<style is:global>
+  .knowledge-toc__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .knowledge-toc__item {
+    margin: 0;
+  }
+
+  .knowledge-toc__link {
+    display: block;
+    padding: 0.4rem 0 0.4rem 0.875rem;
+    margin-left: 0;
+    border-left: 2px solid transparent;
+    color: hsl(0 0% 55%);
+    line-height: 1.55;
+    font-size: 0.8125rem;
+    text-decoration: none;
+    transition:
+      color 0.15s ease,
+      border-color 0.15s ease;
+  }
+
+  .knowledge-toc__link:hover {
+    color: var(--color-foreground);
+  }
+
+  /* tocbot がネストした ul に自動付与する is-collapsed クラスでもインデントを効かせる */
+  .knowledge-toc__list .knowledge-toc__list,
+  .knowledge-toc__list ul {
+    padding-left: 0.875rem;
+  }
+
+  .knowledge-toc__link.is-child,
+  .knowledge-toc__list .knowledge-toc__list .knowledge-toc__link {
+    font-size: 0.78125rem;
+    color: hsl(0 0% 60%);
+  }
+
+  .knowledge-toc__link--active {
+    color: var(--color-foreground);
+    border-left-color: var(--color-primary);
+    font-weight: 600;
+  }
+</style>

--- a/src/layouts/KnowledgeLayout.astro
+++ b/src/layouts/KnowledgeLayout.astro
@@ -3,9 +3,11 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
 import Breadcrumb from "@/components/knowledge/Breadcrumb.astro";
 import Badge from "@/components/ui/Badge.astro";
 import ArticleSidebar from "@/components/knowledge/ArticleSidebar.astro";
+import ArticleToc from "@/components/knowledge/ArticleToc.astro";
 import { categories } from "@/data/knowledge";
 import type { KnowledgeTier } from "@/data/knowledgeTiers";
 import type { KnowledgeCategory } from "@/types";
+import type { MarkdownHeading } from "astro";
 
 interface SidebarArticle {
   slug: string;
@@ -37,6 +39,7 @@ interface Props {
   sidebarGroups: SidebarGroup[];
   previous: AdjacentArticle | null;
   next: AdjacentArticle | null;
+  headings?: readonly MarkdownHeading[];
 }
 
 const {
@@ -53,6 +56,7 @@ const {
   sidebarGroups,
   previous,
   next,
+  headings = [],
 } = Astro.props;
 
 const categoryMeta = categories.find((c) => c.slug === category);
@@ -107,13 +111,14 @@ const jsonLd = JSON.stringify({
   <Fragment slot="head">
     <script type="application/ld+json" set:html={jsonLd} />
   </Fragment>
-  <article class="py-20 px-4">
-    <div class="max-w-6xl mx-auto">
+  <article class="py-20 px-6 lg:px-10">
+    <div class="max-w-[1600px] mx-auto">
       <Breadcrumb items={breadcrumbItems} />
 
-      <div class="lg:flex lg:gap-10 lg:items-start">
+      <div class="lg:grid lg:grid-cols-[17rem_minmax(0,1fr)_15rem] lg:gap-10 lg:items-start">
         <aside
-          class="hidden lg:block lg:w-64 lg:flex-shrink-0 lg:sticky lg:top-24 lg:max-h-[calc(100vh-7rem)] lg:overflow-y-auto"
+          class="hidden lg:block lg:sticky lg:top-24 lg:max-h-[calc(100vh-7rem)] lg:overflow-y-auto"
+          aria-label="記事一覧"
         >
           <ArticleSidebar
             groups={sidebarGroups}
@@ -125,7 +130,7 @@ const jsonLd = JSON.stringify({
           />
         </aside>
 
-        <div class="flex-1 min-w-0 max-w-3xl">
+        <div class="min-w-0">
           <header class="mb-10">
             <div class="flex items-center gap-2 flex-wrap mb-4">
               <Badge variant="teal">{categoryLabel}</Badge>
@@ -214,6 +219,12 @@ const jsonLd = JSON.stringify({
             </a>
           </footer>
         </div>
+
+        <aside
+          class="hidden lg:block lg:sticky lg:top-24 lg:max-h-[calc(100vh-7rem)] lg:overflow-y-auto"
+        >
+          <ArticleToc headings={headings} />
+        </aside>
       </div>
     </div>
   </article>

--- a/src/pages/knowledge/[category]/[slug].astro
+++ b/src/pages/knowledge/[category]/[slug].astro
@@ -67,7 +67,7 @@ type Props = InferGetStaticPropsType<typeof getStaticPaths>;
 
 const { entry, currentSlug, sidebarGroups, previous, next } =
   Astro.props as Props;
-const { Content } = await render(entry);
+const { Content, headings } = await render(entry);
 ---
 
 <KnowledgeLayout
@@ -82,6 +82,7 @@ const { Content } = await render(entry);
   sidebarGroups={sidebarGroups}
   previous={previous}
   next={next}
+  headings={headings}
 >
   <Content />
 </KnowledgeLayout>

--- a/src/pages/knowledge/[category]/[subcategory]/[slug].astro
+++ b/src/pages/knowledge/[category]/[subcategory]/[slug].astro
@@ -91,7 +91,7 @@ const {
   previous,
   next,
 } = Astro.props as Props;
-const { Content } = await render(entry);
+const { Content, headings } = await render(entry);
 ---
 
 <KnowledgeLayout
@@ -108,6 +108,7 @@ const { Content } = await render(entry);
   sidebarGroups={sidebarGroups}
   previous={previous}
   next={next}
+  headings={headings}
 >
   <Content />
 </KnowledgeLayout>

--- a/src/pages/knowledge/[category]/[subcategory]/index.astro
+++ b/src/pages/knowledge/[category]/[subcategory]/index.astro
@@ -1,144 +1,66 @@
 ---
-import type { GetStaticPaths } from "astro";
+import type { GetStaticPaths, InferGetStaticPropsType } from "astro";
 import { getCollection } from "astro:content";
-import BaseLayout from "@/layouts/BaseLayout.astro";
-import SectionHeader from "@/components/ui/SectionHeader.astro";
-import Breadcrumb from "@/components/knowledge/Breadcrumb.astro";
-import ArticleCard from "@/components/knowledge/ArticleCard.astro";
 import { categories, subcategories } from "@/data/knowledge";
-import { getTiersFor } from "@/data/knowledgeTiers";
 import {
+  getPublishedArticles,
   getArticlesByCategoryAndSubcategory,
-  groupArticlesByTier,
-  toUnifiedFromInternal,
 } from "@/utils/knowledge";
-import type { CategoryMeta, SubcategoryMeta } from "@/types";
+import type { KnowledgeCategory } from "@/types";
 
-export const getStaticPaths: GetStaticPaths = async () => {
-  const paths: Array<{
-    params: { category: string; subcategory: string };
-    props: { category: CategoryMeta; subcategory: SubcategoryMeta };
-  }> = [];
+export const getStaticPaths = (async () => {
+  const allEntries = await getCollection("knowledge");
+  const published = getPublishedArticles(allEntries);
+  const validCategories = new Set(categories.map((c) => c.slug));
+
+  const paths: {
+    params: { category: KnowledgeCategory; subcategory: string };
+    props: { target: string };
+  }[] = [];
+
   for (const cat of categories) {
+    if (!validCategories.has(cat.slug)) continue;
     const subs = subcategories[cat.slug] ?? [];
     for (const sub of subs) {
+      const articles = getArticlesByCategoryAndSubcategory(
+        published,
+        cat.slug,
+        sub.slug,
+      );
+      if (articles.length === 0) continue;
+      const first = articles[0];
+      const firstSlug = first.id.split("/").pop() as string;
       paths.push({
         params: { category: cat.slug, subcategory: sub.slug },
-        props: { category: cat, subcategory: sub },
+        props: {
+          target: `/knowledge/${cat.slug}/${sub.slug}/${firstSlug}`,
+        },
       });
     }
   }
   return paths;
-};
+}) satisfies GetStaticPaths;
 
-interface Props {
-  category: CategoryMeta;
-  subcategory: SubcategoryMeta;
-}
-
-const { category, subcategory } = Astro.props;
-const allEntries = await getCollection("knowledge");
-const entries = getArticlesByCategoryAndSubcategory(
-  allEntries,
-  category.slug,
-  subcategory.slug,
-);
-const articles = entries.map(toUnifiedFromInternal);
-const tiers = getTiersFor(category.slug, subcategory.slug);
-const groups = tiers ? groupArticlesByTier(articles, tiers) : null;
+type Props = InferGetStaticPropsType<typeof getStaticPaths>;
+const { target } = Astro.props as Props;
 ---
 
-<BaseLayout
-  title={`${subcategory.label} | ${category.label} | Knowledge Base | shogoworks`}
-  description={subcategory.description}
->
-  <section class="py-20 px-4">
-    <div class="max-w-5xl mx-auto">
-      <Breadcrumb
-        items={[
-          { label: "Knowledge Base", href: "/knowledge" },
-          { label: category.label, href: `/knowledge/${category.slug}` },
-          { label: subcategory.label },
-        ]}
-      />
-
-      <SectionHeader
-        title={subcategory.label}
-        subtitle={subcategory.description}
-      />
-
-      {
-        articles.length === 0 ? (
-          <div class="text-center py-16 animate-on-scroll">
-            <p class="text-muted-foreground text-lg">
-              このサブカテゴリにはまだ記事がありません。
-            </p>
-            <a
-              href={`/knowledge/${category.slug}`}
-              class="inline-block mt-4 text-teal-600 hover:text-teal-700 transition-colors"
-            >
-              ← {category.label} に戻る
-            </a>
-          </div>
-        ) : groups ? (
-          <div class="space-y-12">
-            {groups.map((group) =>
-              group.articles.length > 0 ? (
-                <div>
-                  {group.tier && (
-                    <div class="mb-6">
-                      <h2 class="text-xl font-bold text-foreground flex items-baseline gap-3">
-                        <span class="inline-flex items-center justify-center w-9 h-9 rounded-full bg-teal-500/10 text-teal-600 text-sm font-semibold">
-                          {group.tier.order}
-                        </span>
-                        <span>{group.tier.label}</span>
-                      </h2>
-                      {group.tier.description && (
-                        <p class="text-sm text-muted-foreground mt-2 ml-12">
-                          {group.tier.description}
-                        </p>
-                      )}
-                    </div>
-                  )}
-                  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                    {group.articles.map((article, i) => (
-                      <div class={`animate-on-scroll stagger-${(i % 5) + 1}`}>
-                        <ArticleCard
-                          title={article.title}
-                          description={article.description}
-                          categoryLabel={subcategory.label}
-                          tags={article.tags}
-                          createdAt={article.createdAt}
-                          href={article.href}
-                          isExternal={article.isExternal}
-                          platform={article.platform}
-                        />
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              ) : null,
-            )}
-          </div>
-        ) : (
-          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {articles.map((article, i) => (
-              <div class={`animate-on-scroll stagger-${(i % 5) + 1}`}>
-                <ArticleCard
-                  title={article.title}
-                  description={article.description}
-                  categoryLabel={subcategory.label}
-                  tags={article.tags}
-                  createdAt={article.createdAt}
-                  href={article.href}
-                  isExternal={article.isExternal}
-                  platform={article.platform}
-                />
-              </div>
-            ))}
-          </div>
-        )
-      }
-    </div>
-  </section>
-</BaseLayout>
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="robots" content="noindex" />
+    <meta http-equiv="refresh" content={`0; url=${target}`} />
+    <link rel="canonical" href={target} />
+    <title>Redirecting…</title>
+    <script is:inline define:vars={{ target }}>
+      window.location.replace(target);
+    </script>
+  </head>
+  <body>
+    <p>
+      ページを移動しています…
+      <a href={target}>クリックしない場合はこちら</a>
+    </p>
+  </body>
+</html>

--- a/src/pages/knowledge/[category]/index.astro
+++ b/src/pages/knowledge/[category]/index.astro
@@ -23,7 +23,7 @@ interface Props {
   category: CategoryMeta;
 }
 
-const { category } = Astro.props;
+const { category } = Astro.props as unknown as Props;
 const allEntries = await getCollection("knowledge");
 const allCategoryArticles = mergeArticlesByCategory(
   externalArticles,

--- a/src/utils/headings.ts
+++ b/src/utils/headings.ts
@@ -1,0 +1,44 @@
+import type { MarkdownHeading } from "astro";
+
+export interface TocItem {
+  depth: number;
+  slug: string;
+  text: string;
+  children: TocItem[];
+}
+
+const MIN_DEPTH = 2;
+const MAX_DEPTH = 3;
+
+/**
+ * Astro の `render()` が返す MarkdownHeading[] から右TOC用の階層構造を作る。
+ * h2 を親、直後の h3 を子として束ねる。h1 と h4 以下は除外する。
+ */
+export function getTocHeadings(
+  headings: readonly MarkdownHeading[],
+): TocItem[] {
+  const filtered = headings.filter(
+    (h) => h.depth >= MIN_DEPTH && h.depth <= MAX_DEPTH,
+  );
+  const root: TocItem[] = [];
+  let lastH2: TocItem | null = null;
+
+  for (const h of filtered) {
+    const item: TocItem = {
+      depth: h.depth,
+      slug: h.slug,
+      text: h.text,
+      children: [],
+    };
+    if (h.depth === 2) {
+      root.push(item);
+      lastH2 = item;
+    } else if (lastH2) {
+      lastH2.children.push(item);
+    } else {
+      root.push(item);
+    }
+  }
+
+  return root;
+}

--- a/tests/build/astro-build.test.ts
+++ b/tests/build/astro-build.test.ts
@@ -11,6 +11,7 @@ describe("Astro build", () => {
         timeout: TIMEOUT,
         stdio: "pipe",
         maxBuffer: MAX_BUFFER,
+        env: { ...process.env, VITEST: "", NODE_ENV: "production" },
       });
     }).not.toThrow();
   }, TIMEOUT);
@@ -21,6 +22,7 @@ describe("Astro build", () => {
         timeout: TIMEOUT,
         stdio: "pipe",
         maxBuffer: MAX_BUFFER,
+        env: { ...process.env, VITEST: "", NODE_ENV: "production" },
       });
     }).not.toThrow();
   }, TIMEOUT);

--- a/tests/components/ArticleToc.test.ts
+++ b/tests/components/ArticleToc.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import ArticleToc from "@/components/knowledge/ArticleToc.astro";
+import type { MarkdownHeading } from "astro";
+
+let container: AstroContainer;
+
+beforeAll(async () => {
+  container = await AstroContainer.create();
+});
+
+const headings = (items: MarkdownHeading[]) => items;
+
+describe("ArticleToc.astro", () => {
+  it("renders a nav landmark with aria-label", async () => {
+    const html = await container.renderToString(ArticleToc, {
+      props: { headings: headings([{ depth: 2, slug: "intro", text: "Intro" }]) },
+    });
+    expect(html).toMatch(/<nav[^>]+aria-label="[^"]+"/);
+  });
+
+  it("renders anchor links pointing to heading slugs", async () => {
+    const html = await container.renderToString(ArticleToc, {
+      props: {
+        headings: headings([
+          { depth: 2, slug: "section-a", text: "Section A" },
+          { depth: 3, slug: "section-a-1", text: "Section A.1" },
+          { depth: 2, slug: "section-b", text: "Section B" },
+        ]),
+      },
+    });
+    expect(html).toContain('href="#section-a"');
+    expect(html).toContain('href="#section-a-1"');
+    expect(html).toContain('href="#section-b"');
+    expect(html).toContain("Section A");
+    expect(html).toContain("Section A.1");
+    expect(html).toContain("Section B");
+  });
+
+  it("nests h3 entries inside the preceding h2 list item", async () => {
+    const html = await container.renderToString(ArticleToc, {
+      props: {
+        headings: headings([
+          { depth: 2, slug: "parent", text: "Parent" },
+          { depth: 3, slug: "child", text: "Child" },
+        ]),
+      },
+    });
+    const parentIdx = html.indexOf("Parent");
+    const childIdx = html.indexOf("Child");
+    expect(parentIdx).toBeGreaterThan(-1);
+    expect(childIdx).toBeGreaterThan(parentIdx);
+    expect(html).toMatch(/<ul[^>]*>[\s\S]*<ul[^>]*>/);
+  });
+
+  it("renders nothing visible when there are no h2/h3 headings", async () => {
+    const html = await container.renderToString(ArticleToc, {
+      props: { headings: headings([{ depth: 1, slug: "h1", text: "H1" }]) },
+    });
+    expect(html).not.toContain("<a ");
+  });
+
+  it("excludes h1 and h4+ from the rendered links", async () => {
+    const html = await container.renderToString(ArticleToc, {
+      props: {
+        headings: headings([
+          { depth: 1, slug: "title", text: "Title" },
+          { depth: 2, slug: "ok", text: "OK" },
+          { depth: 4, slug: "too-deep", text: "TooDeep" },
+        ]),
+      },
+    });
+    expect(html).not.toContain('href="#title"');
+    expect(html).not.toContain('href="#too-deep"');
+    expect(html).toContain('href="#ok"');
+  });
+});

--- a/tests/utils/headings.test.ts
+++ b/tests/utils/headings.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { getTocHeadings } from "@/utils/headings";
+import type { MarkdownHeading } from "astro";
+
+const h = (depth: number, slug: string, text: string): MarkdownHeading => ({
+  depth,
+  slug,
+  text,
+});
+
+describe("getTocHeadings", () => {
+  it("returns empty array when given empty input", () => {
+    expect(getTocHeadings([])).toEqual([]);
+  });
+
+  it("includes h2 and h3, excludes h1/h4/h5/h6", () => {
+    const input: MarkdownHeading[] = [
+      h(1, "title", "Title"),
+      h(2, "intro", "Intro"),
+      h(3, "background", "Background"),
+      h(4, "detail", "Detail"),
+      h(5, "deeper", "Deeper"),
+      h(6, "deepest", "Deepest"),
+    ];
+    const result = getTocHeadings(input);
+    expect(result).toHaveLength(1);
+    expect(result[0].slug).toBe("intro");
+    expect(result[0].children).toHaveLength(1);
+    expect(result[0].children[0].slug).toBe("background");
+  });
+
+  it("nests consecutive h3 entries under the preceding h2", () => {
+    const input: MarkdownHeading[] = [
+      h(2, "a", "A"),
+      h(3, "a1", "A1"),
+      h(3, "a2", "A2"),
+      h(2, "b", "B"),
+      h(3, "b1", "B1"),
+    ];
+    const result = getTocHeadings(input);
+    expect(result.map((r) => r.slug)).toEqual(["a", "b"]);
+    expect(result[0].children.map((c) => c.slug)).toEqual(["a1", "a2"]);
+    expect(result[1].children.map((c) => c.slug)).toEqual(["b1"]);
+  });
+
+  it("places orphan h3 (no preceding h2) at root level", () => {
+    const input: MarkdownHeading[] = [
+      h(3, "orphan", "Orphan"),
+      h(2, "later", "Later"),
+      h(3, "child", "Child"),
+    ];
+    const result = getTocHeadings(input);
+    expect(result.map((r) => r.slug)).toEqual(["orphan", "later"]);
+    expect(result[0].children).toEqual([]);
+    expect(result[1].children.map((c) => c.slug)).toEqual(["child"]);
+  });
+
+  it("preserves heading text exactly", () => {
+    const input: MarkdownHeading[] = [h(2, "slug", "見出しテキスト")];
+    expect(getTocHeadings(input)[0].text).toBe("見出しテキスト");
+  });
+
+  it("does not mutate the input array", () => {
+    const input: MarkdownHeading[] = [h(2, "a", "A"), h(3, "a1", "A1")];
+    const snapshot = JSON.parse(JSON.stringify(input));
+    getTocHeadings(input);
+    expect(input).toEqual(snapshot);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from "vitest/config";
+import { getViteConfig } from "astro/config";
 import { fileURLToPath } from "node:url";
 
-export default defineConfig({
+export default getViteConfig({
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),


### PR DESCRIPTION
## Summary
- Knowledge Base 記事ページを 3カラム（左ナビ / 本文 / 右TOC）構成に刷新、最大幅 1600px へ拡張
- 右TOC（ArticleToc.astro）を新設し、tocbot でスクロール追従ハイライト
- 左サイドバーの tier セクションを `<details>` でトグル開閉式に（現在記事を含む tier のみ初期展開）
- サブカテゴリ index（例: `/knowledge/ai-tools/codex`）を最初の記事への meta-refresh リダイレクトに変更
- TOC スタイル: 薄グレー基調 + アクティブ項目に teal の縦バー・太字

## Test plan
- [x] `npm run test`: 88/88 グリーン（getTocHeadings + ArticleToc コンポーネントテスト新規追加）
- [x] `npx astro check`: 0 errors
- [x] `npm run build`: 本番ビルド成功
- [ ] `npm run dev` でローカル目視確認（3カラム表示、TOC スクロール追従、サイドバートグル、サブカテゴリ→記事リダイレクト）

🤖 Generated with [Claude Code](https://claude.com/claude-code)