### PR TITLE
feat: 2026-05-25 AIニュース日次チェック（直近24h・更新なし）

### DIFF
--- a/docs/research/daily-ai-updates/2026-05-25.md
+++ b/docs/research/daily-ai-updates/2026-05-25.md
@@ -1,0 +1,102 @@
+---
+date: 2026-05-25
+title: "AI公式アップデート日次チェック 2026-05-25"
+fetched_at: 2026-05-25T11:30:00+09:00
+window_start: 2026-05-24T10:55:00+09:00
+window_end: 2026-05-25T11:30:00+09:00
+---
+
+# AI公式アップデート日次チェック 2026-05-25
+
+このファイルは日次サマリー専用です。詳細メモは各ツールの `official-updates/` 配下、公開候補は `src/content/ai-news/`、教材化メモは `src/content/ai-news-notes/` へ追加します。
+
+## サマリー
+
+- 対象期間: 2026-05-24T10:55:00+09:00 から 2026-05-25T11:30:00+09:00（前回ログ `2026-05-24.md` の window_end から連続。期間に欠落なし）
+- 更新あり: 0件（user-facing な公式リリースなし）
+- 更新なし: 14件
+- 取得失敗・保留: 3件（OpenAI 公式系 403、xAI 公式 403、xAI Docs Release Notes が空テンプレ表示）
+- インシデント: 1件（OpenAI Status — gpt-5.5 in Codex / 短時間で復旧）
+- 公開記事化: 0件
+- 教材化メモ追加: 0件
+
+## 公開記事化済み
+
+なし。窓内に user-facing な公式アップデートが見当たらなかったため、AIニュース記事化は実施しない。
+
+## 見送り
+
+| service | title | 理由 |
+| --- | --- | --- |
+| OpenAI / Codex | gpt-5.5 in Codex の elevated errors（2026-05-24 22:15 UTC、完全復旧） | 短時間 incident。SKILL ルールに従い日次サマリー言及のみで記事化・詳細メモ化はしない |
+
+## 更新あり
+
+| service | published_at | title | category | detail |
+| --- | --- | --- | --- | --- |
+| - | - | （window 内に user-facing な公式リリース・記事化対象なし） | - | - |
+
+補足:
+
+- **OpenAI Status** に gpt-5.5 in Codex の elevated errors（2026-05-24 22:15 UTC ≒ 2026-05-25 07:15 JST 前後）の incident が 1 件。完全復旧。短時間 incident のため SKILL ルールに従い記事化・詳細メモ化は見送り、日次サマリーへの言及のみとする。
+- **Claude Code** は GitHub Releases 最新が `v2.1.150`（2026-05-23T04:03:51Z、前回 2026-05-24.md で既に記録済み）。窓内の新規リリースなし。
+- **OpenAI Codex** は GitHub Releases 最新が `rust-v0.134.0-alpha.3`（2026-05-23T01:05:40Z、stable は `rust-v0.133.0` で 2026-05-21）。窓内の新規 stable / alpha リリースなし。
+- **n8n** は GitHub Releases 最新が `n8n@2.22.2`（2026-05-22T10:01:57Z、pre-release）。窓内の新規リリースなし。
+- **Dify** は GitHub Releases 最新が `1.14.2`（2026-05-19）。窓内の新規リリースなし。
+- **GitHub Copilot Changelog** 最新は `2026-05-21` の Eclipse OSS 化。窓内の新規エントリなし。
+- **Workspace Updates Blog** は 2026-05-15 の週次 Recap 以降、個別ポスト・週次 Recap いずれも公開なし（次の Recap は 2026-05-22 の可能性があるが、search でも未確認）。
+- **Runway** は changelog 最新が 2026-05-21 の Aleph 2.0、News も同日。窓内の新規発表なし。
+- **xAI Docs Release Notes** はページ構造のみ表示で本文取得できず（前日も同様）。`x.ai/news` は 403。`docs.x.ai/developers/migration/may-15-retirement` の旧告知が二次ソース引用に出るのみで、新規発表は確認できず。
+
+## 更新なし
+
+- ChatGPT / OpenAI（Newsトップ / カテゴリ系 / help center）: 窓内の新規投稿なし（直アクセス 403、search 経由でも 5/24-25 付け公式新規記事なし）
+- OpenAI Codex（GitHub Releases / Developers Changelog）: 窓内の新規リリースなし
+- Anthropic（anthropic.com/news）: 直近 2026-05-22 の Project Glasswing が最新
+- Claude（claude.com/blog）: 直近 2026-05-22 の finance team 事例が最新
+- Claude Release Notes（support.claude.com）: 直近 2026-05-21 が最新
+- Claude Code（CHANGELOG / Releases）: 直近 v2.1.150（2026-05-23）が最新
+- GitHub Copilot Changelog: 直近 2026-05-21 が最新
+- Google Workspace Updates: 直近 2026-05-15 の Weekly Recap が最新
+- Gemini Blog（blog.google）: I/O 2026（5/19）以降の独立した新規発表は窓内に確認できず
+- DeepMind Blog: 窓内の新規投稿なし（I/O 2026 関連は前週分）
+- Runway（changelog / News）: 直近 2026-05-21 の Aleph 2.0 が最新
+- Meta AI Blog: 直近 2026-04-08 が最新
+- Genspark Blog: 直近 2026-05-17 が最新
+- Manus Blog: 直近 2026-05-19 が最新
+- Dify（GitHub Releases / Blog）: 直近 1.14.2（2026-05-19）が最新
+- n8n（GitHub Releases）: 直近 n8n@2.22.2（2026-05-22, pre-release）が最新
+- ByteDance Seed Blog: 直近 2026-04-23 が最新
+- Pika（pika.art/blog）: 公式 Blog 観測本文は古い投稿のみで窓内更新なし
+- AWS What's New / Machine Learning Blog（Claude 関連逆引き）: 窓内に Claude / Bedrock の新規発表は確認できず
+
+## 取得失敗・保留
+
+- `openai.com/news/`、`help.openai.com/.../chatgpt-release-notes`、`openai.com/news/product-releases/`: 直アクセス 403。代替に search 経由で巡回したが、5/24-25 付けの公式新規記事は確認できず。前日と同様、Releasebot 等の二次ソースも 2026-05-21 の release notes（Appshots / Goal モード GA / browser annotation 強化 / Locked Computer Use）止まり。
+- `x.ai/news`: 直アクセス 403。search でも 5/22 の third-party connectors 以降の窓内新規発表は確認できず。
+- `docs.x.ai/docs/release-notes`: ページが空テンプレート表示で本文取得できず。Releasebot 経由でも窓内の新規エントリは確認できず。
+
+## 補足メモ
+
+- ユーザー認識ギャップ該当: 特になし。
+- 二次ソース観測（Releasebot / 業界系まとめ）でも、2026-05-24 〜 2026-05-25 にかけて主要ベンダーの user-facing な公式新規発表は確認されず。直近 1 週間で I/O 2026・Code w/ Claude・Codex 0.133.0 / Appshots 等の大型発表が集中したあと、各社の発表リズムが一時的に落ち着いている状態と判断。
+
+## チェック対象
+
+- ChatGPT / OpenAI: https://help.openai.com/en/articles/6825453-chatgpt-release-notes / https://openai.com/news/ / https://status.openai.com/
+- OpenAI Codex: https://github.com/openai/codex/releases / https://developers.openai.com/codex/changelog
+- Anthropic / Claude: https://www.anthropic.com/news / https://claude.com/blog / https://support.claude.com/en/articles/12138966-release-notes
+- Claude Code: https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md / https://github.com/anthropics/claude-code/releases
+- GitHub Copilot: https://github.blog/changelog/label/copilot/
+- Gemini / Workspace: https://blog.google/products-and-platforms/products/gemini/ / https://workspaceupdates.googleblog.com/
+- xAI / Grok: https://docs.x.ai/docs/release-notes / https://x.ai/news
+- n8n: https://github.com/n8n-io/n8n/releases
+- Dify: https://github.com/langgenius/dify/releases
+- Runway: https://runwayml.com/changelog / https://runwayml.com/news
+- Meta AI: https://ai.meta.com/blog/
+- Genspark: https://www.genspark.ai/blog
+- Manus: https://manus.im/blog
+- ByteDance Seed: https://seed.bytedance.com/en/blog/
+- Pika: https://pika.art/blog
+- DeepMind: https://deepmind.google/discover/blog/
+- AWS（Claude 連携逆引き）: https://aws.amazon.com/about-aws/whats-new/recent/


### PR DESCRIPTION
## Summary

- 直近 24h（2026-05-24T10:55+09:00 〜 2026-05-25T11:30+09:00）の AI 公式アップデートを `daily-ai-update-monitor` スキルに従って巡回。
- 主要 17 ソースとも user-facing な公式新規リリースなし。OpenAI Status の `gpt-5.5 in Codex` 短時間 incident（完全復旧）のみで、SKILL ルールに従い記事化・詳細メモ化は見送り、日次サマリー言及のみ。
- 公開記事化: 0 件 / 教材化メモ: 0 件（前日 #167 と同じ「更新なし日」パターン）。

## 変更ファイル

- `docs/research/daily-ai-updates/2026-05-25.md`（新規 / 102 行）

## 取得失敗・保留

- OpenAI 公式系 (`openai.com/news/`、`help.openai.com/.../chatgpt-release-notes`、`product-releases/`): 直アクセス 403。search 経由でも 5/24-25 付け公式新規記事は確認できず。
- `x.ai/news`: 403。
- `docs.x.ai/docs/release-notes`: ページが空テンプレ表示で本文取得できず。

## Test plan

- [x] `npm run check` 実行（0 errors / 0 warnings）
- [x] frontmatter（`date` / `fetched_at` / `window_start` / `window_end`）整合確認
- [x] 前日 `2026-05-24.md` の `window_end` と連続していること
- [x] `TODO` / `FIXME` / `要確認` 残りなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)