### PR TITLE
feat: トップページに note 最新記事3件セクションを追加

### DIFF
--- a/src/components/sections/NoteArticles.astro
+++ b/src/components/sections/NoteArticles.astro
@@ -1,0 +1,75 @@
+---
+import { mediaOutlets } from "@/data";
+import SectionHeader from "@/components/ui/SectionHeader.astro";
+import { fetchNoteFeed } from "@/utils/noteFeed";
+
+const noteOutlet = mediaOutlets.find((o) => o.name === "note");
+const noteUrl = noteOutlet?.url;
+const rssUrl = noteUrl ? `${noteUrl.replace(/\/$/, "")}/rss` : undefined;
+
+const articles = rssUrl ? await fetchNoteFeed(rssUrl, 3) : [];
+
+function formatDate(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}/${m}/${d}`;
+}
+---
+
+{
+  articles.length > 0 && (
+    <section id="note-articles" class="py-20">
+      <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+        <SectionHeader
+          title="note の最新記事"
+          subtitle="現場視点の AI 活用メモを継続発信中。直近の投稿をピックアップしています。"
+        />
+
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {articles.map((article, i) => (
+            <a
+              href={article.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              class={`group block bg-card/95 ring-1 ring-gray-950/5 shadow-sm rounded-3xl overflow-hidden transition-all duration-300 hover:ring-teal-500/20 hover:shadow-md animate-on-scroll stagger-${(i % 5) + 1}`}
+            >
+              {article.thumbnail && (
+                <div class="aspect-video bg-secondary/40 overflow-hidden">
+                  <img
+                    src={article.thumbnail}
+                    alt=""
+                    loading="lazy"
+                    class="w-full h-full object-cover group-hover:scale-[1.02] transition-transform duration-300"
+                  />
+                </div>
+              )}
+              <div class="p-5">
+                <p class="text-xs text-muted-foreground mb-2">
+                  {formatDate(article.pubDate)}
+                </p>
+                <h3 class="text-base font-semibold text-foreground group-hover:text-teal-700 transition-colors line-clamp-2">
+                  {article.title}
+                  <span class="text-muted-foreground text-sm ml-1">↗</span>
+                </h3>
+              </div>
+            </a>
+          ))}
+        </div>
+
+        {noteUrl && (
+          <div class="mt-10 text-center">
+            <a
+              href={noteUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="inline-flex items-center gap-1 text-sm font-medium text-teal-600 hover:text-teal-700 transition-colors"
+            >
+              note をすべて見る →
+            </a>
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,6 +5,7 @@ import Stats from "@/components/sections/Stats.astro";
 import Services from "@/components/sections/Services.astro";
 import FeaturedKnowledge from "@/components/sections/FeaturedKnowledge.astro";
 import Media from "@/components/sections/Media.astro";
+import NoteArticles from "@/components/sections/NoteArticles.astro";
 import Resources from "@/components/sections/Resources.astro";
 import TechStack from "@/components/sections/TechStack.astro";
 import Cta from "@/components/sections/Cta.astro";
@@ -16,6 +17,7 @@ import Cta from "@/components/sections/Cta.astro";
   <Services />
   <FeaturedKnowledge />
   <Media />
+  <NoteArticles />
   <Resources />
   <TechStack />
   <Cta />

--- a/src/utils/noteFeed.ts
+++ b/src/utils/noteFeed.ts
@@ -1,0 +1,94 @@
+/**
+ * note (note.com) の個人ページ RSS 2.0 フィードを取得・パースするユーティリティ。
+ * 外部ライブラリ依存を避けるため、文字列ベースの軽量パーサで実装する。
+ * note の RSS は固定構造（<item> 単位、CDATA セクション、<media:thumbnail>）のため
+ * 正規表現で十分実用に足る。汎用 RSS パーサが必要になったら xml2js 等への置換を検討する。
+ */
+
+export interface NoteArticle {
+  title: string;
+  link: string;
+  pubDate: Date;
+  thumbnail: string | undefined;
+  description: string;
+}
+
+const ITEM_RE = /<item\b[^>]*>([\s\S]*?)<\/item>/g;
+
+function extractTag(block: string, tag: string): string | undefined {
+  const re = new RegExp(`<${tag}\\b[^>]*>([\\s\\S]*?)<\\/${tag}>`);
+  const m = block.match(re);
+  if (!m) return undefined;
+  return stripCdata(m[1]).trim();
+}
+
+function stripCdata(value: string): string {
+  const cdataMatch = value.match(/<!\[CDATA\[([\s\S]*?)\]\]>/);
+  return cdataMatch ? cdataMatch[1] : value;
+}
+
+function stripHtml(value: string): string {
+  return value
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .trim();
+}
+
+export function parseNoteFeed(xml: string): NoteArticle[] {
+  if (!xml || !xml.includes("<item")) return [];
+
+  try {
+    const articles: NoteArticle[] = [];
+    const matches = xml.matchAll(ITEM_RE);
+
+    for (const match of matches) {
+      const block = match[1];
+      const title = extractTag(block, "title");
+      const link = extractTag(block, "link");
+      const pubDateStr = extractTag(block, "pubDate");
+      const descriptionRaw = extractTag(block, "description") ?? "";
+      const thumbnail = extractTag(block, "media:thumbnail");
+
+      if (!title || !link || !pubDateStr) continue;
+      const pubDate = new Date(pubDateStr);
+      if (Number.isNaN(pubDate.getTime())) continue;
+
+      articles.push({
+        title,
+        link,
+        pubDate,
+        thumbnail: thumbnail || undefined,
+        description: stripHtml(descriptionRaw),
+      });
+    }
+
+    return articles;
+  } catch (error) {
+    console.error("[noteFeed] parse failed:", error);
+    return [];
+  }
+}
+
+export async function fetchNoteFeed(
+  rssUrl: string,
+  limit: number,
+): Promise<NoteArticle[]> {
+  try {
+    const response = await fetch(rssUrl, {
+      headers: { "User-Agent": "shogo-works-site/1.0 (+https://shogoworks.com)" },
+    });
+    if (!response.ok) {
+      console.error(`[noteFeed] fetch failed: ${response.status} ${rssUrl}`);
+      return [];
+    }
+    const xml = await response.text();
+    return parseNoteFeed(xml).slice(0, limit);
+  } catch (error) {
+    console.error("[noteFeed] fetch threw:", error);
+    return [];
+  }
+}

--- a/tests/utils/noteFeed.test.ts
+++ b/tests/utils/noteFeed.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchNoteFeed, parseNoteFeed } from "@/utils/noteFeed";
+
+const sampleRss = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/" xmlns:note="https://note.com/">
+  <channel>
+    <title>note - shogo123198</title>
+    <item>
+      <title><![CDATA[最新記事タイトル1]]></title>
+      <link>https://note.com/shogo123198/n/n0000001</link>
+      <guid>https://note.com/shogo123198/n/n0000001</guid>
+      <pubDate>Sat, 23 May 2026 10:00:00 +0900</pubDate>
+      <description><![CDATA[<p>概要1のテキスト</p>]]></description>
+      <media:thumbnail>https://assets.st-note.com/img/1.jpg</media:thumbnail>
+    </item>
+    <item>
+      <title><![CDATA[2件目のタイトル]]></title>
+      <link>https://note.com/shogo123198/n/n0000002</link>
+      <guid>https://note.com/shogo123198/n/n0000002</guid>
+      <pubDate>Wed, 20 May 2026 09:00:00 +0900</pubDate>
+      <description><![CDATA[概要2]]></description>
+      <media:thumbnail>https://assets.st-note.com/img/2.jpg</media:thumbnail>
+    </item>
+    <item>
+      <title><![CDATA[3件目]]></title>
+      <link>https://note.com/shogo123198/n/n0000003</link>
+      <guid>https://note.com/shogo123198/n/n0000003</guid>
+      <pubDate>Tue, 01 Apr 2026 08:00:00 +0900</pubDate>
+      <description><![CDATA[概要3]]></description>
+      <media:thumbnail>https://assets.st-note.com/img/3.jpg</media:thumbnail>
+    </item>
+    <item>
+      <title><![CDATA[4件目]]></title>
+      <link>https://note.com/shogo123198/n/n0000004</link>
+      <guid>https://note.com/shogo123198/n/n0000004</guid>
+      <pubDate>Mon, 01 Mar 2026 08:00:00 +0900</pubDate>
+      <description><![CDATA[概要4]]></description>
+    </item>
+  </channel>
+</rss>`;
+
+describe("parseNoteFeed", () => {
+  it("正常系: RSS文字列を受け取ったとき、各itemをNoteArticleにパースすること", () => {
+    const articles = parseNoteFeed(sampleRss);
+
+    expect(articles).toHaveLength(4);
+    expect(articles[0]).toEqual({
+      title: "最新記事タイトル1",
+      link: "https://note.com/shogo123198/n/n0000001",
+      pubDate: new Date("Sat, 23 May 2026 10:00:00 +0900"),
+      thumbnail: "https://assets.st-note.com/img/1.jpg",
+      description: "概要1のテキスト",
+    });
+  });
+
+  it("正常系: media:thumbnailが無いitemでも、thumbnailがundefinedで返ること", () => {
+    const articles = parseNoteFeed(sampleRss);
+    const fourth = articles[3];
+    expect(fourth.thumbnail).toBeUndefined();
+    expect(fourth.title).toBe("4件目");
+  });
+
+  it("正常系: descriptionのHTMLタグを除去すること", () => {
+    const articles = parseNoteFeed(sampleRss);
+    expect(articles[0].description).toBe("概要1のテキスト");
+  });
+
+  it("異常系: 空文字を渡したとき、空配列を返すこと", () => {
+    expect(parseNoteFeed("")).toEqual([]);
+  });
+
+  it("異常系: 不正なXMLを渡したとき、空配列を返すこと", () => {
+    expect(parseNoteFeed("<<<not xml>>>")).toEqual([]);
+  });
+});
+
+describe("fetchNoteFeed", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("正常系: limitを指定したとき、その件数までに絞り込まれること", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => sampleRss,
+    }) as typeof fetch;
+
+    const articles = await fetchNoteFeed("https://note.com/x/rss", 3);
+    expect(articles).toHaveLength(3);
+    expect(articles[0].title).toBe("最新記事タイトル1");
+  });
+
+  it("異常系: fetchがokでないとき、空配列を返すこと", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => "",
+    }) as typeof fetch;
+
+    const articles = await fetchNoteFeed("https://note.com/x/rss", 3);
+    expect(articles).toEqual([]);
+  });
+
+  it("異常系: fetchがthrowしたとき、空配列を返すこと", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("network down")) as typeof fetch;
+
+    const articles = await fetchNoteFeed("https://note.com/x/rss", 3);
+    expect(articles).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- note 個人ページの RSS フィード（`https://note.com/shogo123198/rss`）をビルド時に取得し、トップページの Media セクション直後にサムネ付きカードで最新3件を表示
- `src/utils/noteFeed.ts` を外部ラッパーとして追加（外部ライブラリ依存なし／文字列ベースのパース）
- fetch/パース失敗時は空配列にフォールバックし、セクション自体を非表示にすることでビルドを継続

## 変更ファイル
- `src/utils/noteFeed.ts` — RSS 取得＋パース層
- `tests/utils/noteFeed.test.ts` — vitest（正常系5/異常系3）
- `src/components/sections/NoteArticles.astro` — 表示セクション
- `src/pages/index.astro` — `<NoteArticles />` を `<Media />` 直後に挿入

## Test plan
- [x] `npm test -- noteFeed` → 8/8 pass
- [x] `npm run check` → 0 errors / 0 warnings
- [x] `npm run build` → 成功、`dist/client/index.html` に直近3件の note 記事URLが静的埋め込み済み
- [ ] プレビューでの目視確認（カード表示・サムネ・「note をすべて見る」リンク）

🤖 Generated with [Claude Code](https://claude.com/claude-code)