### PR TITLE
feat: Knowledge Base UI Phase 3 - カテゴリトップのサブカテゴリカード強化

### DIFF
--- a/src/pages/knowledge/[category]/index.astro
+++ b/src/pages/knowledge/[category]/index.astro
@@ -9,6 +9,7 @@ import { categories, externalArticles } from "@/data/knowledge";
 import {
   mergeArticlesByCategory,
   getSubcategories,
+  getSubcategoryMetrics,
 } from "@/utils/knowledge";
 import type { CategoryMeta } from "@/types";
 
@@ -35,6 +36,17 @@ const articles = allCategoryArticles.filter(
   (a) => a.subcategory === undefined,
 );
 const subcategoryList = getSubcategories(category.slug);
+
+const subcategoryMetrics = subcategoryList.map((sub) => ({
+  meta: sub,
+  metrics: getSubcategoryMetrics(allEntries, category.slug, sub.slug),
+}));
+
+const dateFormatter = new Intl.DateTimeFormat("ja-JP", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+});
 ---
 
 <BaseLayout
@@ -59,17 +71,28 @@ const subcategoryList = getSubcategories(category.slug);
               サブカテゴリ
             </h2>
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-              {subcategoryList.map((sub) => (
+              {subcategoryMetrics.map(({ meta, metrics }) => (
                 <a
-                  href={`/knowledge/${category.slug}/${sub.slug}`}
-                  class="block p-5 rounded-2xl border border-border hover:border-teal-500/60 hover:bg-teal-50/30 transition-colors"
+                  href={`/knowledge/${category.slug}/${meta.slug}`}
+                  class="flex flex-col p-5 rounded-2xl border border-border hover:border-teal-500/60 hover:bg-teal-50/30 transition-colors"
                 >
                   <h3 class="font-semibold text-foreground mb-1">
-                    {sub.label}
+                    {meta.label}
                   </h3>
-                  <p class="text-sm text-muted-foreground line-clamp-2">
-                    {sub.description}
+                  <p class="text-sm text-muted-foreground line-clamp-2 mb-3">
+                    {meta.description}
                   </p>
+                  <div class="mt-auto flex items-center gap-2 flex-wrap text-[11px] text-muted-foreground">
+                    <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-teal-500/10 text-teal-700 font-medium tabular-nums">
+                      {metrics.articleCount}
+                      <span class="font-normal">記事</span>
+                    </span>
+                    {metrics.lastUpdatedAt && (
+                      <span class="tabular-nums">
+                        最終更新: {dateFormatter.format(metrics.lastUpdatedAt)}
+                      </span>
+                    )}
+                  </div>
                 </a>
               ))}
             </div>

--- a/src/utils/knowledge.ts
+++ b/src/utils/knowledge.ts
@@ -182,6 +182,38 @@ export interface SubcategoryNavOption {
   href: string;
 }
 
+/**
+ * カテゴリトップページのサブカテゴリカード等で使う、サブカテゴリ単位の集計情報。
+ *
+ * - `articleCount`: 公開状態の MDX 記事数（draft は除外）
+ * - `lastUpdatedAt`: 公開記事の `updatedAt ?? createdAt` の最大値。記事ゼロなら null
+ *
+ * 外部記事は subcategory を持たない仕様のため対象外。
+ */
+export interface SubcategoryMetrics {
+  articleCount: number;
+  lastUpdatedAt: Date | null;
+}
+
+export function getSubcategoryMetrics<T extends KnowledgeEntry>(
+  entries: T[],
+  category: KnowledgeCategory,
+  subcategory: string,
+): SubcategoryMetrics {
+  const matches = getPublishedArticles(entries).filter(
+    (e) =>
+      e.data.category === category && e.data.subcategory === subcategory,
+  );
+  if (matches.length === 0) {
+    return { articleCount: 0, lastUpdatedAt: null };
+  }
+  const lastUpdatedAt = matches.reduce<Date>((acc, e) => {
+    const d = e.data.updatedAt ?? e.data.createdAt;
+    return d.getTime() > acc.getTime() ? d : acc;
+  }, new Date(0));
+  return { articleCount: matches.length, lastUpdatedAt };
+}
+
 export function getAllSubcategoryNavOptions(): SubcategoryNavOption[] {
   const options: SubcategoryNavOption[] = [];
   for (const cat of categories) {

--- a/tests/utils/knowledge.test.ts
+++ b/tests/utils/knowledge.test.ts
@@ -5,6 +5,7 @@ import {
   getArticlesByCategoryAndSubcategory,
   getSubcategories,
   getAllSubcategoryNavOptions,
+  getSubcategoryMetrics,
   getAdjacentArticles,
   getAllTags,
   getArticlesByTag,
@@ -594,6 +595,106 @@ describe("getAllSubcategoryNavOptions", () => {
     );
     expect(claudeCode?.categoryLabel).toBe("AI Tools");
     expect(claudeCode?.subcategoryLabel).toBe("Claude Code");
+  });
+});
+
+describe("getSubcategoryMetrics", () => {
+  const entries: MockEntry[] = [
+    {
+      id: "ai-tools/agents/a",
+      data: {
+        title: "A",
+        description: "",
+        category: "ai-tools",
+        subcategory: "agents",
+        tags: [],
+        sortOrder: 0,
+        createdAt: new Date("2026-04-01"),
+        updatedAt: new Date("2026-04-15"),
+        draft: false,
+        author: "x",
+      },
+    },
+    {
+      id: "ai-tools/agents/b",
+      data: {
+        title: "B",
+        description: "",
+        category: "ai-tools",
+        subcategory: "agents",
+        tags: [],
+        sortOrder: 1,
+        createdAt: new Date("2026-04-10"),
+        // updatedAt なし
+        draft: false,
+        author: "x",
+      },
+    },
+    {
+      id: "ai-tools/agents/draft",
+      data: {
+        title: "Draft",
+        description: "",
+        category: "ai-tools",
+        subcategory: "agents",
+        tags: [],
+        sortOrder: 2,
+        createdAt: new Date("2026-05-01"),
+        updatedAt: new Date("2026-05-01"),
+        draft: true,
+        author: "x",
+      },
+    },
+    {
+      id: "ai-tools/other/c",
+      data: {
+        title: "C",
+        description: "",
+        category: "ai-tools",
+        subcategory: "other",
+        tags: [],
+        sortOrder: 0,
+        createdAt: new Date("2026-03-01"),
+        draft: false,
+        author: "x",
+      },
+    },
+  ];
+
+  it("正常系: 該当サブカテゴリの公開記事数を返すこと", () => {
+    const m = getSubcategoryMetrics(entries, "ai-tools", "agents");
+    expect(m.articleCount).toBe(2);
+  });
+
+  it("正常系: 最終更新日は (updatedAt ?? createdAt) の最大値を返すこと", () => {
+    const m = getSubcategoryMetrics(entries, "ai-tools", "agents");
+    // A.updatedAt=2026-04-15, B.createdAt=2026-04-10 → 2026-04-15
+    expect(m.lastUpdatedAt?.toISOString()).toBe(
+      new Date("2026-04-15").toISOString(),
+    );
+  });
+
+  it("異常系: 該当記事ゼロのとき articleCount=0 / lastUpdatedAt=null", () => {
+    const m = getSubcategoryMetrics(entries, "ai-tools", "none");
+    expect(m.articleCount).toBe(0);
+    expect(m.lastUpdatedAt).toBeNull();
+  });
+
+  it("異常系: draft 記事は count にも lastUpdatedAt にも含まれないこと", () => {
+    const m = getSubcategoryMetrics(entries, "ai-tools", "agents");
+    expect(m.articleCount).toBe(2);
+    // draft の 2026-05-01 が反映されない
+    expect(m.lastUpdatedAt?.getTime()).toBeLessThan(
+      new Date("2026-05-01").getTime(),
+    );
+  });
+
+  it("正常系: 他カテゴリ/他サブカテゴリの記事が混入しないこと", () => {
+    const m = getSubcategoryMetrics(entries, "ai-tools", "other");
+    expect(m.articleCount).toBe(1);
+    expect(m.lastUpdatedAt?.toISOString()).toBe(
+      new Date("2026-03-01").toISOString(),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- カテゴリトップ `/knowledge/[category]/index.astro` のサブカテゴリカードに「記事数」「最終更新日」バッジを追加
- 新規 util `getSubcategoryMetrics()` を追加（公開記事のみ、`updatedAt ?? createdAt` の最大値）
- サブカテゴリ index ページのリダイレクト（Phase 1 挙動）は維持

## Changes
- `src/utils/knowledge.ts` — `getSubcategoryMetrics()` と `SubcategoryMetrics` 型を追加
- `src/pages/knowledge/[category]/index.astro` — カードに記事数バッジ + 最終更新日を表示。flex 化して下端揃え
- `tests/utils/knowledge.test.ts` — 5 ケース追加（公開記事のみ集計・最終更新日の合成ロジック・draft 除外・他カテゴリ混入なし）

## Test plan
- [x] `npm run test` 107 / 107 passed（Phase 3 新規 5 件）
- [x] `npx astro check` 0 errors / 0 warnings
- [x] `npm run build` 成功
- [ ] ローカル `npm run dev` で `/knowledge/ai-tools` を開き、各サブカテゴリカードに記事数と最終更新日が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)