### PR TITLE
feat: Knowledge Base UI Phase 4 - ロードマップページ新設

### DIFF
--- a/src/data/roadmap.ts
+++ b/src/data/roadmap.ts
@@ -1,0 +1,140 @@
+/**
+ * ロードマップ（目的別学習パス）のデータ定義。
+ *
+ * 編集容易性を最優先し、各 step は `ref` 文字列だけを持つ。
+ * `ref` は Astro Content Collection の id（拡張子なし）と一致させる。
+ * 例: "prompt-engineering/few-shot-prompting" / "web-development/cloudflare-docs/00-overview"
+ *
+ * 未解決 ref / draft 記事への ref は `resolveRoadmap` が throw するため、
+ * ビルド時 (`astro build`) に検出される。
+ */
+
+export interface RoadmapStep {
+  /** Astro Content Collection の id（拡張子なし） */
+  ref: string;
+  /** 1 行コメント（その記事を勧める理由） */
+  note: string;
+}
+
+export interface RoadmapPath {
+  /** ページ内アンカー兼識別子（kebab-case） */
+  id: string;
+  title: string;
+  description: string;
+  steps: RoadmapStep[];
+}
+
+export const roadmapPaths: RoadmapPath[] = [
+  {
+    id: "prompt-context-mastery",
+    title: "プロンプト & コンテキスト設計を体系で学ぶ",
+    description:
+      "AI に意図通りの出力をさせるためのプロンプト工学と、長い対話・大規模ドキュメントを破綻させないコンテキスト工学を、入門から実装まで一気通貫で押さえる学習パスです。",
+    steps: [
+      {
+        ref: "prompt-engineering/prompt-engineering-complete-guide",
+        note: "プロンプト工学の全体マップ。まずここで地図を持つ。",
+      },
+      {
+        ref: "prompt-engineering/zero-shot-prompting",
+        note: "最も基本のゼロショット。前提と限界を押さえる。",
+      },
+      {
+        ref: "prompt-engineering/few-shot-prompting",
+        note: "事例を渡して精度を上げる、実務で最頻出のテクニック。",
+      },
+      {
+        ref: "prompt-engineering/chain-of-thought",
+        note: "推論ステップを明示させる CoT。複雑なタスクで効く。",
+      },
+      {
+        ref: "context-engineering/context-engineering-complete-guide",
+        note: "コンテキスト工学の全体像。プロンプトの「外側」を設計する視点。",
+      },
+      {
+        ref: "context-engineering/context-window-management",
+        note: "ウィンドウ制約と圧縮戦略。長い対話を成立させる土台。",
+      },
+      {
+        ref: "context-engineering/rag-architecture",
+        note: "RAG の基本構造。社内ドキュメントを LLM に食わせる定番。",
+      },
+      {
+        ref: "context-engineering/memory-systems",
+        note: "短期・長期メモリの設計。エージェント時代の必須トピック。",
+      },
+    ],
+  },
+  {
+    id: "harness-engineering",
+    title: "AI エージェントを現場運用に乗せる（Harness Engineering）",
+    description:
+      "個人利用の Claude Code / Codex を、チームや本番運用に耐える「ハーネス」として整える方法を、設計原則から CI/CD まで段階的に学ぶパスです。",
+    steps: [
+      {
+        ref: "harness-engineering/harness-engineering-complete-guide",
+        note: "ハーネス工学の全体像。なぜ「単なるプロンプト集」では足りないか。",
+      },
+      {
+        ref: "harness-engineering/agents-md-design",
+        note: "AGENTS.md / CLAUDE.md の設計。エージェントの行動規範を文書化する。",
+      },
+      {
+        ref: "harness-engineering/hooks-feedback-loops",
+        note: "フックでフィードバックループを閉じる。自動検証の土台。",
+      },
+      {
+        ref: "harness-engineering/sub-agent-patterns",
+        note: "サブエージェント分割。責務の切り出しと並列化のパターン。",
+      },
+      {
+        ref: "harness-engineering/tdd-with-agents",
+        note: "エージェントと TDD。失敗するテストを先に書かせるワークフロー。",
+      },
+      {
+        ref: "harness-engineering/ci-cd-guardrails",
+        note: "CI/CD ガードレール。本番マージ前の自動検証を組む。",
+      },
+      {
+        ref: "harness-engineering/team-harness-sharing",
+        note: "チームでのハーネス共有。スキル・コマンドを資産化する。",
+      },
+    ],
+  },
+  {
+    id: "cloudflare-supabase-launch",
+    title: "Web サービスを Cloudflare + Supabase で立ち上げる",
+    description:
+      "個人開発でフロント／バックエンド／DB／ストレージを最短で公開するための、Cloudflare Pages・Workers と Supabase の組み合わせを学ぶパスです。",
+    steps: [
+      {
+        ref: "web-development/cloudflare-docs/00-overview",
+        note: "Cloudflare 製品群の俯瞰。どこに何を置くかの判断材料。",
+      },
+      {
+        ref: "web-development/cloudflare-docs/17-pages",
+        note: "Pages で静的・SSR を素早く公開する基本。",
+      },
+      {
+        ref: "web-development/cloudflare-docs/24-workers",
+        note: "Workers でエッジ実行する API・ミドルウェアの作り方。",
+      },
+      {
+        ref: "web-development/cloudflare-docs/12-d1",
+        note: "D1 のサーバレス SQLite。小〜中規模なら主役を張れる。",
+      },
+      {
+        ref: "web-development/cloudflare-docs/19-r2",
+        note: "R2 のオブジェクトストレージ。エグレス無料が効く。",
+      },
+      {
+        ref: "web-development/supabase-docs/10-overview-landscape",
+        note: "Supabase の全体像。Postgres ベースの BaaS をどう使い分けるか。",
+      },
+      {
+        ref: "web-development/supabase-docs/21-auth",
+        note: "Supabase Auth。認証・認可を最短で乗せる方法。",
+      },
+    ],
+  },
+];

--- a/src/pages/knowledge/index.astro
+++ b/src/pages/knowledge/index.astro
@@ -28,6 +28,46 @@ function getCategoryLabel(slug: string): string {
         subtitle="AI活用・Web開発・DevOpsなど、実践的な技術ナレッジを発信しています"
       />
 
+      <a
+        href="/knowledge/roadmap"
+        class="group block mb-10 animate-on-scroll"
+      >
+        <div
+          class="rounded-3xl p-6 md:p-7 bg-gradient-to-r from-teal-50 to-emerald-50 ring-1 ring-teal-500/20 hover:ring-teal-500/40 transition-all"
+        >
+          <div class="flex items-start gap-4">
+            <div
+              class="w-12 h-12 rounded-2xl bg-gradient-to-br from-teal-500 to-emerald-500 flex items-center justify-center text-2xl shrink-0"
+              aria-hidden="true"
+            >
+              🧭
+            </div>
+            <div class="flex-1 min-w-0">
+              <div class="flex items-center gap-2 mb-1">
+                <h3
+                  class="text-lg font-semibold text-foreground group-hover:text-teal-700 transition-colors"
+                >
+                  ロードマップから始める
+                </h3>
+                <span
+                  class="text-xs text-teal-700 bg-white/70 px-2 py-0.5 rounded-full"
+                  >推奨</span
+                >
+              </div>
+              <p class="text-sm text-muted-foreground line-clamp-2">
+                目的別に「何をどの順で読むか」を整理した学習パス。プロンプト工学・ハーネス工学・Web
+                構築などのコースを用意しています。
+              </p>
+            </div>
+            <span
+              aria-hidden="true"
+              class="shrink-0 text-teal-600 group-hover:translate-x-1 transition-transform mt-1"
+              >→</span
+            >
+          </div>
+        </div>
+      </a>
+
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
         {
           categories.map((category, i) => (

--- a/src/pages/knowledge/roadmap.astro
+++ b/src/pages/knowledge/roadmap.astro
@@ -1,0 +1,110 @@
+---
+import { getCollection } from "astro:content";
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import SectionHeader from "@/components/ui/SectionHeader.astro";
+import Card from "@/components/ui/Card.astro";
+import { roadmapPaths } from "@/data/roadmap";
+import { resolveAllRoadmaps } from "@/utils/roadmap";
+
+const allEntries = await getCollection("knowledge");
+// 未解決 ref / draft への ref があればここで throw され、ビルドが失敗する
+const resolvedPaths = resolveAllRoadmaps(roadmapPaths, allEntries);
+---
+
+<BaseLayout
+  title="ロードマップ | Knowledge Base | shogoworks"
+  description="目的別に推奨記事を順序立てて学ぶための学習ロードマップ。プロンプト工学・ハーネス工学・Web 構築などのパスを用意しています。"
+>
+  <section class="py-20 px-4">
+    <div class="max-w-4xl mx-auto">
+      <SectionHeader
+        title="学習ロードマップ"
+        subtitle="目的別に、おすすめの記事を順番に並べました。上から読み進めるだけで、その分野の地図が頭に入ります。"
+      />
+
+      <nav
+        aria-label="ロードマップ一覧"
+        class="mb-12 flex flex-wrap justify-center gap-2 animate-on-scroll"
+      >
+        {
+          resolvedPaths.map((path) => (
+            <a
+              href={`#${path.id}`}
+              class="inline-flex items-center px-4 py-2 rounded-full border border-border bg-secondary/40 text-sm text-foreground hover:border-teal-500 hover:text-teal-700 transition-colors"
+            >
+              {path.title}
+            </a>
+          ))
+        }
+      </nav>
+
+      <div class="space-y-16">
+        {
+          resolvedPaths.map((path, pathIdx) => (
+            <section
+              id={path.id}
+              class={`animate-on-scroll stagger-${(pathIdx % 5) + 1} scroll-mt-24`}
+            >
+              <header class="mb-6">
+                <h2 class="text-2xl font-bold text-foreground mb-2">
+                  {path.title}
+                </h2>
+                <p class="text-muted-foreground leading-relaxed">
+                  {path.description}
+                </p>
+              </header>
+
+              <Card>
+                <ol class="divide-y divide-border">
+                  {path.steps.map((step, idx) => (
+                    <li class="py-4 first:pt-0 last:pb-0">
+                      <a
+                        href={step.href}
+                        class="group flex gap-4 items-start"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="shrink-0 w-9 h-9 rounded-full bg-teal-50 text-teal-700 border border-teal-200 flex items-center justify-center text-sm font-semibold"
+                        >
+                          {idx + 1}
+                        </span>
+                        <div class="flex-1 min-w-0">
+                          <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1 mb-1">
+                            <h3 class="text-base font-semibold text-foreground group-hover:text-teal-700 transition-colors">
+                              {step.title}
+                            </h3>
+                            <span class="text-xs text-muted-foreground">
+                              約{step.readingMinutes}分
+                            </span>
+                          </div>
+                          <p class="text-sm text-muted-foreground leading-relaxed">
+                            {step.note}
+                          </p>
+                        </div>
+                        <span
+                          aria-hidden="true"
+                          class="shrink-0 text-muted-foreground group-hover:text-teal-700 transition-colors mt-1"
+                        >
+                          →
+                        </span>
+                      </a>
+                    </li>
+                  ))}
+                </ol>
+              </Card>
+            </section>
+          ))
+        }
+      </div>
+
+      <div class="mt-16 text-center animate-on-scroll">
+        <a
+          href="/knowledge"
+          class="inline-flex items-center gap-1 text-sm text-teal-600 hover:text-teal-700 transition-colors"
+        >
+          ← Knowledge Base トップへ戻る
+        </a>
+      </div>
+    </div>
+  </section>
+</BaseLayout>

--- a/src/utils/readingTime.ts
+++ b/src/utils/readingTime.ts
@@ -1,0 +1,22 @@
+const CJK_CHARS_PER_MINUTE = 600;
+const ENGLISH_WORDS_PER_MINUTE = 200;
+const MIN_MINUTES = 1;
+
+const CJK_REGEX = /[぀-ヿ㐀-䶿一-鿿豈-﫿]/g;
+const ENGLISH_WORD_REGEX = /[A-Za-z][A-Za-z0-9'-]*/g;
+
+/**
+ * 本文テキストから推定読了時間（分）を返す。
+ *
+ * 日本語（CJK 文字）は文字数を 600 字/分、英単語は 200 語/分で換算し、
+ * 両者を合算して切り上げる。最小 1 分。
+ */
+export function estimateReadingMinutes(text: string): number {
+  const cjkCount = (text.match(CJK_REGEX) ?? []).length;
+  const wordCount = (text.match(ENGLISH_WORD_REGEX) ?? []).length;
+
+  const minutes =
+    cjkCount / CJK_CHARS_PER_MINUTE + wordCount / ENGLISH_WORDS_PER_MINUTE;
+
+  return Math.max(MIN_MINUTES, Math.ceil(minutes));
+}

--- a/src/utils/roadmap.ts
+++ b/src/utils/roadmap.ts
@@ -1,0 +1,89 @@
+import type { RoadmapPath, RoadmapStep } from "@/data/roadmap";
+import { estimateReadingMinutes } from "@/utils/readingTime";
+
+/** ロードマップ解決時に最低限必要となる Content Entry の形 */
+interface RoadmapKnowledgeEntry {
+  id: string;
+  body?: string;
+  data: {
+    title: string;
+    description: string;
+    category: string;
+    subcategory?: string;
+    draft: boolean;
+    updatedAt?: Date;
+    createdAt: Date;
+  };
+}
+
+export interface ResolvedRoadmapStep extends RoadmapStep {
+  title: string;
+  description: string;
+  href: string;
+  readingMinutes: number;
+  updatedAt: Date;
+}
+
+export interface ResolvedRoadmapPath {
+  id: string;
+  title: string;
+  description: string;
+  steps: ResolvedRoadmapStep[];
+}
+
+function buildHref(entry: RoadmapKnowledgeEntry): string {
+  const slug = entry.id.split("/").pop() as string;
+  const { category, subcategory } = entry.data;
+  return subcategory
+    ? `/knowledge/${category}/${subcategory}/${slug}`
+    : `/knowledge/${category}/${slug}`;
+}
+
+/**
+ * 1 つのロードマップパスを解決する。
+ * 未解決 ref / draft 記事への ref が含まれる場合は throw する。
+ * これにより `astro build` 時にロードマップ整合性が検証される。
+ */
+export function resolveRoadmap(
+  path: RoadmapPath,
+  entries: RoadmapKnowledgeEntry[],
+): ResolvedRoadmapPath {
+  const byId = new Map(entries.map((e) => [e.id, e]));
+
+  const steps: ResolvedRoadmapStep[] = path.steps.map((step) => {
+    const entry = byId.get(step.ref);
+    if (!entry) {
+      throw new Error(
+        `[roadmap] ref "${step.ref}" in path "${path.id}" does not match any knowledge entry`,
+      );
+    }
+    if (entry.data.draft) {
+      throw new Error(
+        `[roadmap] ref "${step.ref}" in path "${path.id}" points to a draft article`,
+      );
+    }
+    return {
+      ref: step.ref,
+      note: step.note,
+      title: entry.data.title,
+      description: entry.data.description,
+      href: buildHref(entry),
+      readingMinutes: estimateReadingMinutes(entry.body ?? ""),
+      updatedAt: entry.data.updatedAt ?? entry.data.createdAt,
+    };
+  });
+
+  return {
+    id: path.id,
+    title: path.title,
+    description: path.description,
+    steps,
+  };
+}
+
+export function resolveAllRoadmaps(
+  paths: RoadmapPath[],
+  entries: RoadmapKnowledgeEntry[],
+): ResolvedRoadmapPath[] {
+  return paths.map((p) => resolveRoadmap(p, entries));
+}

--- a/tests/utils/readingTime.test.ts
+++ b/tests/utils/readingTime.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { estimateReadingMinutes } from "@/utils/readingTime";
+
+describe("estimateReadingMinutes", () => {
+  it("正常系: 空文字のとき、最小値の1分を返すこと", () => {
+    expect(estimateReadingMinutes("")).toBe(1);
+  });
+
+  it("正常系: 短い日本語のとき、最小値の1分を返すこと", () => {
+    expect(estimateReadingMinutes("これは短い文章です。")).toBe(1);
+  });
+
+  it("正常系: 日本語のみのとき、CJK文字数を600で割った値（切り上げ）を返すこと", () => {
+    // 1200 CJK chars / 600 = 2 min
+    const text = "あ".repeat(1200);
+    expect(estimateReadingMinutes(text)).toBe(2);
+  });
+
+  it("正常系: 英語のみのとき、単語数を200で割った値（切り上げ）を返すこと", () => {
+    // 600 words / 200 = 3 min
+    const text = Array.from({ length: 600 }, () => "word").join(" ");
+    expect(estimateReadingMinutes(text)).toBe(3);
+  });
+
+  it("正常系: 日本語と英語が混在するとき、両者を合算して切り上げで返すこと", () => {
+    // 600 CJK (= 1 min) + 200 英単語 (= 1 min) = 2 min
+    const text = "あ".repeat(600) + " " + Array.from({ length: 200 }, () => "word").join(" ");
+    expect(estimateReadingMinutes(text)).toBe(2);
+  });
+
+  it("異常系: 1分未満になる量のとき、最小値の1分を返すこと", () => {
+    expect(estimateReadingMinutes("hello world")).toBe(1);
+  });
+});

--- a/tests/utils/roadmap.test.ts
+++ b/tests/utils/roadmap.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from "vitest";
+import { resolveRoadmap, resolveAllRoadmaps } from "@/utils/roadmap";
+import type { RoadmapPath } from "@/data/roadmap";
+
+interface MockEntry {
+  id: string;
+  body?: string;
+  data: {
+    title: string;
+    description: string;
+    category: string;
+    subcategory?: string;
+    tags: string[];
+    sortOrder: number;
+    createdAt: Date;
+    updatedAt?: Date;
+    draft: boolean;
+    author: string;
+  };
+}
+
+const baseData = {
+  description: "desc",
+  category: "prompt-engineering",
+  tags: [],
+  sortOrder: 0,
+  createdAt: new Date("2026-04-01"),
+  draft: false,
+  author: "田中省伍",
+};
+
+const mockEntries: MockEntry[] = [
+  {
+    id: "prompt-engineering/few-shot-prompting",
+    body: "あ".repeat(1200),
+    data: { ...baseData, title: "Few-shot Prompting" },
+  },
+  {
+    id: "prompt-engineering/chain-of-thought",
+    body: "Chain of thought ".repeat(100),
+    data: {
+      ...baseData,
+      title: "Chain of Thought",
+      updatedAt: new Date("2026-05-10"),
+    },
+  },
+  {
+    id: "harness-engineering/agents-md-design",
+    body: "harness body",
+    data: { ...baseData, title: "AGENTS.md 設計", category: "harness-engineering" },
+  },
+  {
+    id: "ai-tools/claude-code/draft-only",
+    body: "",
+    data: {
+      ...baseData,
+      title: "Draft",
+      category: "ai-tools",
+      subcategory: "claude-code",
+      draft: true,
+    },
+  },
+];
+
+describe("resolveRoadmap", () => {
+  it("正常系: 定義済みの ref をすべて解決できるとき、定義順で resolved steps を返すこと", () => {
+    const path: RoadmapPath = {
+      id: "prompt-mastery",
+      title: "プロンプト習熟",
+      description: "テスト",
+      steps: [
+        { ref: "prompt-engineering/few-shot-prompting", note: "事例で学ぶ" },
+        { ref: "prompt-engineering/chain-of-thought", note: "推論を促す" },
+      ],
+    };
+
+    const resolved = resolveRoadmap(path, mockEntries);
+
+    expect(resolved.id).toBe("prompt-mastery");
+    expect(resolved.steps).toHaveLength(2);
+    expect(resolved.steps[0].title).toBe("Few-shot Prompting");
+    expect(resolved.steps[0].note).toBe("事例で学ぶ");
+    expect(resolved.steps[0].href).toBe(
+      "/knowledge/prompt-engineering/few-shot-prompting",
+    );
+    expect(resolved.steps[0].readingMinutes).toBeGreaterThanOrEqual(1);
+    expect(resolved.steps[1].title).toBe("Chain of Thought");
+  });
+
+  it("正常系: subcategory 付き ref のとき、3階層 href を組み立てること", () => {
+    const path: RoadmapPath = {
+      id: "harness",
+      title: "Harness",
+      description: "x",
+      steps: [
+        { ref: "harness-engineering/agents-md-design", note: "AGENTS.md" },
+      ],
+    };
+    const resolved = resolveRoadmap(path, mockEntries);
+    expect(resolved.steps[0].href).toBe(
+      "/knowledge/harness-engineering/agents-md-design",
+    );
+  });
+
+  it("異常系: 存在しない ref を含むとき、エラーを投げること", () => {
+    const path: RoadmapPath = {
+      id: "broken",
+      title: "x",
+      description: "x",
+      steps: [{ ref: "prompt-engineering/does-not-exist", note: "n" }],
+    };
+    expect(() => resolveRoadmap(path, mockEntries)).toThrowError(
+      /does-not-exist/,
+    );
+  });
+
+  it("異常系: draft 記事を ref したとき、エラーを投げること", () => {
+    const path: RoadmapPath = {
+      id: "draft-ref",
+      title: "x",
+      description: "x",
+      steps: [{ ref: "ai-tools/claude-code/draft-only", note: "n" }],
+    };
+    expect(() => resolveRoadmap(path, mockEntries)).toThrowError(/draft/i);
+  });
+});
+
+describe("resolveAllRoadmaps", () => {
+  it("正常系: 複数パスをまとめて解決できること", () => {
+    const paths: RoadmapPath[] = [
+      {
+        id: "a",
+        title: "A",
+        description: "",
+        steps: [{ ref: "prompt-engineering/few-shot-prompting", note: "" }],
+      },
+      {
+        id: "b",
+        title: "B",
+        description: "",
+        steps: [{ ref: "harness-engineering/agents-md-design", note: "" }],
+      },
+    ];
+    const resolved = resolveAllRoadmaps(paths, mockEntries);
+    expect(resolved).toHaveLength(2);
+    expect(resolved[0].id).toBe("a");
+    expect(resolved[1].id).toBe("b");
+  });
+
+  it("異常系: いずれかのパスに未解決 ref が含まれるとき、エラーを投げること", () => {
+    const paths: RoadmapPath[] = [
+      {
+        id: "ok",
+        title: "ok",
+        description: "",
+        steps: [{ ref: "prompt-engineering/few-shot-prompting", note: "" }],
+      },
+      {
+        id: "ng",
+        title: "ng",
+        description: "",
+        steps: [{ ref: "prompt-engineering/missing", note: "" }],
+      },
+    ];
+    expect(() => resolveAllRoadmaps(paths, mockEntries)).toThrowError(/missing/);
+  });
+});


### PR DESCRIPTION
## Summary
- `/knowledge/roadmap` を新設し、目的別の学習パス3本（プロンプト&コンテキスト / Harness Engineering / Cloudflare+Supabase）を提供
- `src/data/roadmap.ts` でパス定義を一元管理。今後パスを追加する際は配列に push するだけで済む構造
- 未解決 slug / draft 記事への参照は `astro build` 時に throw して fail（util に TDD で切り出し）
- `/knowledge` トップに「ロードマップから始める」CTA カードを追加して入口を強化
- 推定読了時間 util を新規追加（日本語600字+英語200語/分のハイブリッド）

## 採用方針
- Claude Code 入門パスは記事整備の都合で今回スコープ外
- 各 step は `{ ref, note }` の最小構造。記事メタ（title/description/href/読了時間）は util が解決時に注入
- ビルド時整合性検証を採用（ランタイムスキップではなく fail させる）

## Test plan
- [x] `npm run test` 全 119 件パス（うち readingTime 6 件・roadmap 6 件を新規追加）
- [x] `npx astro check` 型エラーなし
- [x] `npm run build` 成功
- [x] 未解決 ref を入れたとき `npm run build` が exit 1 で落ちることを確認済み
- [ ] `npm run dev` で `/knowledge/roadmap` および `/knowledge` トップの CTA を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)