### PR TITLE
feat: トップページに blueai 風 4 セクション追加（注目ナレッジ・メディア・お役立ち資料・取り扱い技術）

### DIFF
--- a/src/components/sections/FeaturedKnowledge.astro
+++ b/src/components/sections/FeaturedKnowledge.astro
@@ -1,0 +1,57 @@
+---
+import { featuredKnowledge } from "@/data";
+import SectionHeader from "@/components/ui/SectionHeader.astro";
+import Badge from "@/components/ui/Badge.astro";
+import { externalLinkAttrs } from "@/utils/externalLink";
+---
+
+<section id="featured-knowledge" class="py-20">
+  <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+    <SectionHeader
+      title="注目のナレッジ"
+      subtitle="読まれている解説記事をピックアップ。Claude Code・プロンプト工学・現場運用のハーネス設計まで。"
+    />
+
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      {
+        featuredKnowledge.map((item, i) => (
+          <a
+            href={item.href}
+            class={`group block bg-card/95 ring-1 ring-gray-950/5 shadow-sm rounded-3xl p-6 transition-all duration-300 hover:ring-teal-500/20 hover:shadow-md animate-on-scroll stagger-${(i % 5) + 1}`}
+            {...externalLinkAttrs(item.source)}
+          >
+            <div class="flex items-center gap-2 flex-wrap mb-3">
+              {item.categoryLabel && (
+                <Badge variant="teal">{item.categoryLabel}</Badge>
+              )}
+              {item.source === "external" && item.platform && (
+                <Badge variant="blue">
+                  {item.platform}
+                  <span class="ml-0.5">↗</span>
+                </Badge>
+              )}
+            </div>
+            <h3 class="text-lg font-semibold text-foreground group-hover:text-teal-700 transition-colors mb-2 line-clamp-2">
+              {item.title}
+              {item.source === "external" && (
+                <span class="text-muted-foreground text-sm ml-1">↗</span>
+              )}
+            </h3>
+            <p class="text-sm text-muted-foreground leading-relaxed line-clamp-3">
+              {item.description}
+            </p>
+          </a>
+        ))
+      }
+    </div>
+
+    <div class="mt-10 text-center">
+      <a
+        href="/knowledge"
+        class="inline-flex items-center gap-1 text-sm font-medium text-teal-600 hover:text-teal-700 transition-colors"
+      >
+        Knowledge Base をすべて見る →
+      </a>
+    </div>
+  </div>
+</section>

--- a/src/components/sections/Media.astro
+++ b/src/components/sections/Media.astro
@@ -1,0 +1,72 @@
+---
+import { mediaOutlets } from "@/data";
+import SectionHeader from "@/components/ui/SectionHeader.astro";
+import Badge from "@/components/ui/Badge.astro";
+
+function iconUrl(slug: string, color?: string): string {
+  // simple-icons CDN（公式・無料・CC0）
+  // color 指定がある場合は brand color、無い場合はデフォルト黒
+  const trimmed = color?.replace(/^#/, "");
+  return trimmed
+    ? `https://cdn.simpleicons.org/${slug}/${trimmed}`
+    : `https://cdn.simpleicons.org/${slug}`;
+}
+---
+
+<section id="media" class="py-20 bg-secondary/30">
+  <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+    <SectionHeader
+      title="メディア発信"
+      subtitle="各プラットフォームで発信中／準備中です。気になる媒体からフォローいただけると嬉しいです。"
+    />
+
+    <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+      {
+        mediaOutlets.map((outlet, i) => {
+          const inner = (
+            <div class="flex items-start gap-3">
+              <img
+                src={iconUrl(outlet.iconSlug, outlet.brandColor)}
+                alt={outlet.name}
+                width="28"
+                height="28"
+                class="shrink-0 mt-0.5"
+                loading="lazy"
+              />
+              <div class="flex-1 min-w-0">
+                <div class="flex items-center gap-2 mb-1 flex-wrap">
+                  <span class="text-base font-semibold text-foreground">
+                    {outlet.name}
+                  </span>
+                  {outlet.comingSoon && (
+                    <Badge variant="default">準備中</Badge>
+                  )}
+                </div>
+                <p class="text-xs text-muted-foreground leading-relaxed">
+                  {outlet.description}
+                </p>
+              </div>
+            </div>
+          );
+
+          const wrapperClass = `block bg-card/95 ring-1 ring-gray-950/5 shadow-sm rounded-2xl p-5 transition-all duration-300 animate-on-scroll stagger-${(i % 5) + 1}`;
+
+          return outlet.comingSoon ? (
+            <div class={`${wrapperClass} opacity-60`} aria-disabled="true">
+              {inner}
+            </div>
+          ) : (
+            <a
+              href={outlet.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              class={`${wrapperClass} group hover:ring-teal-500/30 hover:shadow-md`}
+            >
+              {inner}
+            </a>
+          );
+        })
+      }
+    </div>
+  </div>
+</section>

--- a/src/components/sections/Resources.astro
+++ b/src/components/sections/Resources.astro
@@ -1,0 +1,52 @@
+---
+import { resources } from "@/data";
+import SectionHeader from "@/components/ui/SectionHeader.astro";
+import Badge from "@/components/ui/Badge.astro";
+---
+
+<section id="resources" class="py-20">
+  <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+    <SectionHeader
+      title="お役立ち資料"
+      subtitle="サービス紹介資料・ホワイトペーパー・テンプレート集を順次公開予定です。"
+    />
+
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+      {
+        resources.map((res, i) => {
+          const card = (
+            <>
+              <div class="w-12 h-12 rounded-xl bg-teal-50 flex items-center justify-center mb-4 text-2xl">
+                📄
+              </div>
+              <div class="flex items-center gap-2 mb-2 flex-wrap">
+                <h3 class="text-lg font-semibold text-foreground">
+                  {res.title}
+                </h3>
+                {res.comingSoon && <Badge variant="default">準備中</Badge>}
+              </div>
+              <p class="text-sm text-muted-foreground leading-relaxed">
+                {res.description}
+              </p>
+            </>
+          );
+
+          const wrapperClass = `block bg-card/95 ring-1 ring-gray-950/5 shadow-sm rounded-3xl p-6 transition-all duration-300 animate-on-scroll stagger-${(i % 5) + 1}`;
+
+          return res.comingSoon ? (
+            <div class={`${wrapperClass} opacity-70`} aria-disabled="true">
+              {card}
+            </div>
+          ) : (
+            <a
+              href={res.href}
+              class={`${wrapperClass} group hover:ring-teal-500/20 hover:shadow-md`}
+            >
+              {card}
+            </a>
+          );
+        })
+      }
+    </div>
+  </div>
+</section>

--- a/src/components/sections/TechStack.astro
+++ b/src/components/sections/TechStack.astro
@@ -1,0 +1,68 @@
+---
+import { techStack } from "@/data";
+import SectionHeader from "@/components/ui/SectionHeader.astro";
+---
+
+<section id="tech-stack" class="py-20 bg-secondary/30">
+  <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+    <SectionHeader
+      title="取り扱い技術"
+      subtitle="AI / クラウド / Web を中心に、対応可能な主要技術スタックです。"
+    />
+
+    <div class="space-y-8">
+      {
+        techStack.map((category, i) => (
+          <div
+            class={`bg-card/95 ring-1 ring-gray-950/5 shadow-sm rounded-3xl p-6 md:p-7 animate-on-scroll stagger-${(i % 5) + 1}`}
+          >
+            <h3 class="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-4">
+              {category.label}
+            </h3>
+            <div class="flex flex-wrap gap-2">
+              {category.items.map((tech) => {
+                const chipClass =
+                  "inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-border bg-background hover:border-teal-500/40 hover:text-teal-700 transition-colors text-sm text-foreground";
+                const chipInner = (
+                  <>
+                    <img
+                      src={`https://cdn.simpleicons.org/${tech.iconSlug}`}
+                      alt=""
+                      width="18"
+                      height="18"
+                      class="shrink-0"
+                      loading="lazy"
+                      aria-hidden="true"
+                    />
+                    <span>{tech.name}</span>
+                  </>
+                );
+                return tech.url ? (
+                  <a
+                    href={tech.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class={chipClass}
+                  >
+                    {chipInner}
+                  </a>
+                ) : (
+                  <span class={chipClass}>{chipInner}</span>
+                );
+              })}
+            </div>
+          </div>
+        ))
+      }
+    </div>
+
+    <div class="mt-10 text-center">
+      <a
+        href="/skills"
+        class="inline-flex items-center gap-1 text-sm font-medium text-teal-600 hover:text-teal-700 transition-colors"
+      >
+        スキル一覧（レベル評価付き）を見る →
+      </a>
+    </div>
+  </div>
+</section>

--- a/src/data/featuredKnowledge.ts
+++ b/src/data/featuredKnowledge.ts
@@ -1,0 +1,57 @@
+import type { FeaturedKnowledgeItem } from "@/types";
+
+/**
+ * トップページ「注目のナレッジ」に表示するピックアップ記事。
+ * source: "internal" は Knowledge Base 内部、"external" は Zenn / Qiita / note / YouTube 等の外部記事。
+ * 並び順がそのまま表示順になる。
+ */
+export const featuredKnowledge: FeaturedKnowledgeItem[] = [
+  {
+    title: "Claude Code 全体像",
+    description:
+      "Anthropic 公式の AI コーディングエージェント Claude Code の機能と運用ポイントを俯瞰。",
+    href: "/knowledge/ai-tools/claude-code/overview",
+    source: "internal",
+    categoryLabel: "Claude Code",
+  },
+  {
+    title: "Codex 全体像",
+    description:
+      "OpenAI の Codex（CLI / IDE / Cloud / SDK）の全体像と Claude Code との比較。",
+    href: "/knowledge/ai-tools/codex/overview",
+    source: "internal",
+    categoryLabel: "Codex",
+  },
+  {
+    title: "プロンプトエンジニアリング完全ガイド",
+    description:
+      "Zero-shot / Few-shot / CoT など主要プロンプト技法を体系的に整理。",
+    href: "/knowledge/prompt-engineering/prompt-engineering-complete-guide",
+    source: "internal",
+    categoryLabel: "Prompt Engineering",
+  },
+  {
+    title: "コンテキストエンジニアリング完全ガイド",
+    description:
+      "ウィンドウ管理・RAG・メモリ設計まで「プロンプトの外側」を設計する考え方。",
+    href: "/knowledge/context-engineering/context-engineering-complete-guide",
+    source: "internal",
+    categoryLabel: "Context Engineering",
+  },
+  {
+    title: "Harness Engineering 完全ガイド",
+    description:
+      "AI エージェントを個人利用から本番運用に乗せる「ハーネス」の設計原則。",
+    href: "/knowledge/harness-engineering/harness-engineering-complete-guide",
+    source: "internal",
+    categoryLabel: "Harness Engineering",
+  },
+  {
+    title: "Knowledge Base ロードマップ",
+    description:
+      "目的別に「何をどの順で読むか」を整理した学習パス集。最初の入口として。",
+    href: "/knowledge/roadmap",
+    source: "internal",
+    categoryLabel: "Roadmap",
+  },
+];

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -12,3 +12,7 @@ export {
 export { stats } from "./stats";
 export { categories, externalArticles } from "./knowledge";
 export { aiNewsStatuses, aiNewsTools } from "./aiNews";
+export { featuredKnowledge } from "./featuredKnowledge";
+export { mediaOutlets } from "./mediaOutlets";
+export { resources } from "./resources";
+export { techStack } from "./techStack";

--- a/src/data/mediaOutlets.ts
+++ b/src/data/mediaOutlets.ts
@@ -1,0 +1,71 @@
+import type { MediaOutlet } from "@/types";
+
+/**
+ * トップページ「メディア発信」セクションに表示する媒体一覧。
+ * `comingSoon: true` は枠だけ確保しグレーアウト表示。実 URL が決まったら url を埋めて
+ * comingSoon を外す。
+ */
+export const mediaOutlets: MediaOutlet[] = [
+  {
+    name: "note",
+    description: "現場視点の AI 活用メモを継続発信",
+    url: "#",
+    iconSlug: "note",
+    brandColor: "#000000",
+    comingSoon: true,
+  },
+  {
+    name: "X",
+    description: "日々の気づき・最新情報を投稿",
+    url: "https://x.com/shogo_works",
+    iconSlug: "x",
+    brandColor: "#000000",
+  },
+  {
+    name: "LinkedIn",
+    description: "経歴・実績・お仕事のご相談はこちら",
+    url: "https://www.linkedin.com/in/shogoworks/",
+    iconSlug: "linkedin",
+    brandColor: "#0A66C2",
+  },
+  {
+    name: "Threads",
+    description: "短文の発信を準備中",
+    url: "#",
+    iconSlug: "threads",
+    brandColor: "#000000",
+    comingSoon: true,
+  },
+  {
+    name: "Zenn",
+    description: "技術記事の連載を準備中",
+    url: "#",
+    iconSlug: "zenn",
+    brandColor: "#3EA8FF",
+    comingSoon: true,
+  },
+  {
+    name: "YouTube",
+    description: "解説動画を準備中",
+    url: "#",
+    iconSlug: "youtube",
+    brandColor: "#FF0000",
+    comingSoon: true,
+  },
+  {
+    name: "Udemy",
+    description: "オンライン講座を準備中",
+    url: "#",
+    iconSlug: "udemy",
+    brandColor: "#A435F0",
+    comingSoon: true,
+  },
+  {
+    name: "Kindle",
+    description: "電子書籍を準備中",
+    url: "#",
+    iconSlug: "amazonkindle",
+    brandColor: "#00A8E1",
+    comingSoon: true,
+  },
+];

--- a/src/data/mediaOutlets.ts
+++ b/src/data/mediaOutlets.ts
@@ -9,10 +9,9 @@ export const mediaOutlets: MediaOutlet[] = [
   {
     name: "note",
     description: "現場視点の AI 活用メモを継続発信",
-    url: "#",
+    url: "https://note.com/shogo123198",
     iconSlug: "note",
     brandColor: "#000000",
-    comingSoon: true,
   },
   {
     name: "X",

--- a/src/data/resources.ts
+++ b/src/data/resources.ts
@@ -1,0 +1,28 @@
+import type { ResourceItem } from "@/types";
+
+/**
+ * トップページ「お役立ち資料」セクションのリソース一覧。
+ * 現状は全て準備中。コンテンツが用意でき次第 href を埋め、comingSoon を false に。
+ */
+export const resources: ResourceItem[] = [
+  {
+    title: "サービス紹介資料",
+    description: "ご提供しているサービスの概要・料金体系をまとめた資料です。",
+    href: "#",
+    comingSoon: true,
+  },
+  {
+    title: "AI 導入の進め方（ホワイトペーパー）",
+    description:
+      "中小企業向けの AI 導入ステップとよくある落とし穴を整理した資料です。",
+    href: "#",
+    comingSoon: true,
+  },
+  {
+    title: "無料テンプレート集",
+    description:
+      "プロンプト雛形・AGENTS.md テンプレなど、現場ですぐ使える素材をまとめた配布物です。",
+    href: "#",
+    comingSoon: true,
+  },
+];

--- a/src/data/techStack.ts
+++ b/src/data/techStack.ts
@@ -1,0 +1,44 @@
+import type { TechCategory } from "@/types";
+
+/**
+ * トップページ「取り扱い技術」セクション。
+ * `iconSlug` は simple-icons の slug。https://cdn.simpleicons.org/<slug> で SVG を取得。
+ */
+export const techStack: TechCategory[] = [
+  {
+    key: "ai-llm",
+    label: "AI / LLM",
+    items: [
+      { name: "Claude", iconSlug: "anthropic" },
+      { name: "OpenAI", iconSlug: "openai" },
+      { name: "Gemini", iconSlug: "googlegemini" },
+      { name: "Dify", iconSlug: "dify" },
+      { name: "n8n", iconSlug: "n8n" },
+      { name: "LangChain", iconSlug: "langchain" },
+    ],
+  },
+  {
+    key: "cloud-web",
+    label: "Cloud / Web",
+    items: [
+      { name: "Cloudflare", iconSlug: "cloudflare" },
+      { name: "Vercel", iconSlug: "vercel" },
+      { name: "Supabase", iconSlug: "supabase" },
+      { name: "Next.js", iconSlug: "nextdotjs" },
+      { name: "Astro", iconSlug: "astro" },
+      { name: "React", iconSlug: "react" },
+    ],
+  },
+  {
+    key: "languages-tools",
+    label: "Languages / Tools",
+    items: [
+      { name: "TypeScript", iconSlug: "typescript" },
+      { name: "Python", iconSlug: "python" },
+      { name: "Google Apps Script", iconSlug: "google" },
+      { name: "PowerShell", iconSlug: "powershell" },
+      { name: "Git", iconSlug: "git" },
+      { name: "GitHub", iconSlug: "github" },
+    ],
+  },
+];

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,10 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
 import Hero from "@/components/sections/Hero.astro";
 import Stats from "@/components/sections/Stats.astro";
 import Services from "@/components/sections/Services.astro";
+import FeaturedKnowledge from "@/components/sections/FeaturedKnowledge.astro";
+import Media from "@/components/sections/Media.astro";
+import Resources from "@/components/sections/Resources.astro";
+import TechStack from "@/components/sections/TechStack.astro";
 import Cta from "@/components/sections/Cta.astro";
 ---
 
@@ -10,5 +14,9 @@ import Cta from "@/components/sections/Cta.astro";
   <Hero />
   <Stats />
   <Services />
+  <FeaturedKnowledge />
+  <Media />
+  <Resources />
+  <TechStack />
   <Cta />
 </BaseLayout>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -147,3 +147,45 @@ export interface AiNewsStatusMeta {
   label: string;
   description: string;
 }
+
+// --- Top page: featured knowledge / media outlets / resources / tech stack ---
+
+export type FeaturedSource = "internal" | "external";
+export type FeaturedPlatform = "zenn" | "qiita" | "note" | "youtube";
+
+export interface FeaturedKnowledgeItem {
+  title: string;
+  description: string;
+  href: string;
+  source: FeaturedSource;
+  platform?: FeaturedPlatform;
+  categoryLabel?: string;
+}
+
+export interface MediaOutlet {
+  name: string;
+  description: string;
+  url: string;
+  iconSlug: string; // simple-icons の slug
+  brandColor?: string;
+  comingSoon?: boolean;
+}
+
+export interface ResourceItem {
+  title: string;
+  description: string;
+  href: string;
+  comingSoon: boolean;
+}
+
+export interface TechItem {
+  name: string;
+  iconSlug: string;
+  url?: string;
+}
+
+export interface TechCategory {
+  key: string;
+  label: string;
+  items: TechItem[];
+}

--- a/src/utils/externalLink.ts
+++ b/src/utils/externalLink.ts
@@ -1,0 +1,18 @@
+export type LinkSource = "internal" | "external";
+
+export function isExternalSource(source: LinkSource): boolean {
+  return source === "external";
+}
+
+/**
+ * 外部リンク時に <a> へ展開する追加属性を返す。
+ * 内部リンク時は空オブジェクトを返す（spread しても無害）。
+ */
+export function externalLinkAttrs(
+  source: LinkSource,
+): { target: "_blank"; rel: "noopener noreferrer" } | Record<string, never> {
+  if (isExternalSource(source)) {
+    return { target: "_blank", rel: "noopener noreferrer" };
+  }
+  return {};
+}

--- a/tests/utils/externalLink.test.ts
+++ b/tests/utils/externalLink.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { isExternalSource, externalLinkAttrs } from "@/utils/externalLink";
+
+describe("isExternalSource", () => {
+  it("正常系: source が 'external' のとき、true を返すこと", () => {
+    expect(isExternalSource("external")).toBe(true);
+  });
+
+  it("正常系: source が 'internal' のとき、false を返すこと", () => {
+    expect(isExternalSource("internal")).toBe(false);
+  });
+});
+
+describe("externalLinkAttrs", () => {
+  it("正常系: 外部リンクのとき、target/rel 属性を返すこと", () => {
+    expect(externalLinkAttrs("external")).toEqual({
+      target: "_blank",
+      rel: "noopener noreferrer",
+    });
+  });
+
+  it("正常系: 内部リンクのとき、空オブジェクトを返すこと", () => {
+    expect(externalLinkAttrs("internal")).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
参考: [blueai.co.jp](https://blueai.co.jp/) の下部セクション構成を個人サイト向けに転用。SNS 発信強化に合わせ、Hero/Stats/Services と Cta の間にコンテンツ資産と媒体導線を集約する 4 セクションを追加。

- **FeaturedKnowledge** — 注目記事 6 件（Claude Code / Codex / Prompt / Context / Harness / Roadmap）。`source: "internal" | "external"` で外部記事（Zenn / Qiita / note 等）も差し込める汎用構造
- **Media** — 媒体 8 枠（note / X / LinkedIn / Threads / Zenn / YouTube / Udemy / Kindle）。実 URL 未確定の媒体は `comingSoon: true` でグレーアウト + 「準備中」バッジ
- **Resources** — お役立ち資料 3 枠（サービス資料・ホワイトペーパー・テンプレート集）を全て準備中で配置
- **TechStack** — 3 カテゴリ（AI/LLM・Cloud/Web・Languages/Tools）のロゴチップ。[simple-icons CDN](https://cdn.simpleicons.org/) を `<img>` で利用し外部依存ゼロ

## 採用方針
- `social.ts`（フッター用 SNS アイコン）と `mediaOutlets.ts`（カード形式の媒体紹介）は責務分離で別管理
- 外部リンクの `target/rel` 切替は `src/utils/externalLink.ts` に切り出して TDD
- セクションコンポーネントは既存の `SectionHeader + Card + .map()` パターンを踏襲。新規 UI 部品なし

## Test plan
- [x] `npm run test` 全 127 件パス（externalLink 4 件を新規追加）
- [x] `npx astro check` 型エラーなし
- [x] `npm run build` 成功
- [ ] `npm run dev` でトップを目視: 4 セクションの順序・準備中バッジ・simple-icons の読み込み・内部/外部リンクの遷移

## 後追いタスク（このPRでは扱わない）
- Threads / Zenn / YouTube / Udemy / Kindle の実 URL 設定（data ファイル編集だけで反映）
- Resources の実コンテンツ用意 → href / comingSoon 更新
- 注目ナレッジの差し替えはキュレーション運用

🤖 Generated with [Claude Code](https://claude.com/claude-code)