### PR TITLE
feat: Knowledge Base UI Phase 2 - サブカテゴリ切替・進捗バッジ・description表示

### DIFF
--- a/src/components/knowledge/ArticleSidebar.astro
+++ b/src/components/knowledge/ArticleSidebar.astro
@@ -1,6 +1,7 @@
 ---
 import type { KnowledgeCategory } from "@/types";
 import type { KnowledgeTier } from "@/data/knowledgeTiers";
+import type { SubcategoryNavOption } from "@/utils/knowledge";
 
 interface SidebarArticle {
   slug: string;
@@ -22,6 +23,8 @@ interface Props {
   categorySlug: KnowledgeCategory;
   subcategorySlug?: string;
   subcategoryLabel?: string;
+  /** サブカテゴリ切替ドロップダウンの選択肢（任意） */
+  navOptions?: SubcategoryNavOption[];
 }
 
 const {
@@ -31,6 +34,7 @@ const {
   categorySlug,
   subcategorySlug,
   subcategoryLabel,
+  navOptions = [],
 } = Astro.props;
 
 const headingLabel = subcategoryLabel ?? categoryLabel;
@@ -41,9 +45,54 @@ const articleBasePath = subcategorySlug
   ? `/knowledge/${categorySlug}/${subcategorySlug}`
   : `/knowledge/${categorySlug}`;
 const hasTiers = groups.some((g) => g.tier !== null);
+const totalArticles = groups.reduce((sum, g) => sum + g.articles.length, 0);
+
+// navOptions をカテゴリ単位にまとめる（カテゴリ定義順は維持）
+const navGroups: { category: KnowledgeCategory; categoryLabel: string; options: SubcategoryNavOption[] }[] = [];
+for (const opt of navOptions) {
+  const last = navGroups[navGroups.length - 1];
+  if (last && last.category === opt.category) {
+    last.options.push(opt);
+  } else {
+    navGroups.push({
+      category: opt.category,
+      categoryLabel: opt.categoryLabel,
+      options: [opt],
+    });
+  }
+}
+const currentHref = headingHref;
 ---
 
 <nav class="text-sm" aria-label={`${headingLabel} の記事一覧`}>
+  {
+    navGroups.length > 0 && (
+      <div class="mb-4">
+        <label class="block text-[10px] font-semibold uppercase tracking-wider text-muted-foreground mb-1.5">
+          サブカテゴリ
+        </label>
+        <select
+          class="w-full text-sm rounded-md border border-border bg-background px-2.5 py-1.5 text-foreground focus:outline-none focus:ring-2 focus:ring-teal-500/40 focus:border-teal-500/60"
+          aria-label="サブカテゴリを切り替える"
+          onchange="if(this.value)window.location.href=this.value"
+        >
+          {navGroups.map((g) => (
+            <optgroup label={g.categoryLabel}>
+              {g.options.map((opt) => (
+                <option
+                  value={opt.href}
+                  selected={opt.href === currentHref}
+                >
+                  {opt.subcategoryLabel}
+                </option>
+              ))}
+            </optgroup>
+          ))}
+        </select>
+      </div>
+    )
+  }
+
   <a
     href={headingHref}
     class="block text-xs font-semibold uppercase tracking-wider text-muted-foreground hover:text-teal-600 transition-colors mb-3"
@@ -62,9 +111,9 @@ const hasTiers = groups.some((g) => g.tier !== null);
                 group.articles.some((a) => a.slug === currentSlug)
               }
             >
-              <summary class="flex items-center gap-2 cursor-pointer select-none py-1.5 text-[11px] font-bold uppercase tracking-wide text-foreground/80 hover:text-teal-600 transition-colors list-none">
+              <summary class="flex items-start gap-2 cursor-pointer select-none py-1.5 text-[11px] font-bold uppercase tracking-wide text-foreground/80 hover:text-teal-600 transition-colors list-none">
                 <svg
-                  class="w-3 h-3 transition-transform duration-200 group-open/tier:rotate-90 flex-shrink-0"
+                  class="w-3 h-3 mt-1 transition-transform duration-200 group-open/tier:rotate-90 flex-shrink-0"
                   viewBox="0 0 12 12"
                   fill="none"
                   aria-hidden="true"
@@ -78,13 +127,25 @@ const hasTiers = groups.some((g) => g.tier !== null);
                   />
                 </svg>
                 {group.tier && (
-                  <span class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-teal-500/10 text-teal-600 text-[10px] font-semibold flex-shrink-0">
+                  <span class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-teal-500/10 text-teal-600 text-[10px] font-semibold flex-shrink-0 mt-0.5">
                     {group.tier.order}
                   </span>
                 )}
-                <span class="flex-1">
-                  {group.tier ? group.tier.label : "記事一覧"}
+                <span class="flex-1 min-w-0">
+                  <span class="block">
+                    {group.tier ? group.tier.label : "記事一覧"}
+                  </span>
+                  {group.tier?.description && (
+                    <span class="block mt-0.5 text-[10px] font-normal normal-case tracking-normal text-muted-foreground/90 leading-snug line-clamp-2">
+                      {group.tier.description}
+                    </span>
+                  )}
                 </span>
+                {group.tier && (
+                  <span class="ml-2 mt-0.5 text-[10px] font-medium normal-case tracking-normal text-muted-foreground tabular-nums flex-shrink-0">
+                    {group.articles.length} / {totalArticles} 記事
+                  </span>
+                )}
               </summary>
               <ol class="mt-2 ml-1.5 space-y-1 border-l border-border">
                 {group.articles.map((article) => {

--- a/src/layouts/KnowledgeLayout.astro
+++ b/src/layouts/KnowledgeLayout.astro
@@ -5,6 +5,7 @@ import Badge from "@/components/ui/Badge.astro";
 import ArticleSidebar from "@/components/knowledge/ArticleSidebar.astro";
 import ArticleToc from "@/components/knowledge/ArticleToc.astro";
 import { categories } from "@/data/knowledge";
+import { getAllSubcategoryNavOptions } from "@/utils/knowledge";
 import type { KnowledgeTier } from "@/data/knowledgeTiers";
 import type { KnowledgeCategory } from "@/types";
 import type { MarkdownHeading } from "astro";
@@ -61,6 +62,7 @@ const {
 
 const categoryMeta = categories.find((c) => c.slug === category);
 const categoryLabel = categoryMeta?.label ?? category;
+const navOptions = getAllSubcategoryNavOptions();
 
 const articleBasePath = subcategorySlug
   ? `/knowledge/${category}/${subcategorySlug}`
@@ -127,6 +129,7 @@ const jsonLd = JSON.stringify({
             categorySlug={category}
             subcategorySlug={subcategorySlug}
             subcategoryLabel={subcategoryLabel}
+            navOptions={navOptions}
           />
         </aside>
 

--- a/src/utils/knowledge.ts
+++ b/src/utils/knowledge.ts
@@ -171,6 +171,35 @@ export function getSubcategories(
 }
 
 /**
+ * サブカテゴリ切替ドロップダウン等で使う、全カテゴリ×全サブカテゴリの
+ * フラットな選択肢リスト。カテゴリ定義順 → サブカテゴリ定義順で返す。
+ */
+export interface SubcategoryNavOption {
+  category: KnowledgeCategory;
+  categoryLabel: string;
+  subcategorySlug: string;
+  subcategoryLabel: string;
+  href: string;
+}
+
+export function getAllSubcategoryNavOptions(): SubcategoryNavOption[] {
+  const options: SubcategoryNavOption[] = [];
+  for (const cat of categories) {
+    const subs = subcategories[cat.slug] ?? [];
+    for (const sub of subs) {
+      options.push({
+        category: cat.slug,
+        categoryLabel: cat.label,
+        subcategorySlug: sub.slug,
+        subcategoryLabel: sub.label,
+        href: `/knowledge/${cat.slug}/${sub.slug}`,
+      });
+    }
+  }
+  return options;
+}
+
+/**
  * UnifiedArticle 配列を tier 単位でグループ化する。
  * tier 定義の各エントリの `sortOrderStart` をしきい値にして区切る。
  *

--- a/tests/components/ArticleSidebar.test.ts
+++ b/tests/components/ArticleSidebar.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import ArticleSidebar from "@/components/knowledge/ArticleSidebar.astro";
+import type { KnowledgeTier } from "@/data/knowledgeTiers";
+import type { SubcategoryNavOption } from "@/utils/knowledge";
+
+let container: AstroContainer;
+
+beforeAll(async () => {
+  container = await AstroContainer.create();
+});
+
+const tier1: KnowledgeTier = {
+  order: 1,
+  label: "Getting Started",
+  description: "全体像から始める",
+  sortOrderStart: 0,
+};
+const tier2: KnowledgeTier = {
+  order: 2,
+  label: "Concepts",
+  // description なし
+  sortOrderStart: 5,
+};
+
+const navOptions: SubcategoryNavOption[] = [
+  {
+    category: "ai-tools",
+    categoryLabel: "AI Tools",
+    subcategorySlug: "claude-code",
+    subcategoryLabel: "Claude Code",
+    href: "/knowledge/ai-tools/claude-code",
+  },
+  {
+    category: "ai-tools",
+    categoryLabel: "AI Tools",
+    subcategorySlug: "codex",
+    subcategoryLabel: "OpenAI Codex",
+    href: "/knowledge/ai-tools/codex",
+  },
+  {
+    category: "web-development",
+    categoryLabel: "Web開発",
+    subcategorySlug: "supabase",
+    subcategoryLabel: "Supabase",
+    href: "/knowledge/web-development/supabase",
+  },
+];
+
+const baseProps = {
+  currentSlug: "intro",
+  categoryLabel: "AI Tools",
+  categorySlug: "ai-tools" as const,
+  subcategorySlug: "claude-code",
+  subcategoryLabel: "Claude Code",
+  navOptions,
+};
+
+describe("ArticleSidebar.astro - dropdown navigation", () => {
+  it("正常系: navOptions の件数分の <option> をレンダリングすること", async () => {
+    const html = await container.renderToString(ArticleSidebar, {
+      props: {
+        ...baseProps,
+        groups: [{ tier: tier1, articles: [{ slug: "intro", title: "入門", sortOrder: 0 }] }],
+      },
+    });
+    expect(html).toContain('<select');
+    for (const opt of navOptions) {
+      expect(html).toContain(`value="${opt.href}"`);
+      expect(html).toContain(opt.subcategoryLabel);
+    }
+  });
+
+  it("正常系: <optgroup> でカテゴリラベルが表示されること", async () => {
+    const html = await container.renderToString(ArticleSidebar, {
+      props: {
+        ...baseProps,
+        groups: [{ tier: tier1, articles: [{ slug: "intro", title: "入門", sortOrder: 0 }] }],
+      },
+    });
+    expect(html).toMatch(/<optgroup[^>]+label="AI Tools"/);
+    expect(html).toMatch(/<optgroup[^>]+label="Web開発"/);
+  });
+
+  it("正常系: 現在のサブカテゴリの option に selected が付与されること", async () => {
+    const html = await container.renderToString(ArticleSidebar, {
+      props: {
+        ...baseProps,
+        groups: [{ tier: tier1, articles: [{ slug: "intro", title: "入門", sortOrder: 0 }] }],
+      },
+    });
+    expect(html).toMatch(
+      /<option[^>]+value="\/knowledge\/ai-tools\/claude-code"[^>]*selected/,
+    );
+  });
+});
+
+describe("ArticleSidebar.astro - progress badge", () => {
+  it("正常系: tier ありグループで 'X / Y 記事' バッジが表示されること", async () => {
+    const html = await container.renderToString(ArticleSidebar, {
+      props: {
+        ...baseProps,
+        groups: [
+          {
+            tier: tier1,
+            articles: [
+              { slug: "intro", title: "入門", sortOrder: 0 },
+              { slug: "second", title: "次", sortOrder: 1 },
+            ],
+          },
+          {
+            tier: tier2,
+            articles: [{ slug: "concept", title: "概念", sortOrder: 5 }],
+          },
+        ],
+      },
+    });
+    // Y = 全グループ合計 = 3
+    expect(html).toContain("2 / 3 記事");
+    expect(html).toContain("1 / 3 記事");
+  });
+
+  it("異常系: tier=null グループでは進捗バッジが出ないこと", async () => {
+    const html = await container.renderToString(ArticleSidebar, {
+      props: {
+        ...baseProps,
+        groups: [
+          {
+            tier: null,
+            articles: [{ slug: "intro", title: "入門", sortOrder: 0 }],
+          },
+        ],
+      },
+    });
+    // 進捗バッジ表記 "N / M 記事" は含まれないこと
+    expect(html).not.toMatch(/\d+\s*\/\s*\d+\s*記事/);
+  });
+});
+
+describe("ArticleSidebar.astro - tier description", () => {
+  it("正常系: description ありの tier では summary 内に description が表示される", async () => {
+    const html = await container.renderToString(ArticleSidebar, {
+      props: {
+        ...baseProps,
+        groups: [
+          { tier: tier1, articles: [{ slug: "intro", title: "入門", sortOrder: 0 }] },
+        ],
+      },
+    });
+    expect(html).toContain("全体像から始める");
+  });
+
+  it("異常系: description なしの tier では description ノードが出ないこと", async () => {
+    const html = await container.renderToString(ArticleSidebar, {
+      props: {
+        ...baseProps,
+        groups: [
+          { tier: tier2, articles: [{ slug: "x", title: "X", sortOrder: 5 }] },
+        ],
+      },
+    });
+    expect(html).not.toContain("全体像から始める");
+  });
+});
+
+describe("ArticleSidebar.astro - Phase 1 挙動の回帰", () => {
+  it("正常系: 現在記事の <a> に aria-current=page と teal クラスが付くこと", async () => {
+    const html = await container.renderToString(ArticleSidebar, {
+      props: {
+        ...baseProps,
+        currentSlug: "intro",
+        groups: [
+          {
+            tier: tier1,
+            articles: [
+              { slug: "intro", title: "入門", sortOrder: 0 },
+              { slug: "other", title: "別記事", sortOrder: 1 },
+            ],
+          },
+        ],
+      },
+    });
+    expect(html).toMatch(
+      /<a[^>]+href="\/knowledge\/ai-tools\/claude-code\/intro"[^>]*aria-current="page"/,
+    );
+    expect(html).toMatch(/border-teal-500[\s\S]*intro/);
+  });
+
+  it("正常系: hasTiers=false（全グループ tier=null）でフラットリストにフォールバックすること", async () => {
+    const html = await container.renderToString(ArticleSidebar, {
+      props: {
+        ...baseProps,
+        groups: [
+          {
+            tier: null,
+            articles: [
+              { slug: "a", title: "A", sortOrder: 0 },
+              { slug: "b", title: "B", sortOrder: 1 },
+            ],
+          },
+        ],
+      },
+    });
+    expect(html).not.toContain("<details");
+    expect(html).toContain("A");
+    expect(html).toContain("B");
+  });
+});

--- a/tests/utils/knowledge.test.ts
+++ b/tests/utils/knowledge.test.ts
@@ -4,6 +4,7 @@ import {
   getArticlesByCategory,
   getArticlesByCategoryAndSubcategory,
   getSubcategories,
+  getAllSubcategoryNavOptions,
   getAdjacentArticles,
   getAllTags,
   getArticlesByTag,
@@ -15,6 +16,7 @@ import {
   toUnifiedFromExternal,
   toUnifiedFromInternal,
 } from "@/utils/knowledge";
+import { categories, subcategories } from "@/data/knowledge";
 import type { ExternalArticle } from "@/types";
 
 interface MockEntry {
@@ -543,6 +545,55 @@ describe("getSubcategories", () => {
   it("正常系: サブカテゴリ未登録カテゴリのとき、空配列を返すこと", () => {
     const result = getSubcategories("career");
     expect(result).toEqual([]);
+  });
+});
+
+describe("getAllSubcategoryNavOptions", () => {
+  it("正常系: 全カテゴリ×全サブカテゴリの総数を返すこと", () => {
+    const expected = categories.reduce(
+      (sum, c) => sum + (subcategories[c.slug]?.length ?? 0),
+      0,
+    );
+    const result = getAllSubcategoryNavOptions();
+    expect(result).toHaveLength(expected);
+  });
+
+  it("正常系: href が /knowledge/{category}/{subcategory} 形式であること", () => {
+    const result = getAllSubcategoryNavOptions();
+    for (const opt of result) {
+      expect(opt.href).toBe(
+        `/knowledge/${opt.category}/${opt.subcategorySlug}`,
+      );
+    }
+  });
+
+  it("正常系: サブカテゴリ未定義カテゴリ（career）が含まれないこと", () => {
+    const result = getAllSubcategoryNavOptions();
+    expect(result.some((o) => o.category === "career")).toBe(false);
+  });
+
+  it("正常系: カテゴリ定義順 → サブカテゴリ定義順で返ること", () => {
+    const result = getAllSubcategoryNavOptions();
+    // 各カテゴリの開始 index がカテゴリ定義順に従う
+    const aiToolsIdx = result.findIndex((o) => o.category === "ai-tools");
+    const webDevIdx = result.findIndex((o) => o.category === "web-development");
+    expect(aiToolsIdx).toBeLessThan(webDevIdx);
+
+    // ai-tools 内ではサブカテゴリ定義順
+    const aiToolsSubs = result
+      .filter((o) => o.category === "ai-tools")
+      .map((o) => o.subcategorySlug);
+    const aiToolsDefinedOrder = subcategories["ai-tools"]?.map((s) => s.slug) ?? [];
+    expect(aiToolsSubs).toEqual(aiToolsDefinedOrder);
+  });
+
+  it("正常系: categoryLabel と subcategoryLabel がメタ情報と一致すること", () => {
+    const result = getAllSubcategoryNavOptions();
+    const claudeCode = result.find(
+      (o) => o.category === "ai-tools" && o.subcategorySlug === "claude-code",
+    );
+    expect(claudeCode?.categoryLabel).toBe("AI Tools");
+    expect(claudeCode?.subcategoryLabel).toBe("Claude Code");
   });
 });
 


### PR DESCRIPTION
## Summary
- 左 `ArticleSidebar` 上部に全カテゴリ × 全サブカテゴリの `<select>` + `<optgroup>` を追加し、別サブカテゴリへワンクリックで遷移できるようにした
- 各 tier の `<summary>` に「X / Y 記事」進捗バッジを表示（X = tier 内記事数、Y = サブカテゴリ全記事数）
- `tier.description` を `<summary>` 内に小さく表示し、tier の意図が読めるようにした
- Phase 1 の現在記事 teal 強調・`<details open>` ロジックは維持

## Changes
- `src/utils/knowledge.ts` — `getAllSubcategoryNavOptions()` と `SubcategoryNavOption` 型を追加
- `src/components/knowledge/ArticleSidebar.astro` — props に `navOptions` を追加、上部ドロップダウン・description・進捗バッジを実装
- `src/layouts/KnowledgeLayout.astro` — `navOptions` を Sidebar に渡す
- `tests/utils/knowledge.test.ts` — `getAllSubcategoryNavOptions` のユニットテスト
- `tests/components/ArticleSidebar.test.ts` — Astro Container API でコンポーネントテスト新規

## Test plan
- [x] `npm run test`（102 tests passed / Phase 2 新規 14 件含む）
- [x] `npx astro check`（0 errors / 0 warnings）
- [x] `npm run build`（成功）
- [ ] ローカル `npm run dev` で `/knowledge/ai-tools/claude-code/<記事>` を開き、ドロップダウン・進捗バッジ・description が表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)