### PR TITLE
feat: 2026-05-24 AIニュース日次チェック（直近24h・更新なし）

### DIFF
--- a/docs/research/daily-ai-updates/2026-05-24.md
+++ b/docs/research/daily-ai-updates/2026-05-24.md
@@ -1,0 +1,86 @@
+---
+date: 2026-05-24
+title: "AI公式アップデート日次チェック 2026-05-24"
+fetched_at: 2026-05-24T10:55:00+09:00
+window_start: 2026-05-23T10:50:00+09:00
+window_end: 2026-05-24T10:55:00+09:00
+---
+
+# AI公式アップデート日次チェック 2026-05-24
+
+このファイルは日次サマリー専用です。詳細メモは各ツールの `official-updates/` 配下、公開候補は `src/content/ai-news/`、教材化メモは `src/content/ai-news-notes/` へ追加します。
+
+## サマリー
+
+- 対象期間: 2026-05-23T10:50:00+09:00 から 2026-05-24T10:55:00+09:00（前回ログ `2026-05-23.md` の window_end から連続。期間に欠落なし）
+- 更新あり: 1件（Claude Code v2.1.150 / 内部のみ）
+- 更新なし: 12件
+- 取得失敗・保留: 2件（OpenAI 公式 403 系、xAI 公式 403）
+- 公開記事化: 0件
+- 教材化メモ追加: 0件
+
+## 公開記事化済み
+
+なし。窓内に user-facing な公式アップデートが見当たらなかったため、AIニュース記事化は実施しない。
+
+## 見送り
+
+| service | title | 理由 |
+| --- | --- | --- |
+| Claude Code | v2.1.150 | CHANGELOG 上「Internal infrastructure improvements (no user-facing changes)」。読者影響なし |
+| OpenAI Codex | rust-v0.134.0-alpha 系 | 窓内 alpha 公開なし（最新 alpha.3 は 2026-05-23T01:05Z で前回窓内） |
+| OpenAI Status | Codex rate limit incident（2026-05-23 10:58 PT 前後） | 短時間で軽減策適用済み。記事化は見送り |
+
+直近24時間で観測された公式アップデートは Claude Code v2.1.150 のみで、内容は内部基盤改善（user-facing change なし）。前回窓（〜2026-05-23 10:50 JST）に v2.1.149 が release で記事化済みのため、v2.1.150 は連続パッチの内部リリースとして「更新あり / 記事化なし」で記録。
+他の主要 AI 製品の公式 Release Notes / Blog / Changelog には対象期間内の新規日付見出しが確認できず、また Workspace Updates / GitHub Copilot changelog / Anthropic news / claude.com/blog / Runway changelog & news / xAI release notes / Genspark / Manus / Meta AI / ByteDance Seed / Pika / Dify いずれも窓内更新なし。OpenAI 公式は WebFetch が 403 を返したため `取得失敗・保留` として記録。
+
+## 更新あり
+
+| service | published_at | title | category | detail |
+| --- | --- | --- | --- | --- |
+| Claude Code | 2026-05-23T04:03:51Z | Claude Code v2.1.150 — 内部基盤改善のみ | release | ../zenn-claude-code-release-basic/official-updates/2026-05-23T040351-claude-code-v2-1-150.md |
+
+## 更新なし
+
+- ChatGPT / OpenAI: OpenAI 公式 (`openai.com/news/`, `openai.com/ja-JP/news/`, `help.openai.com` ChatGPT release notes) は WebFetch 403 で本文取得失敗。Status 経由で確認した限り Codex rate limit incident のみ。Bloomberg / TechCrunch / Help Net Security 等の二次ソース経由でも対象期間内の独立な公式発表は捕捉できず。
+- OpenAI Codex: GitHub Releases は 2026-05-21T16:48Z の stable `rust-v0.133.0` 以降、窓内に新規 stable / alpha の公開なし（前回窓に含めた alpha.1〜alpha.3 以降の追加 alpha なし）。developers.openai.com/codex/changelog も 2026-05-21 以降の新規エントリなし。
+- Gemini: `blog.google/products-and-platforms/products/gemini/` に窓内日付の新規投稿なし。
+- Workspace Updates Blog: トップに窓内日付の個別ポストなし（最新は 2026-05-15）。週次 Recap も窓内未掲載。
+- Claude: `support.claude.com` release notes 最新日付見出しが 2026-05-21。`anthropic.com/news` 最新が 2026-05-22 Project Glasswing。`claude.com/blog` 最新が 2026-05-22 finance team 事例。いずれも前回窓に含めて記事化済み。窓内追加なし。
+- GitHub Copilot: `github.blog/changelog/label/copilot/` 最新が 2026-05-21（Eclipse 拡張機能 OSS 化）。窓内更新なし。
+- Genspark: `genspark.ai/blog` 最新が 2026-05-17。窓内更新なし。
+- Manus: `manus.im/blog` 最新が 2026-05-19。窓内更新なし。
+- Dify: GitHub Releases 最新が 2026-05-19 の 1.14.2。窓内更新なし。
+- n8n: GitHub Releases 直近 24h で新規リリース観測されず（最新が 2026-05-22T10:01Z 群で前回窓内）。窓内更新なし。
+- Meta AI: `ai.meta.com/blog/` 最新が 2026-04-08。窓内更新なし。
+- Runway: `runwayml.com/changelog` 最新が 2026-05-21 Aleph 2.0、`runwayml.com/news` も同日まで。窓内更新なし。
+- ByteDance Seed: `seed.bytedance.com/en/blog/` 最新が 2026-04-23。窓内更新なし。
+- Pika: `pika.art/blog` 最新が 2024-06-05（観測上）。窓内更新なし。
+
+## 取得失敗・保留
+
+- OpenAI 公式 (`help.openai.com` ChatGPT Release Notes, `openai.com/news/`, `openai.com/ja-JP/news/`): WebFetch から HTTP 403。Status 経由・Anthropic 等の二次ソース経由でも独立な窓内公式発表は確認できないため、現時点では「窓内更新なし」と推定。次回チェック時に再確認。
+- xAI 公式 (`x.ai/news`): WebFetch から HTTP 403。`docs.x.ai/docs/release-notes` 側も対象期間の見出しなし。次回再確認。
+
+## 補足メモ
+
+- 前回ログ 2026-05-23.md 末尾の補足「Codex エラー率インシデントの解消コメントで GPT-5.5 の Codex 有料ユーザー全体展開言及があったが公式独立記事なし」については、本日も OpenAI 公式から独立記事を確認できず（403 のためも含む）。引き続き `status: 保留（公式独立記事なし）` のまま継続観察。
+- ユーザー認識ギャップへの新規追加なし。
+
+## チェック対象
+
+- ChatGPT / OpenAI: https://help.openai.com/en/articles/6825453-chatgpt-release-notes ・ https://openai.com/news/ ・ https://openai.com/ja-JP/news/ ・ https://status.openai.com/history
+- OpenAI Codex: https://github.com/openai/codex/releases ・ https://developers.openai.com/codex/changelog
+- Gemini: https://blog.google/products-and-platforms/products/gemini/ ・ https://workspaceupdates.googleblog.com/
+- Claude: https://support.claude.com/en/articles/12138966-release-notes ・ https://www.anthropic.com/news ・ https://claude.com/blog
+- Claude Code: https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md ・ https://github.com/anthropics/claude-code/releases
+- GitHub Copilot: https://github.blog/changelog/label/copilot/
+- Genspark: https://www.genspark.ai/blog
+- Manus: https://manus.im/blog
+- Dify: https://github.com/langgenius/dify/releases
+- n8n: https://github.com/n8n-io/n8n/releases
+- Meta AI: https://ai.meta.com/blog/
+- Runway: https://runwayml.com/changelog ・ https://runwayml.com/news
+- xAI / Grok: https://docs.x.ai/docs/release-notes ・ https://x.ai/news
+- ByteDance Seed: https://seed.bytedance.com/en/blog/
+- Pika: https://pika.art/blog

--- a/docs/research/zenn-claude-code-release-basic/official-updates/2026-05-23T040351-claude-code-v2-1-150.md
+++ b/docs/research/zenn-claude-code-release-basic/official-updates/2026-05-23T040351-claude-code-v2-1-150.md
@@ -1,0 +1,40 @@
+---
+date: 2026-05-23
+title: "Claude Code v2.1.150 — 内部基盤改善のみ（user-facing change なし）"
+service: "Claude Code"
+source: https://github.com/anthropics/claude-code/releases/tag/v2.1.150
+fetched_at: 2026-05-24T10:55:00+09:00
+published_at: 2026-05-23T04:03:51Z
+date_precision: timestamp
+category: release
+---
+
+# 2026-05-23 Claude Code v2.1.150
+
+## 公式内容の日本語要約
+
+raw CHANGELOG (`raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md`) の v2.1.150 セクションには「Internal infrastructure improvements (no user-facing changes)」とだけ記載されている。新機能・バグ修正・UI 変更はなく、内部基盤のメンテナンスリリース。
+
+前バージョン v2.1.149（前回窓内に release）が `/usage` カテゴリ内訳・MCP Enterprise 一括許可・PowerShell 権限バイパス修正など複数の機能変更を含んだのに対し、v2.1.150 はそれらの上に乗せる内部リファクタ／インフラ修正の位置付け。
+
+## できるようになったこと
+
+- 直接的に増える機能はなし。
+
+## 影響範囲
+
+- 対象ユーザー: 全 Claude Code ユーザー（自動更新で適用される想定）。
+- 対象プラン: 影響なし。
+- API / UI / 管理者機能: いずれも変更なし。
+
+## 教材化メモ
+
+- AIニュース記事化はしない。`/changelog` / `/release-notes` の「内部のみリリース」をユーザー視点で扱う運用例として、次回チャレンジ記事化時の「採否判断基準」サンプルにする。
+- v2.1.149 までの累積差分（バージョン跨ぎでの学び）は、別途まとめ記事化を検討する余地あり。今回単体での教材化は見送り。
+
+## 原文確認
+
+- 公式見出し: v2.1.150 / Internal infrastructure improvements (no user-facing changes)
+- 公式URL: https://github.com/anthropics/claude-code/releases/tag/v2.1.150
+- raw CHANGELOG: https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md
+- 原文全文は公式ページで確認してください。


### PR DESCRIPTION
## Summary
- 対象期間: 2026-05-23T10:50 〜 2026-05-24T10:55 JST
- 窓内で観測された公式アップデートは **Claude Code v2.1.150 のみ**で、CHANGELOG 上「Internal infrastructure improvements (no user-facing changes)」のため AIニュース記事化は見送り
- 他の主要 AI 製品の公式 Release Notes / Blog / Changelog（Gemini / Anthropic news / claude.com/blog / Codex GH Releases / Workspace Updates / Copilot changelog / Runway / xAI / Genspark / Manus / Dify / n8n / Meta AI / ByteDance Seed / Pika）は窓内更新なし
- OpenAI 公式 (`help.openai.com` / `openai.com/news/` / `openai.com/ja-JP/news/`) と xAI `x.ai/news` は WebFetch から 403 のため `取得失敗・保留`。OpenAI Status から Codex rate limit incident（短時間で復旧）は確認済みで日次サマリーに言及のみ
- 結果として AIニュース記事 / 教材化メモの追加はなし

## 含まれる変更
- `docs/research/daily-ai-updates/2026-05-24.md`（日次サマリー）
- `docs/research/zenn-claude-code-release-basic/official-updates/2026-05-23T040351-claude-code-v2-1-150.md`（詳細メモ）

## Test plan
- [x] サマリーの window が前回ログ `2026-05-23.md` の window_end から欠落なく連続している
- [x] 詳細メモに `source` / `fetched_at` / `published_at` / `原文確認` が揃っている
- [x] サマリー内の相対リンク `../zenn-claude-code-release-basic/official-updates/...` が解決する

🤖 Generated with [Claude Code](https://claude.com/claude-code)