### PR TITLE
feat: Knowledge Base UI Phase 5 - 仕上げ（デザイン微調整・最近更新セクション）

### DIFF
--- a/src/components/ui/Card.astro
+++ b/src/components/ui/Card.astro
@@ -11,7 +11,7 @@ const { class: className, hover = false } = Astro.props;
 
 <div
   class={cn(
-    "bg-white/80 ring-1 ring-gray-950/5 shadow-sm rounded-3xl p-6 transition-all duration-300",
+    "bg-card/95 ring-1 ring-gray-950/5 shadow-sm rounded-3xl p-6 transition-all duration-300",
     hover && "hover:border-teal-500/20",
     className
   )}

--- a/src/layouts/KnowledgeLayout.astro
+++ b/src/layouts/KnowledgeLayout.astro
@@ -119,7 +119,7 @@ const jsonLd = JSON.stringify({
 
       <div class="lg:grid lg:grid-cols-[17rem_minmax(0,1fr)_15rem] lg:gap-10 lg:items-start">
         <aside
-          class="hidden lg:block lg:sticky lg:top-24 lg:max-h-[calc(100vh-7rem)] lg:overflow-y-auto"
+          class="hidden lg:block lg:sticky lg:top-24 lg:max-h-[calc(100vh-7rem)] lg:overflow-y-auto lg:bg-secondary/40 lg:rounded-2xl lg:p-4"
           aria-label="記事一覧"
         >
           <ArticleSidebar
@@ -224,7 +224,7 @@ const jsonLd = JSON.stringify({
         </div>
 
         <aside
-          class="hidden lg:block lg:sticky lg:top-24 lg:max-h-[calc(100vh-7rem)] lg:overflow-y-auto"
+          class="hidden lg:block lg:sticky lg:top-24 lg:max-h-[calc(100vh-7rem)] lg:overflow-y-auto lg:bg-secondary/40 lg:rounded-2xl lg:p-4"
         >
           <ArticleToc headings={headings} />
         </aside>

--- a/src/pages/knowledge/index.astro
+++ b/src/pages/knowledge/index.astro
@@ -5,12 +5,21 @@ import SectionHeader from "@/components/ui/SectionHeader.astro";
 import CategoryCard from "@/components/knowledge/CategoryCard.astro";
 import ArticleCard from "@/components/knowledge/ArticleCard.astro";
 import { categories, externalArticles } from "@/data/knowledge";
-import { mergeArticles, getUnifiedCategoryCount } from "@/utils/knowledge";
+import {
+  getRecentlyUpdatedArticles,
+  getUnifiedCategoryCount,
+  toUnifiedFromInternal,
+} from "@/utils/knowledge";
 
 const allEntries = await getCollection("knowledge");
-const unified = mergeArticles(externalArticles, allEntries);
 const counts = getUnifiedCategoryCount(externalArticles, allEntries);
-const latestArticles = unified.slice(0, 6);
+const recentlyUpdated = getRecentlyUpdatedArticles(allEntries, 10).map((e) => {
+  const unified = toUnifiedFromInternal(e);
+  return {
+    ...unified,
+    displayDate: e.data.updatedAt ?? e.data.createdAt,
+  };
+});
 
 function getCategoryLabel(slug: string): string {
   return categories.find((c) => c.slug === slug)?.label ?? slug;
@@ -91,20 +100,20 @@ function getCategoryLabel(slug: string): string {
       </div>
 
       {
-        latestArticles.length > 0 && (
+        recentlyUpdated.length > 0 && (
           <div>
             <h2 class="text-2xl font-bold text-foreground mb-6 animate-on-scroll">
-              最新記事
+              最近更新された記事
             </h2>
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-              {latestArticles.map((article, i) => (
+              {recentlyUpdated.map((article, i) => (
                 <div class={`animate-on-scroll stagger-${(i % 5) + 1}`}>
                   <ArticleCard
                     title={article.title}
                     description={article.description}
                     categoryLabel={getCategoryLabel(article.category)}
                     tags={article.tags}
-                    createdAt={article.createdAt}
+                    createdAt={article.displayDate}
                     href={article.href}
                     isExternal={article.isExternal}
                     platform={article.platform}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -127,7 +127,7 @@ body {
 
 /* Knowledge base prose */
 .knowledge-prose {
-  line-height: 1.8;
+  line-height: 1.9;
   font-size: 1rem;
 }
 
@@ -138,7 +138,7 @@ body {
   margin-top: 2.5rem;
   margin-bottom: 1rem;
   padding-bottom: 0.5rem;
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 2px solid color-mix(in srgb, var(--color-primary) 30%, transparent);
 }
 
 .knowledge-prose h3 {

--- a/src/utils/knowledge.ts
+++ b/src/utils/knowledge.ts
@@ -342,6 +342,25 @@ export function getCategoryArticleCount<T extends KnowledgeEntry>(
   return counts;
 }
 
+/**
+ * 公開記事を「最終更新日」の降順で返す。
+ * 各記事の最終更新日は `updatedAt ?? createdAt` で評価する。
+ * 外部記事は updatedAt を持たないため対象外（MDX のみ）。
+ */
+export function getRecentlyUpdatedArticles<T extends KnowledgeEntry>(
+  entries: T[],
+  limit: number,
+): T[] {
+  return entries
+    .filter((entry) => !entry.data.draft)
+    .sort((a, b) => {
+      const aDate = (a.data.updatedAt ?? a.data.createdAt).getTime();
+      const bDate = (b.data.updatedAt ?? b.data.createdAt).getTime();
+      return bDate - aDate;
+    })
+    .slice(0, limit);
+}
+
 export function getRelatedArticles<T extends KnowledgeEntry>(
   entries: T[],
   currentId: string,

--- a/tests/utils/knowledge.test.ts
+++ b/tests/utils/knowledge.test.ts
@@ -10,6 +10,7 @@ import {
   getAllTags,
   getArticlesByTag,
   getCategoryArticleCount,
+  getRecentlyUpdatedArticles,
   getRelatedArticles,
   mergeArticles,
   mergeArticlesByCategory,
@@ -732,5 +733,77 @@ describe("toUnifiedFromInternal with subcategory", () => {
     const result = toUnifiedFromInternal(mockEntriesWithSubcategory[0]);
     expect(result.href).toBe("/knowledge/ai-tools/claude-code-intro");
     expect(result.subcategory).toBeUndefined();
+  });
+});
+
+describe("getRecentlyUpdatedArticles", () => {
+  const baseData = {
+    description: "",
+    category: "ai-tools",
+    tags: [],
+    sortOrder: 0,
+    draft: false,
+    author: "田中省伍",
+  };
+  const entries = [
+    {
+      id: "a",
+      data: {
+        ...baseData,
+        title: "A",
+        createdAt: new Date("2026-01-01"),
+        updatedAt: new Date("2026-05-10"),
+      },
+    },
+    {
+      id: "b",
+      data: {
+        ...baseData,
+        title: "B",
+        createdAt: new Date("2026-04-01"),
+        // updatedAt 無し → createdAt で代用される
+      },
+    },
+    {
+      id: "c",
+      data: {
+        ...baseData,
+        title: "C",
+        createdAt: new Date("2026-03-01"),
+        updatedAt: new Date("2026-05-20"),
+      },
+    },
+    {
+      id: "d-draft",
+      data: {
+        ...baseData,
+        title: "D",
+        createdAt: new Date("2026-05-30"),
+        updatedAt: new Date("2026-05-30"),
+        draft: true,
+      },
+    },
+  ];
+
+  it("正常系: updatedAt ?? createdAt の降順で並ぶこと", () => {
+    const result = getRecentlyUpdatedArticles(entries, 10);
+    expect(result.map((e) => e.id)).toEqual(["c", "a", "b"]);
+  });
+
+  it("正常系: updatedAt が無い記事は createdAt で代用されること", () => {
+    const result = getRecentlyUpdatedArticles(entries, 10);
+    // b は createdAt 2026-04-01 なので a(2026-05-10) より後ろ、b単独でも結果に含まれる
+    expect(result.map((e) => e.id)).toContain("b");
+  });
+
+  it("正常系: limit を超える場合、limit 件で打ち切ること", () => {
+    const result = getRecentlyUpdatedArticles(entries, 2);
+    expect(result).toHaveLength(2);
+    expect(result.map((e) => e.id)).toEqual(["c", "a"]);
+  });
+
+  it("異常系: draft 記事は除外されること", () => {
+    const result = getRecentlyUpdatedArticles(entries, 10);
+    expect(result.map((e) => e.id)).not.toContain("d-draft");
   });
 });


### PR DESCRIPTION
## Summary
- `/knowledge` トップの「最新記事」（実態は sortOrder ソート）を「最近更新された記事」に置き換え（updatedAt ?? createdAt 降順 10 件）
- `getRecentlyUpdatedArticles` util を TDD で新規追加
- 本文 line-height 1.8 → 1.9、h2 章境界を primary/30 の 2px に強調
- 左サイドバー / 右TOC の `<aside>` ラッパーに secondary/40 背景を入れ、本文領域と視覚的に分離
- `Card.astro` の `bg-white/80` → `bg-card/95`（token 経由化）

## 採用方針
- カード全体を secondary に切り替える大規模変更は services/portfolio との整合性を崩すため見送り。サイドバーラッパーの背景でコントラストを担保
- ArticleCard には日付ラベルが 1 つだけなので、`updatedAt ?? createdAt` を `createdAt` prop として渡し、セクションタイトル「最近更新された記事」で文脈を補う

## Test plan
- [x] `npm run test` 全 123 件パス（getRecentlyUpdatedArticles 4 件を新規追加）
- [x] `npx astro check` 型エラーなし
- [x] `npm run build` 成功
- [ ] `npm run dev` で目視確認: 本文行間/h2 アクセント/サイドバー背景/最近更新セクション
- [ ] レスポンシブ確認: lg / md / sm / モバイル

🤖 Generated with [Claude Code](https://claude.com/claude-code)