### PR TITLE
feat: 2026-05-28 AIニュース日次チェック（Claude Code v2.1.152/153、Codex 0.134.0、Managed Agents、Copilot、Cursor 初収載）

### DIFF
--- a/.claude/skills/daily-ai-update-monitor/references/perception-gaps.md
+++ b/.claude/skills/daily-ai-update-monitor/references/perception-gaps.md
@@ -18,6 +18,19 @@
 
 ---
 
+## 2026-05-28: 「Genspark Slides 5.0 がリリースされた」
+
+- **ユーザー認識**: 「Genspark Slides が 5.0 になった」
+- **公式実態**: Genspark の公式 Blog（`genspark.ai/blog`）と AI Slides Changelog（`genspark.ai/docs/ai_slides_changelog`、当窓は 403 で取得不可）のいずれも、対象期間（2026-05-26〜2026-05-28）に「Slides 5.0」名義の発表は確認できない。直近の大型発表は 2026-04-08 の **AI Workspace 4.0**、製品系列としての Slides は **Creative Mode** や `.pptx インポート→テンプレ化` などの個別機能追加が直近のメイン更新。「Slides 5.0」というメジャーバージョン採番は公式に存在しない（少なくとも公開ページ上では確認できない）。
+- **裏取り URL**:
+  - Genspark Blog 直近一覧（最新が 2026-05-17、Workspace 4.0 は 2026-04-08）: https://www.genspark.ai/blog
+  - AI Workspace 4.0 公式発表: https://www.genspark.ai/blog/introducing-genspark-ai-workspace-4-0-your-ai-employee-now-everywhere
+  - AI Slides 製品トップ: https://www.genspark.ai/agents?type=slides_agent
+- **窓内の関連発表**: 2026-05-26〜2026-05-28 に Slides 関連の公式新規エントリなし（`genspark.ai/docs` は 403 で再確認待ち）。
+- **メモ作成日**: 2026-05-28
+
+---
+
 ## エントリ追加ルール
 
 新しいギャップが見つかったら、上記フォーマットで上から積む。

--- a/.claude/skills/daily-ai-update-monitor/references/source-catalog.md
+++ b/.claude/skills/daily-ai-update-monitor/references/source-catalog.md
@@ -11,6 +11,7 @@
 | Gemini | https://blog.google/products-and-platforms/products/gemini/ | https://workspaceupdates.googleblog.com/（週次Recap + 個別ポスト） | 週数回 | docs/research/zenn-gemini-release-basic/official-updates |
 | Claude | https://support.claude.com/en/articles/12138966-release-notes | https://www.anthropic.com/news、https://claude.com/blog、https://aws.amazon.com/about-aws/whats-new/、https://aws.amazon.com/blogs/machine-learning/、https://platform.claude.com/docs/ | 週1〜2回 | docs/research/zenn-claude-release-basic/official-updates |
 | Claude Code | https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md | https://github.com/anthropics/claude-code/releases | ほぼ毎日 | docs/research/zenn-claude-code-release-basic/official-updates |
+| Cursor | https://cursor.com/changelog | https://cursor.com/blog、https://status.cursor.com/、https://forum.cursor.com/c/announcements | 週1〜2回 | docs/research/zenn-cursor-basic/official-updates |
 | GitHub Copilot | https://github.blog/changelog/label/copilot/ | https://docs.github.com/en/copilot | ほぼ毎日 | docs/research/zenn-github-copilot-basic/official-updates |
 | Genspark | https://www.genspark.ai/blog | なし | 月数回 | docs/research/zenn-genspark-basic/official-updates |
 | Manus | https://manus.im/blog | なし | 月数回 | docs/research/zenn-manus-basic/official-updates |
@@ -64,6 +65,7 @@ Codex は stable（`rust-vX.Y.Z`）と alpha（`rust-vX.Y.Z-alpha.N`）が並行
 - **Claude / Anthropic公式Blogは `anthropic.com/news` だけでなく `claude.com/blog` も確認します**。Claude Platform、Claude API、AWS / Bedrock / Vertex / Foundry 連携、Console、Managed Agents、Skills、MCP connector のような開発者向け発表は `claude.com/blog/<slug>` 側に出ることがあります。
 - **Claude のクラウドプロバイダー連携はプロバイダー公式も一次情報として確認します**。特に AWS は `aws.amazon.com/about-aws/whats-new/` と `aws.amazon.com/blogs/machine-learning/` で Claude Platform on AWS / Bedrock 関連の GA・機能拡張を発表するため、`site:aws.amazon.com Claude Platform Anthropic` などで逆引きします。Anthropic公式に掲載が遅れる / 別ドメイン掲載される場合でも、AWS公式で確認できれば対象にします。
 - Claude Codeはraw changelogが最も安定しています。
+- **Cursor** は `cursor.com/changelog` の個別ポスト URL（例 `cursor.com/changelog/composer-2-5`、`cursor.com/changelog/MM-DD-YY`）の方が本文が詳しいため、トップ一覧で見出しを掴んだら必ず個別 URL を踏みます。メジャー版（`3.0`）と minor 機能名（`Composer 2.5`、`Shared Canvases`）と日付スラッグが混在するため、tag 名だけで重複判定しません。GitHub Releases は公式に未提供。`cursor.com/blog` 側にも re-branding 系・大型 UX 変更（"Meet the new Cursor"）が出るため両方確認します。
 - n8n GitHub Releasesは必ずpagination込みで確認します。HTMLの1ページ目だけを見て完了扱いにしません。
 - **Workspace Updates Blog** は週次Recap（`weekly-recap-MM-DD-2026.html`）に集約されますが、**個別ポスト URL（`workspaceupdates.googleblog.com/2026/MM/<slug>.html`）の方が情報が詳細**で日付もはっきりします。多言語対応・地域ロールアウト・GA切替などは個別ポストにのみ載るため、Recap だけで完了扱いにしません。
 - Difyのpre-releaseは、対象期間内であれば `channel: pre-release` として含めます。

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -36,6 +36,7 @@ const aiNews = defineCollection({
       "claude",
       "claude-code",
       "codex",
+      "cursor",
       "gemini",
       "github-copilot",
       "manus",

--- a/src/content/ai-news-notes/claude-code/claude-code-v2-1-152.mdx
+++ b/src/content/ai-news-notes/claude-code/claude-code-v2-1-152.mdx
@@ -1,0 +1,18 @@
+---
+title: "Claude Code v2.1.152 教材化メモ"
+noteFor: "claude-code/claude-code-v2-1-152"
+date: 2026-05-27
+tags: ["claude-code", "code-review", "hooks", "skills", "auto-mode", "fallback-model"]
+---
+
+new-commands-2026 教材は `/code-review` の節を「結果を見るコマンド」から「`--fix` で適用までできるコマンド」に書き換え候補。`/simplify` が `/code-review --fix` のエイリアスとして同じ動作になった点も追記し、「軽く整える」用途のコマンドが内部的に同じ実体であることを明示する。
+
+hooks 教材は、`MessageDisplay` hook と `SessionStart.hookSpecificOutput.reloadSkills` / `sessionTitle` を扱う節を新設できる。`MessageDisplay` は「アシスタント出力を画面に出す直前に書き換えできる hook」という位置付けで、社外秘マスク・固定フッター挿入・条件付き非表示の例で説明するのが分かりやすい。
+
+skills 教材は、`disallowed-tools` frontmatter を「skill 設計時に最小権限化する仕組み」として節追加。`/reload-skills` を併記して「frontmatter を変えてもセッションを切らずに反映」を運用フローとして書く。
+
+managed-settings 教材があれば、`pluginSuggestionMarketplaces` の節を追加。「context-aware tip 経由で提案される org marketplace を allowlist 化する設定」と説明。
+
+`--fallback-model` の挙動変更（リクエスト単位失敗 → セッション残りを切替）は、install-and-setup 教材または cli-options 教材で、`--model` / `--fallback-model` の組み合わせを扱う節に短く追記。
+
+Vim 逆履歴検索（NORMAL モードで `/`）は、Vim キーバインドを扱う独立節を持っている場合にのみ追記。それ以外は本記事のみで完結させる。

--- a/src/content/ai-news-notes/claude-code/claude-code-v2-1-153.mdx
+++ b/src/content/ai-news-notes/claude-code/claude-code-v2-1-153.mdx
@@ -1,0 +1,18 @@
+---
+title: "Claude Code v2.1.153 教材化メモ"
+noteFor: "claude-code/claude-code-v2-1-153"
+date: 2026-05-28
+tags: ["claude-code", "model", "mcp", "plugins", "background-agents", "security"]
+---
+
+new-commands-2026 教材の `/model` 節を「セッション限定切替」前提から「**既定保存** + `s` でセッション限定切替」前提に書き換え候補。あわせて `modelPicker:setAsDefault` → `modelPicker:thisSessionOnly` のキーバインド名変更を周知。
+
+mcp 教材は、v2.1.147 リグレッション（stateful MCP `tools/list` reconnect ループ）について「**v2.1.147〜v2.1.152 を踏んだ場合は v2.1.153 へ即時アップグレード**」の注意を恒久情報として 1 行入れる。`--strict-mcp-config` が subagent frontmatter MCP server に再度適用されるようになった点も MCP × subagent の節に追記し、「ブロックされた subagent MCP は warning が出る」運用前提を補足。
+
+install-and-setup 教材は、custom API gateway 経由のクレデンシャル誤送信修正について「gateway 運用組織は v2.1.153 以降を強く推奨」を恒久情報として書く。Windows PowerShell installer の偽 "Installation complete!" 修正も Windows セクションに追記候補。
+
+plugins 教材があれば、`skipLfs` オプションを `github`/`git` plugin marketplace source の節に追加。LFS 同梱 plugin の clone コスト対策として説明。
+
+claude agents 教材は、dispatch input autocomplete のネイティブ slash command + bundled skill 対応、PR 列の `PR #N` / `N PRs` 表示を「v2.1.153 以降の挙動」として追記。
+
+background session 周りの修正（tmux 内 `/copy`、iTerm2 `cmd+k`、IME candidate window 位置、Windows での孤立 MCP server 解消、`Agent subagent_type: 'claude'` の temporary worktree 修正）は Knowledge 本体には残さず、本記事リンクからの参照に留める。

--- a/src/content/ai-news-notes/claude/claude-managed-agents-self-hosted-sandboxes-mcp-tunnels.mdx
+++ b/src/content/ai-news-notes/claude/claude-managed-agents-self-hosted-sandboxes-mcp-tunnels.mdx
@@ -1,0 +1,14 @@
+---
+title: "Claude Managed Agents Self-hosted sandboxes / MCP tunnels 教材化メモ"
+noteFor: "claude/claude-managed-agents-self-hosted-sandboxes-mcp-tunnels"
+date: 2026-05-26
+tags: ["claude", "managed-agents", "mcp", "self-hosted", "sandbox", "enterprise"]
+---
+
+managed-agents 教材は、「実行環境はどこで動くか」を扱う節を新設。Anthropic ホスト sandbox の従来構成と、Self-hosted sandboxes（public beta）の差を比較できる形にする。想定デプロイ先（自社インフラ・Cloudflare・Daytona・Modal・Vercel）を列挙しつつ、「いずれも public beta 段階のため、変更前提で扱う」を明文化。
+
+mcp 教材は、MCP tunnels（research preview）を「Managed Agents から社内 MCP に到達する経路」として節追加。社内 MCP 設計時の権限境界（MCP 単位で切る）を、tunnel 提供の登場を踏まえて推奨する記述に書き換える。research preview のため本番投入は早い、を必ず注記。
+
+Claude Code の sandbox 体系、Codex の `--profile` / sandbox 体系との対比は、次回のまとめ記事候補。Knowledge 本体への直接反映は、いずれも beta / preview のため避ける。
+
+Code w/ Claude 東京開催（2026-06-05〜06）は、Knowledge 本体に持ち込まない一過性情報。本記事リンクからの参照に留め、終了後に学んだ内容ベースで別記事化を検討する。

--- a/src/content/ai-news-notes/codex/codex-rust-v0-134-0.mdx
+++ b/src/content/ai-news-notes/codex/codex-rust-v0-134-0.mdx
@@ -1,0 +1,16 @@
+---
+title: "OpenAI Codex rust-v0.134.0 教材化メモ"
+noteFor: "codex/codex-rust-v0-134-0"
+date: 2026-05-26
+tags: ["codex", "profile", "mcp", "hooks", "thread-search", "stable", "breaking-change"]
+---
+
+cli-setup 教材は、`--profile` の主セレクタ昇格と legacy profile v1 廃止を **0.134 における破壊的変更** として節を新設。「0.133 までの設定ファイル・スクリプトは migration guidance に従って書き換える」「`codex sandbox` も `--profile` を受けるように」「profile 切替経路は CLI / TUI / sandbox / app-server で一本化された」の 3 点を明示。
+
+mcp 教材は、per-server environment、streamable HTTP MCP に対する OAuth option、connector tool schema の `$ref`/`$defs` 保持と過大 schema の compact 化、`readOnlyHint` の並列化を統合して節を更新。**MCP 設計指針**として「並列化したい MCP server には `readOnlyHint` を付ける」「環境を分けたい MCP server は per-server env を使う」を含める。Annotation 整備がそのままパフォーマンス改善になる、という運用ポイントを明文化。
+
+hooks 教材は、hook input に subagent identity が、extension tool に conversation history が渡されるようになった点を「v0.134 派生改善」として節追加。これにより subagent ごとに hook 動作を分岐させる、または会話履歴を踏まえてプロンプトを書き換える、いずれの設計パターンも記述例を 1 つずつ用意できる。
+
+knowledge-tools 系の教材があれば、**thread content search**（rollout ベースのローカル会話履歴検索）を「Codex を knowledge base としても扱う」観点で節追加。case-insensitive + result preview の仕様、`/goal` 運用との組み合わせを記載。
+
+bedrock 関連の教材があれば、**Bedrock Mantle GovCloud region** 追加を恒久情報として 1 行追記。

--- a/src/content/ai-news-notes/cursor/cursor-catch-up-2026-05.mdx
+++ b/src/content/ai-news-notes/cursor/cursor-catch-up-2026-05.mdx
@@ -1,0 +1,18 @@
+---
+title: "Cursor 直近キャッチアップ（2026-05）教材化メモ"
+noteFor: "cursor/cursor-catch-up-2026-05"
+date: 2026-05-20
+tags: ["cursor", "composer", "agents-window", "jira", "automations", "shared-canvases", "loop"]
+---
+
+Cursor は当サイトに本日（2026-05-28）初収載のツール。Knowledge 側にはまだ Cursor の独立教材がない想定のため、本キャッチアップ記事は **「初収載時点での全体マップ」** として残し、Knowledge 化はリリース単位の蓄積が進んでから着手する。
+
+- 次回以降は窓内のリリース単位で速報を出す方針に切り替える（catch-up ではなく差分）。
+- Knowledge 教材化候補:
+  - **`/loop` Skill とローカルスケジュール運用**: Composer 2.5 の持続タスク性能と組み合わせた「定常監視 agent」の設計パターン。
+  - **Cursor Automations の複数 repo / repo なし**: 業務 automation の設計指針（コードベース内 / 外をどう分けるか）。
+  - **Shared Canvases によるレビュー運用**: ライブスナップショット共有を前提にした非同期レビューフロー。
+  - **Cursor in Jira 統合**: 課題管理ツールから agent への hand-off パターン。
+- source-catalog 側の Cursor 行で個別ポスト URL を直接踏む運用を続けることで、メジャー版（3.5）と minor 機能名（Composer 2.5、Shared Canvases）と日付スラッグ（05-20-26）の混在に巻き込まれないように注意する。
+
+次回以降の Cursor 速報を書く際、本記事をエントリポイントとして相互リンクすることで、初回 catch-up の網羅性を保つ。

--- a/src/content/ai-news-notes/github-copilot/copilot-memory-controls-and-model-rules.mdx
+++ b/src/content/ai-news-notes/github-copilot/copilot-memory-controls-and-model-rules.mdx
@@ -1,0 +1,17 @@
+---
+title: "Copilot Memory 制御強化 + Model rules 教材化メモ"
+noteFor: "github-copilot/copilot-memory-controls-and-model-rules"
+date: 2026-05-26
+tags: ["github-copilot", "memory", "model-rules", "governance", "enterprise", "business"]
+---
+
+github-copilot/governance 教材があれば、章立てを **Enterprise → 組織 → リポジトリ → ユーザー** の 4 階層に合わせて見直す。
+
+- **Enterprise 層**: Model rules でデフォルトモデル選択と `Enabled` / `Optional` 可用性。Copilot Business / Enterprise プランが対象。
+- **組織層**: Model rules を受領し、組織内ポリシーを決める責務分担を明示。
+- **リポジトリ層**: Copilot Memory のリポジトリレベル off スイッチを節追加。OSS / 法務 NG リポジトリは OFF を推奨。
+- **ユーザー層**: `/memory on` / `/memory off` / `/memory show` の CLI 操作と、保存時の scope（user-level preference / repository-level fact）を明示。
+
+memory 教材があれば、`/memory show` の出力例と、repository-level fact が **全貢献者に共有される** 前提を恒久情報として 1 段追加。外部協力者として参画する場合の自分ルール（「クライアントのリポジトリでは user-level preference のみ、repository-level fact は触らない」）を補足記述として入れる。
+
+scope の明示と `/memory` CLI は public preview の段階のため、「将来仕様変更の可能性あり」を 1 行注記。Model rules は Business / Enterprise プラン限定の旨を明示。

--- a/src/content/ai-news/claude-code/claude-code-v2-1-152.mdx
+++ b/src/content/ai-news/claude-code/claude-code-v2-1-152.mdx
@@ -1,0 +1,73 @@
+---
+title: "Claude Code v2.1.152、`/code-review --fix` で修正自動適用・`MessageDisplay` hook・`/reload-skills`・Auto mode 同意撤廃"
+tool: "claude-code"
+toolLabel: "Claude Code"
+date: 2026-05-27
+sourceUrl: "https://github.com/anthropics/claude-code/releases/tag/v2.1.152"
+summary: "Anthropic は 2026-05-27 01:30 UTC に Claude Code **v2.1.152** を公開した。前リリース v2.1.150 が user-facing change なしの内部修正だけだったのに対し、v2.1.152 は **レビューの自動適用、hook システムの拡張、skill 運用の改善** を中心に user-facing な変更を多数積み増している。最大の追加は `/code-review --fix`（レビュー結果を作業ツリーに直接適用するモード）で、`/simplify` も同じ動きにそろえた。続いて、アシスタントメッセージの表示時に hook で本文を変換・非表示にできる `MessageDisplay` hook、セッションを切らずに skill ディレクトリを再スキャンする `/reload-skills` コマンド、`SessionStart` hook 内から `reloadSkills: true` や `sessionTitle` を返せるフォーマット拡張、skill / slash command の frontmatter に `disallowed-tools` を書くと skill 有効中に特定ツールを model から外せる仕組みなど、運用設計のレバーがまとまって増えた。さらに Auto mode の同意要求が撤廃され、`pluginSuggestionMarketplaces` で管理者が context-aware tip で提案可能な org marketplace を allowlist 化できる managed setting も追加された。主モデルが見つからないとリクエスト単位で失敗していた挙動は、設定済み `--fallback-model` へセッション残りを切り替える形に変わり、Vim NORMAL モードでは `/` が逆履歴検索を起動するようになった。`/usage` の大セッションファイル対応（ストリーミング読み出しでメモリ平準化）、`claude plugin marketplace remove --scope` 対応など、地味だが効く改善も入っている。"
+impact: "`/code-review --fix` の登場は、Claude Code を組織導入したチームの **レビュー→修正適用** のフローを変える。これまで「レビュー出力を読んで `/edit` などで自分で当てる」必要があった部分が、`--fix` 1 つで作業ツリーへ反映される。社内ガイドの「コードレビュー手順」は、見直す価値がある。`MessageDisplay` hook と `disallowed-tools` frontmatter は、**社外秘マスク・固定文言注入・skill 単位の最小権限化** など、配布・統制側の設計余地を一段広げる。Auto mode 同意撤廃と `/reload-skills` は、skill を hook で動的に増減させる運用と相性が良く、社内 skill 配布の即時反映が現実的になる。Enterprise の `pluginSuggestionMarketplaces` は plugin suggestion の出所をホワイトリスト化できるため、社外 marketplace の plugin が混入しないようコントロールしたい組織に効く。`--fallback-model` のセッション継続化は、主モデル切替時の事故率を実務的に下げる修正。"
+tags: ["claude-code", "code-review", "hooks", "skills", "auto-mode", "fallback-model", "vim", "managed-settings", "release-note"]
+status: "candidate"
+relatedKnowledge:
+  - "/knowledge/ai-tools/claude-code/new-commands-2026"
+  - "/knowledge/ai-tools/claude-code/hooks"
+  - "/knowledge/ai-tools/claude-code/skills"
+draft: false
+---
+
+## 要約
+
+Anthropic は 2026 年 5 月 27 日 01:30 UTC（日本時間 10:30）に Claude Code **v2.1.152** を公開しました。直前の v2.1.150 が「内部基盤改善のみ（user-facing change なし）」だったのに対し、v2.1.152 は **レビューの自動適用、hook システムの拡張、skill 運用の改善** を中心に user-facing 変更を多数積み増したリリースです。
+
+最大の追加は **`/code-review --fix`** です。これまでの `/code-review` は再利用・簡略化・効率化の指摘を出力するだけで、適用は手作業でした。`v2.1.152` 以降は `--fix` フラグを付けるとレビュー結果が **作業ツリーへそのまま反映**されます。あわせて `/simplify` が `/code-review --fix` のエイリアスとして再定義され、「軽く整える」用途も同じ動きにそろいました。
+
+**`MessageDisplay` hook** の追加も大きな変化です。アシスタントメッセージが画面に出る瞬間に hook 側で本文を変換したり非表示にしたりできるため、社外秘トークンのマスク、組織共通の前置き挿入、配布構成での出力制御などを構成側で吸収できるようになりました。
+
+**`/reload-skills`** コマンドが追加され、セッションを切らずに skill ディレクトリを再スキャンできます。`SessionStart` hook 側も拡張され、`hookSpecificOutput.reloadSkills: true` を返すと hook が skill をインストールしたあと **同じセッションで** その skill が使えます。さらに `sessionTitle` を返すとセッションタイトルを上書きでき、起動・resume のラベリングを自動化できます。
+
+**skill / slash command の `disallowed-tools` frontmatter** は、skill が有効になっている間だけ model から特定ツールを取り上げる仕組みです。「この skill 中は web fetch を禁止」「この skill 中は edit 系を取り上げる」のような最小権限の設計が、frontmatter 1 行で書けるようになりました。
+
+運用面では **Auto mode の同意要求が撤廃**されました。これまでは Auto mode に切り替える際にオプトイン同意が必要でしたが、v2.1.152 からは即時遷移します。あわせて **`pluginSuggestionMarketplaces`** managed setting が追加され、管理者が context-aware tip で提案可能な org marketplace を allowlist 化できます。
+
+主モデルが見つからないと **リクエストごと**に失敗していた挙動は、設定済み `--fallback-model` へ **セッション残りを切り替える** 形に変わりました。Vim ユーザー向けには NORMAL モードで `/` が逆履歴検索を起動するようになり、bash/zsh の vi モードと挙動が揃いました。
+
+`/usage` は大きなセッションファイルもストリーミング読み出しで対応し、メモリ消費が平準化されています。`claude plugin marketplace remove` も `--scope user|project|local` を受け付けるようになり、`marketplace add` / `install` / `uninstall` と対称になりました。
+
+このほか、Workflow tool のインライン進捗表示の整理、Thinking 表示のマークダウン化と 10 行キャップ、OpenTelemetry の `app.entrypoint` 属性（opt-in）、長セッションでの terminal styling 崩れ修正、focus mode の偽 "N messages hidden" 修正、plugin MCP server の重複判定改善、`/doctor` の stale `enabledPlugins` 警告、Remote Control + 出口プロキシ下の MCP 接続修正など、運用上の細かい改善も多数入っています。
+
+## 何が変わったか
+
+- `/code-review --fix` でレビュー結果を作業ツリーへ自動適用。`/simplify` は `--fix` のエイリアスに。
+- `MessageDisplay` hook を追加。アシスタント出力を hook 側で変換・非表示にできる。
+- `/reload-skills` でセッション維持のまま skill ディレクトリを再スキャン。
+- `SessionStart` hook の `hookSpecificOutput` に `reloadSkills` と `sessionTitle` を追加。
+- skill / slash command frontmatter で `disallowed-tools` を指定すると、skill 有効中に model から特定ツールを外せる。
+- Auto mode のオプトイン同意を撤廃。
+- Enterprise 向けに `pluginSuggestionMarketplaces` managed setting を追加（context-aware tip で提案可能な org marketplace を allowlist 化）。
+- `claude plugin marketplace remove --scope user|project|local` を追加。
+- 主モデル不在時は、リクエスト単位の失敗ではなく `--fallback-model` へセッション残りを切り替え。
+- Vim NORMAL モードで `/` が逆履歴検索（Ctrl+R 相当）に。
+- `/usage` を大セッションファイルでもストリーミング読み出しで対応。
+- Workflow tool のインライン進捗表示・Thinking summary 表示・focus mode カウント・terminal styling・MCP plugin 重複判定 ほか多数の修正。
+
+## 業務インパクト（一般企業向け）
+
+`/code-review --fix` は、Claude Code を組織導入したチームの **「レビューを出してから、誰がいつ反映するか」** という工程を圧縮します。これまでは `/code-review` の出力を見て「修正を当てる人」が手作業で進めるフローが普通でしたが、`--fix` 経由で作業ツリーへ反映されれば、レビュー直後に diff を確認する流れが自然になります。社内ガイドの「コードレビュー手順」を見直す価値があります。
+
+**`MessageDisplay` hook** と **`disallowed-tools`** frontmatter は、配布・統制側に効きます。例えば、社外秘トークンや顧客名を含む出力を hook で自動マスクする運用、特定 skill 利用中は web fetch を取り上げる運用、組織共通のフッターを差し込む運用などが、設定ファイルベースで一元化できます。これまで wrapper を自作して挟んでいた組織にとっては、設計が一段スッキリします。
+
+**Auto mode の同意撤廃** と **`/reload-skills`** は、組織配布の skill を hook で動的に管理する運用と相性が良く、**「新しい skill を hook が入れて、その場で使える」** という流れが現実的になります。社内 skill リポジトリを `SessionStart` hook で同期するパターンを採っているチームは、起動体験が大きく改善するはずです。
+
+**`pluginSuggestionMarketplaces`** managed setting は、社外 marketplace の plugin が context-aware tip 経由で提案されないようコントロールしたい Enterprise 向けです。社内ガバナンス上「提案リストに何が出るか」を管理したい組織は、設定対象に追加してください。
+
+**`--fallback-model` のセッション継続化** は、主モデル切替時の事故率を実務的に下げます。これまでは「主モデル名を変えた瞬間にエラーが連続」していた状況で、自動で fallback へ切り替わるため、運用窓口の問い合わせを減らせます。
+
+## 副業・個人活用視点
+
+個人開発で効くのは、まず **`/code-review --fix`** です。`/code-review` を頻繁に使う人ほど、「指摘は出るが当てるのが面倒」を毎回踏みやすかったところで、`--fix` 1 つで効率が変わります。コミット前のチェックリストに `/code-review --fix → 差分確認 → コミット` を組み込むと体感が違います。
+
+**`/reload-skills`** と **`disallowed-tools`** は、自作 skill を試行錯誤しながら作っているフェーズで効きます。skill の frontmatter を変えるたびに再起動していた人は、`/reload-skills` でループを 1 段速くできます。`disallowed-tools` は「ある skill 中はネット禁止」のような明確な制約を、コメントではなく frontmatter で明文化できる点が重要です。
+
+Vim ユーザーには、NORMAL モードで `/` が **逆履歴検索** になった改善が地味に効きます。Ctrl+R の代替として馴染みのある操作になり、Vim キーバインドのみで履歴を辿れます。
+
+**Auto mode の同意撤廃** は、副業案件で短期スピンアップする人にとって、起動体験のストレスが 1 ステップ消えるメリットがあります。

--- a/src/content/ai-news/claude-code/claude-code-v2-1-153.mdx
+++ b/src/content/ai-news/claude-code/claude-code-v2-1-153.mdx
@@ -1,0 +1,77 @@
+---
+title: "Claude Code v2.1.153、`/model` 既定保存に切替・`skipLfs` plugin オプション・stateful MCP `tools/list` reconnect ループ修正・gateway クレデンシャル誤送信修正・`--strict-mcp-config` の subagent 適用"
+tool: "claude-code"
+toolLabel: "Claude Code"
+date: 2026-05-28
+sourceUrl: "https://github.com/anthropics/claude-code/releases/tag/v2.1.153"
+summary: "Anthropic は 2026-05-28 00:52 UTC に Claude Code **v2.1.153** を公開した。前日 v2.1.152 が `/code-review --fix` や `MessageDisplay` hook の大型機能追加だったのに対し、v2.1.153 は plugin marketplace / `claude agents` / MCP / background agent / `/model` 周りの運用バグ修正と挙動調整を多数まとめたメンテナンス寄りリリース。ただし即気付くレベルの挙動変化を 2 件含む。1 つ目が **`/model` の既定保存切替**で、これまでは「セッション限定で切り替える」が標準だった `/model` が、IDE と同様に **次セッション以降のデフォルトを保存する** 動きに変わった。セッション限定で切りたい場合は picker 内で `s` を押す。`modelPicker:setAsDefault` をカスタマイズしている設定は `modelPicker:thisSessionOnly` にリネームが必要で、`d` action は `s` に置き換わった。2 つ目が **stateful MCP の `tools/list` reconnect ループ修正**で、v2.1.147 で混入したリグレッションが原因の常時再接続を解消した。さらに **custom API gateway 経由でユーザーの Anthropic OAuth クレデンシャルが gateway に誤送信される**バグも修正されている（本来 gateway 用 token のみ送るべきところ）。subagent (Agent tool) frontmatter MCP servers が `--strict-mcp-config` / `--bare` / remote mode / enterprise managed MCP config / managed-settings の allow/deny policy をすべて無視していた問題も修正され、ブロック時には visible warning が出る。Windows PowerShell installer の偽『Installation complete!』、`claude update` のチャネル誤判定、セッション再開時のメモリ過剰使用、`/bg` / `/btw` の background session 関連、tmux 内 `/copy` ほか **background agent 周りの細かい不具合**も多数解消されている。`skipLfs` plugin marketplace オプション、status line コマンドへの `COLUMNS` / `LINES` 渡し、`claude agents` の autocomplete 拡張、PR 列の `PR #N` / `N PRs` 表示、macOS の背景エージェントを「Claude Code」名義の Privacy & Security 権限として永続化、なども入る。"
+impact: "**`/model` の既定保存切替**は社内ガイドの書き換えポイント。これまで「`/model` でセッション限定切替」を前提に書いていた手順は、`s` でセッション限定にできることを明示する形に直す必要がある。**stateful MCP `tools/list` reconnect ループ修正**と **custom API gateway クレデンシャル誤送信修正** は、v2.1.147〜v2.1.152 を使っている組織にとって即時アップデート相当のセキュリティ・安定性修正。特に gateway 経由運用の組織は v2.1.153 へ揃えるのが望ましい。**`--strict-mcp-config` の subagent 適用修正** は、enterprise managed-settings での MCP 統制を「subagent も対象に含む」前提に戻す重要な修正で、ブロック時に warning が出るようになったため、運用上もデバッグが楽になる。`skipLfs` は LFS 同梱 plugin の clone コストが課題だった環境の負荷削減に効き、`claude agents` の autocomplete 拡張は agent dispatch を多用するチームのスループットを地味に押し上げる。"
+tags: ["claude-code", "model", "mcp", "plugins", "claude-agents", "background-agents", "security", "release-note"]
+status: "candidate"
+relatedKnowledge:
+  - "/knowledge/ai-tools/claude-code/new-commands-2026"
+  - "/knowledge/ai-tools/claude-code/mcp"
+  - "/knowledge/ai-tools/claude-code/install-and-setup"
+draft: false
+---
+
+## 要約
+
+Anthropic は 2026 年 5 月 28 日 00:52 UTC（日本時間 9:52）に Claude Code **v2.1.153** を公開しました。前日の v2.1.152 が `/code-review --fix` や `MessageDisplay` hook などの大型機能追加だったのに対し、v2.1.153 は **plugin marketplace / `claude agents` / MCP / background agent / `/model`** 周りの運用バグ修正と挙動調整をまとめたメンテナンス寄りリリースです。ただし、即気付くレベルの挙動変化を 2 件含みます。
+
+1 つ目は **`/model` の既定保存切替**です。これまで `/model` は「セッション限定で切り替える」のが標準でしたが、v2.1.153 からは IDE と同じく **次セッション以降のデフォルトを保存する** 動きに変わりました。セッション限定で切りたい場合は picker 内で `s` を押す形に変わっています。あわせて、`modelPicker:setAsDefault` をカスタマイズしていた `keybindings.json` は `modelPicker:thisSessionOnly` にリネームが必要で、`d` action は `s` に置き換わりました。
+
+2 つ目は **stateful MCP の `tools/list` reconnect ループ修正**です。v2.1.147 で混入したリグレッションが原因で、optional GET SSE stream を持たない stateful MCP server に対して `tools/list` 再接続が無限ループしていた問題が解消されました。**v2.1.147〜v2.1.152 を踏んだチームは即時アップグレードが望ましい**範囲です。
+
+セキュリティ寄りの修正としては、**custom API gateway 経由で gateway 用 token ではなくユーザーの Anthropic OAuth クレデンシャルが gateway に送信される**バグが直りました。gateway 運用組織は v2.1.153 へ揃えるべきです。
+
+エンタープライズ運用に関わる修正として、**subagent (Agent tool) frontmatter MCP servers の `--strict-mcp-config` 適用**が戻りました。これまでは `--strict-mcp-config` / `--bare` / remote mode / enterprise managed MCP config / managed-settings の allow/deny policy が **すべて無視**されており、subagent の MCP は無防備な状態でした。v2.1.153 では適用が復活し、ブロックされた subagent MCP server には visible warning が表示されます。`--strict-mcp-config` も、`--agents` / SDK `agents` で明示渡しした agent 定義の inline `mcpServers` を不必要に剥がさなくなりました。
+
+このほか、`skipLfs` plugin marketplace オプション（`github` / `git` plugin source で LFS の clone を skip）、status line コマンドへの `COLUMNS` / `LINES` 環境変数渡し、`claude agents` dispatch input の autocomplete でネイティブ slash command と bundled skill も提案、PR 列の `PR #N` / `N PRs` 表示、macOS の背景エージェントを「Claude Code」名義として Privacy & Security に表示し権限をアップグレード越しに維持、Windows PowerShell installer の偽 "Installation complete!" 修正、`claude update` のチャネル誤判定修正、セッション再開時のメモリ過剰使用（複数 GB 消費）修正、`/bg` / `/btw` を含む background session 周りの細かい不具合修正（tmux 内 `/copy` の clipboard 失敗、background-color 漏れ、iTerm2 `cmd+k` 描画、IME candidate window 位置、`/rename` のバナー反映遅延、`EnterWorktree` の `ToolSearch` 依存解消）なども入っています。
+
+[VSCode] では、VS Code 終了時に Claude Code プロセスが Windows でクリーンに終了せず、誤った "unclean exit" 報告と孤立 MCP server を残す問題も解消されました。
+
+## 何が変わったか
+
+- `/model` の選択がセッションのデフォルトとして保存される挙動に変更（IDE と同じ）。picker 内 `s` でセッション限定切替に切り替え。
+- `modelPicker:setAsDefault` キーバインドは `modelPicker:thisSessionOnly` にリネーム必要（`d` → `s`）。
+- stateful MCP の `tools/list` 無限再接続を修正（v2.1.147 リグレッション）。
+- custom API gateway がユーザーの Anthropic OAuth クレデンシャルを受け取る不具合を修正。
+- subagent frontmatter MCP servers に対する `--strict-mcp-config` / `--bare` / remote / enterprise managed MCP config / managed-settings allow-deny policy の適用を復活。ブロック時に visible warning。
+- `--strict-mcp-config` が `--agents` / SDK `agents` の inline `mcpServers` を剥がさなくなる。
+- `skipLfs` を `github`/`git` plugin marketplace source に追加（LFS clone を skip）。
+- npm グローバルインストール時の自動更新不可を一回通知 + `/doctor` で修正手順表示。
+- status line コマンドに `COLUMNS` / `LINES` 環境変数を渡す。
+- `claude agents`: dispatch input の autocomplete がネイティブ slash command + bundled skill を提案、PR 列が `PR #N` / `N PRs` を区別。
+- `claude doctor` が直近 update 試行の結果を表示。
+- "MCP / connector authentication" 起動通知を 1 メッセージに統合。
+- macOS の背景エージェントが「Claude Code」名義として Privacy & Security に表示され、アップグレード越しに権限維持。
+- Windows PowerShell installer の偽 "Installation complete!" 修正。
+- `claude update` が npm 環境で release channel のバージョンを使うように修正。
+- セッション再開時のメモリ過剰使用（複数 GB）修正、background agent stale daemon 修正、`/bg` 中の応答継続、tmux 内 `/copy` clipboard 失敗修正、iTerm2 `cmd+k` 描画、IME candidate window 位置、`/rename` バナー反映 ほか background session 関連を多数修正。
+- `Agent` tool with `subagent_type: 'claude'` が undocumented temporary worktree で走り gitignored パスへの出力を silent discard していた問題を修正。
+- MCP tool progress notification が collapsed tool view に表示されない問題を修正。
+- 不正な `file://` リンクが terminal でクリックできない問題を修正。
+- [VSCode] Windows での Claude Code プロセス unclean exit と孤立 MCP server 残存を修正。
+
+## 業務インパクト（一般企業向け）
+
+**`/model` の既定保存切替** は、社内ガイドの記述更新ポイントです。「`/model` は当該セッションだけの一時切替」を前提にしていた手順書は、「`s` を押すとセッション限定」を明示する形に書き換えてください。`keybindings.json` を社内で配布している場合は、`modelPicker:setAsDefault` を `modelPicker:thisSessionOnly` にリネームする周知も必要です。
+
+**stateful MCP `tools/list` reconnect ループ修正** と **custom API gateway クレデンシャル誤送信修正** は、v2.1.147〜v2.1.152 を使っている組織にとって即時アップデート相当です。前者は MCP server を多用する開発ワークフローで CPU / ネットワーク負荷の主要因になっていた可能性があり、後者は gateway 経由運用の組織で **本来 gateway 専用 token のみ送るべき経路で個人 OAuth クレデンシャルが渡る** という重大な情報フロー違反です。社内配布バージョンを v2.1.153 以降に揃えるのが望ましい更新です。
+
+**`--strict-mcp-config` の subagent 適用修正** は、enterprise managed-settings での MCP 統制を「subagent も対象に含む」前提に戻す重要な修正です。これまで「managed-settings で deny にした MCP server が subagent からは普通に呼べていた」状況だった場合、社内のセキュリティ前提が回復します。ブロック時に visible warning が出るようになったため、運用デバッグの観点でも一段見やすくなりました。
+
+`skipLfs` plugin オプションは、LFS 同梱 plugin（モデル重みなどを LFS で配布している plugin）の clone コストが課題だった環境向けです。CI / 大量端末配布で plugin clone の遅さがネックになっていたチームは設定を入れる価値があります。
+
+`claude agents` の autocomplete 拡張と PR 列の表示改善は、agent dispatch を業務フローに組み込んでいるチームのスループットを地味に押し上げます。
+
+## 副業・個人活用視点
+
+個人開発で最も影響が大きいのは **`/model` の挙動変更**です。これまで「`/model` で気軽に切り替えて、セッション越しには戻る」運用をしていた人は、`s` を押さないと **次回起動時もそのモデルが使われる** ことになるため、コスト管理上は意識的に `s` を使う癖をつけた方が無難です。逆に「同じモデルを使い続けたい」人にとっては、毎回設定し直す手間が消える嬉しい変更です。
+
+**stateful MCP の reconnect ループ修正** は、ローカルで stateful MCP server を試している人ほど効きます。v2.1.147 以降で「なんとなく重い」「ファンが回り続ける」感覚があった場合、原因の一つだった可能性があります。
+
+**`skipLfs`** は、自作 plugin marketplace を運用しているとき、LFS 同梱 plugin を読み手側で軽く扱える設定として有用です。配布する側も、`skipLfs` 推奨の plugin かどうかを README に書くと親切です。
+
+**background agent 周りの一連の修正**（特に tmux 内 `/copy` の clipboard 失敗、`cmd+k` 描画、IME candidate window 位置）は、ターミナル中心で副業案件を回している個人にとって日々のストレスが減る部分です。Windows / macOS / Linux 環境で background agent を併用している人ほど、v2.1.153 へ上げるメリットがあります。

--- a/src/content/ai-news/claude/claude-managed-agents-self-hosted-sandboxes-mcp-tunnels.mdx
+++ b/src/content/ai-news/claude/claude-managed-agents-self-hosted-sandboxes-mcp-tunnels.mdx
@@ -1,0 +1,55 @@
+---
+title: "Anthropic、Claude Managed Agents に Self-hosted sandboxes（public beta）と MCP tunnels（research preview）を追加発表（Code w/ Claude London 2026）"
+tool: "claude"
+toolLabel: "Claude"
+date: 2026-05-26
+sourceUrl: "https://claude.com/blog/code-w-claude-london-2026-rethinking-how-we-build"
+summary: "Anthropic は 2026-05-26 のロンドンイベント **Code w/ Claude London 2026** で、Claude Managed Agents の機能拡張を 2 点発表した。1 つ目は **Self-hosted sandboxes（public beta）** で、Managed Agents の tool execution を **ユーザー側がカスタマイズした sandbox 環境**で走らせる仕組み。自社の自前インフラに加え、Cloudflare、Daytona、Modal、Vercel 等が想定先として挙げられている。これまで Managed Agents の実行環境は Anthropic ホスト側に限定されており、依存・ネットワーク・データ局所性などの要件を持つ組織は「Managed の使い勝手は欲しいが実行環境は外せない」というジレンマを抱えていた。public beta としての提供で、その制約を解く第一歩になる。2 つ目は **MCP tunnels（research preview）** で、Managed Agents から **private network 内の MCP server** に、インターネット露出なしの暗号化トンネル経由で到達できる機能。社内 MCP server（内部 API ラッパー、社内 DB を持つ MCP）を外部公開しなくても Managed Agents から呼び出せる設計が現実的になる。research preview のため本番運用には Anthropic 側の追加調整が必要。同イベントでは Boris Cherny（Claude Code 責任者）の基調講演に加え、Cat Wu、Katelyn Lesse、Angela Jiang、Lisa Crofoot らが登壇し、Spotify、Base44、Legora、Amplitude、Clay、Rogo などの参加企業の事例が共有された。次回は東京（2026-06-05〜06）でも同等のイベントが続く予定。"
+impact: "Claude Managed Agents の **「実行環境はどこか」「社内 MCP にどう繋ぐか」** という 2 つの根源的なアーキ判断が動いた。**Self-hosted sandboxes** は、コンプライアンス・データ局所性・社内システム連携が論点になるエンタープライズで「Managed の使い勝手のまま、実行は自社/許可済みクラウドで」というオプションを開く。Cloudflare / Daytona / Modal / Vercel が想定先に挙がっているのは、すでにこれらで agent ランタイムを運用している組織にとって移行コストが下がるメッセージとして読める。**MCP tunnels** は社内 MCP server をインターネットに露出させずに Managed Agents から呼べる仕組みで、社内 API ラッパー / 社内 DB 系の MCP を Managed Agents で活用する道筋が現実化する。research preview のため即時導入は早いが、社内 MCP の設計を進めている組織は「将来 MCP tunnel に乗せる前提」で MCP 単位の権限境界を整理しておく価値がある。Self-hosted sandboxes は public beta、MCP tunnels は research preview と、提供段階の差を取り違えないよう注意。"
+tags: ["claude", "managed-agents", "mcp", "self-hosted", "sandbox", "enterprise", "code-w-claude", "public-beta", "research-preview"]
+status: "candidate"
+relatedKnowledge:
+  - "/knowledge/ai-tools/claude/managed-agents"
+  - "/knowledge/ai-tools/claude/mcp"
+draft: false
+---
+
+## 要約
+
+Anthropic は 2026 年 5 月 26 日のロンドンイベント **Code w/ Claude London 2026** で、Claude Managed Agents の機能拡張を 2 点発表しました。Managed Agents の「実行環境」と「社内ネットワーク連携」という根源的なアーキ判断に直接効く変更です。
+
+1 点目は **Self-hosted sandboxes（public beta）** です。Managed Agents の tool execution を、**ユーザー側がカスタマイズした sandbox 環境**で走らせる仕組みで、想定デプロイ先として:
+
+- 自社の自前インフラ
+- **Cloudflare**
+- **Daytona**
+- **Modal**
+- **Vercel**
+
+が挙げられています。これまで Managed Agents の実行環境は Anthropic ホスト側に閉じており、依存・ネットワーク・データ局所性などの要件を持つ組織は「Managed の使い勝手は欲しいが、実行環境を外せない」というジレンマを抱えていました。Self-hosted sandboxes はそこを解く第一歩で、Managed Agents の運用と sandbox 実体を切り出して別軸で持てるようになります。提供段階は **public beta** です。
+
+2 点目は **MCP tunnels（research preview）** です。Managed Agents から **private network 内の MCP server** に、インターネット露出なしの暗号化トンネル経由で到達できる機能で、これまで Managed Agents から社内 MCP を呼ぶには「社内 MCP を外部に公開する」「逆方向接続のための専用構成を用意する」のいずれかが必要でしたが、tunnel 経由でその構成が一段スッキリします。社内 API ラッパー、社内 DB を持つ MCP server、社内専用の検索 MCP などを Managed Agents から実用的に扱える道筋が開けます。提供段階は **research preview** のため、本番運用には Anthropic 側の追加調整が必要です。
+
+同イベントは Boris Cherny（Claude Code 責任者）の基調講演に加え、Cat Wu（Claude Code 製品責任者）、Katelyn Lesse / Angela Jiang（Claude 開発者プラットフォーム）、Lisa Crofoot（リサーチプロダクトマネージャー）らが登壇しました。参加企業として **Spotify、Base44、Legora、Amplitude、Clay、Rogo** などが紹介され、各社の Claude / Managed Agents 活用事例が共有されました。次回は **東京（2026-06-05〜06）** でも同等のイベントが続く予定で、日本側組織にとっては現地で詳細を確認できる機会になります。
+
+## 何が変わったか
+
+- **Self-hosted sandboxes（public beta）** — Managed Agents の tool execution 環境を、自社インフラ・Cloudflare・Daytona・Modal・Vercel 等のユーザー指定 sandbox で走らせられるように。
+- **MCP tunnels（research preview）** — Managed Agents から private network 内の MCP server へ、インターネット露出なしの暗号化トンネル経由で到達できる。
+- Code w/ Claude のロンドン開催（2026-05-26）に続き、東京開催（2026-06-05〜06）が予定。
+
+## 業務インパクト（一般企業向け）
+
+**Self-hosted sandboxes** は、Managed Agents 採用の前提を変えます。これまで「Managed なら開発コストが下がるが、実行環境を社外に置けない」とブロックしていた組織にとって、**「Managed の使い勝手」 + 「自社が許可した実行環境」** を両立する選択肢が出てきました。Cloudflare / Daytona / Modal / Vercel が想定デプロイ先に挙がっているのは、既存のクラウド資産・コンプライアンス資産を流用しやすいメッセージとして読めます。public beta のため、現時点では「PoC で当てる」「将来本番に乗せる前提で設計しておく」フェーズです。
+
+**MCP tunnels** は、社内 MCP server の設計判断に影響します。社内 API・社内 DB を MCP として公開する設計を進めている組織は、これまで「いずれ外部公開できる構成」をベースに考えていた箇所を、「MCP tunnel に乗せる前提」で **MCP 単位の権限境界** を整理しておく価値があります。research preview の段階で本番投入は早いものの、設計上の前提に組み込むことはすでに可能です。
+
+Code w/ Claude London 2026 そのものは、Claude 開発者プラットフォーム周辺の方向性を読むための材料です。社内で Managed Agents・Claude Code・MCP 周辺を扱うチームは、登壇内容を一次ソースとして資料に組み込む価値があります。**2026-06-05〜06 の東京開催** は、日本拠点の組織にとって現地参加・関係構築のチャンスです。
+
+## 副業・個人活用視点
+
+Self-hosted sandboxes と MCP tunnels はどちらも **enterprise 寄りの機能** ですが、副業・個人開発の視点でも追っておく価値があります。Cloudflare / Modal / Vercel など個人プランで触りやすいクラウドが Self-hosted sandbox の想定先に挙がっているため、**個人で Managed Agents を試す前提のサンドボックス設計** を、将来の business 案件に持ち込める形で先に作っておけます。
+
+社内副業案件で MCP 設計に関わっている人は、**「MCP tunnel に乗せる前提」** を最初から設計に入れておくと、本採用フェーズで設計差し戻しを受けにくくなります。「権限境界が MCP 単位で切れているか」「private network 内に閉じている前提の MCP か」を整理する観点が、tunnel 提供の登場で改めて重要になりました。
+
+Code w/ Claude 東京開催（2026-06-05〜06）は、副業 / 個人として Claude エコシステムに関わっている人にとって現地参加 / レポート発信の機会です。Anthropic の登壇者リスト（Claude Code / 開発者プラットフォーム責任者）からも、Claude Code・Managed Agents・MCP 周辺の話が中心になる見込みです。

--- a/src/content/ai-news/codex/codex-rust-v0-134-0.mdx
+++ b/src/content/ai-news/codex/codex-rust-v0-134-0.mdx
@@ -1,0 +1,76 @@
+---
+title: "OpenAI Codex rust-v0.134.0、ローカル会話履歴検索・`--profile` を主セレクタへ昇格（legacy 廃止）・MCP per-server env + OAuth・readOnly MCP 並列化・hook context に会話履歴と subagent identity 追加"
+tool: "codex"
+toolLabel: "OpenAI Codex"
+date: 2026-05-26
+sourceUrl: "https://github.com/openai/codex/releases/tag/rust-v0.134.0"
+summary: "OpenAI は 2026-05-26 19:13 UTC に Codex CLI **rust-v0.134.0**（stable）を公開した。前 stable rust-v0.133.0（2026-05-21）からのメジャー差分は、**会話履歴検索・profile 体系の整理・MCP 運用の本質的強化・hook context の拡張** が中心。新機能としては、rollout を元にローカルの会話履歴を case-insensitive に検索し result preview を出す **thread content search**、CLI / TUI permissions / sandbox の各フローで `--profile` が **主セレクタへ昇格**し legacy profile v1 の resolution / write path / telemetry が削除（互換は migration guidance のみ）、MCP server の per-server environment 切り出しと streamable HTTP MCP に対する OAuth option、connector tool schema の local `$ref`/`$defs` 保持と過大 schema の best-effort compact 化、`readOnlyHint` を申告する MCP tool の並列実行、hook context への conversation history と subagent identity の追加が入っている。バグ修正・運用改善としては、exec-server websocket client の reconnect、auth recovery 後の即時 retry、remote compaction v2 stream の retry、Windows TUI 描画崩れの VT モード復元、workspace 単位の usage-limit エラー文言、plugin skill 間での plugin-level icon asset 共有、auto-review 起動時の active permission profile metadata 保持、Node ベース tool が managed network proxy 環境を尊重するように、などが含まれる。docs では curl / PowerShell インストーラ手順、`just test` の優先、profile migration リンクが追加され、packaging では DotSlash fetching の reusable 化、Codex 自前 V8 artifact 経由の release build、macOS x64 zsh artifact 追加なども入った。"
+impact: "**`--profile` 主セレクタ化と legacy profile v1 廃止**は、**破壊的変更扱いに近い**運用影響を持つ。0.133 までの profile v1 設定をそのまま流用している環境では migration guidance に従った書き換えが必須。社内で profile v1 を前提とした手順書・スクリプトを持つチームは、0.134 アップグレード前に棚卸しが必要。**MCP per-server environment + OAuth** と **readOnly MCP の並列化** は、Codex を agentic / multi-tool ワークフローで本格運用しているチームの **MCP 設計の質を変える** 変更。これまで「全 MCP server が共有環境を見る」前提だった設計を、per-server に切り出して隔離 / 並列化 / OAuth 適用ができる前提に書き換える価値がある。**hook context 拡張**（会話履歴 + subagent identity）は、organization 配布の hook が「呼び出し元 subagent によって挙動を変える」設計を取りやすくする。**会話履歴検索**は `/goal` ベースの長時間セッション運用で「以前ここで議論した」を辿れるようになり、knowledge 蓄積に直接効く。"
+tags: ["codex", "profile", "mcp", "hooks", "thread-search", "stable", "release-note", "breaking-change"]
+status: "candidate"
+relatedKnowledge:
+  - "/knowledge/ai-tools/codex/cli-setup"
+  - "/knowledge/ai-tools/codex/mcp"
+  - "/knowledge/ai-tools/codex/hooks"
+draft: false
+---
+
+## 要約
+
+OpenAI は 2026 年 5 月 26 日 19:13 UTC（日本時間 5 月 27 日 4:13）に Codex CLI の **rust-v0.134.0**（stable）を公開しました。前 stable rust-v0.133.0（2026-05-21）からのメジャー差分は、**会話履歴検索・profile 体系の整理・MCP 運用の本質的強化・hook context の拡張** が中心で、運用フローを直接書き換える変更を多く含みます。
+
+最初に押さえたい新機能は **ローカル会話履歴検索（thread content search）**です。rollout（Codex の会話保存形式）を元に、過去の thread を **case-insensitive な本文検索** で辿れるようになり、result preview も表示されます。`/goal` を使った長時間タスクの中で「以前ここで議論した結論」を引っ張り出すフローが現実的になりました。
+
+次に、profile 体系の大きな整理です。**`--profile` が CLI / TUI permissions / sandbox の各フローで主セレクタに昇格**し、legacy profile v1 の resolution / write path / telemetry は削除されました。互換性は **migration guidance**（誤って legacy 形式を渡したときに出る案内）のみで提供され、profile v1 を前提にしたスクリプトはそのままでは通りません。これは事実上の破壊的変更です。`codex sandbox` でも `--profile` を直接受けられるようになり、profile の切替経路が CLI / TUI / sandbox / app-server で一本化されました。
+
+**MCP 周りの強化**も大きな変更です。MCP server を **per-server environment** にルーティングできるようになり、streamable HTTP MCP server に対しては **OAuth option** がサポートされました（`codex mcp add` 側も OAuth 対応）。connector tool schema は **local `$ref` / `$defs` を保持しつつ過大 schema は exposure 前に best-effort で compact 化** する処理が入り、tool schema の信頼性が一段上がっています。さらに **`readOnlyHint` を申告する MCP tool は並列実行** が許可され、複数の read 系 MCP を多用するワークフローのレイテンシが下がります。
+
+**hook context の拡張**（派生改善）として、extension tool に **conversation history** が渡されるようになり、hook input には **subagent identity** が含まれるようになりました。組織配布の hook 側で「どの subagent から呼ばれているか」「これまでの会話履歴で何が決まっているか」を見て挙動を分岐させる、いわゆる context-aware な hook 設計が現実的になります。
+
+バグ修正・運用改善も多めです。exec-server websocket client の reconnect、auth recovery 後の即時 retry、remote compaction v2 stream の retry など **remote 系の信頼性強化**、Windows TUI 描画崩れの VT モード復元、workspace 単位の usage-limit エラー文言、plugin skill 間での plugin-level icon asset 共有、auto-review 起動時の active permission profile metadata 保持、Node ベース tool が managed network proxy 環境を尊重するように、などが入りました。
+
+docs 側では curl / PowerShell インストーラ手順、`just test` の優先、profile migration リンクが追記され、packaging は DotSlash fetching の reusable 化、Codex 自前 V8 artifact 経由の release build、macOS x64 zsh artifact 追加など、配布パイプライン側もまとまった刷新が入っています。
+
+26 名の maintainer による寄与。
+
+## 何が変わったか
+
+- ローカル会話履歴検索（rollout-backed thread content search、case-insensitive、result preview 付き）。
+- `--profile` が CLI / TUI permissions / sandbox の主セレクタへ昇格。legacy profile v1 の resolution / write path / telemetry を削除（互換は migration guidance のみ）。
+- `codex sandbox` で `--profile` を受けるように。
+- MCP server を per-server environment にルーティング。
+- streamable HTTP MCP に OAuth option（`codex mcp add` も OAuth 対応）。
+- connector tool schema が local `$ref` / `$defs` を保持。過大 schema は exposure 前に best-effort で compact 化。
+- `readOnlyHint` を申告する MCP tool の並列実行を許可。
+- extension tool に conversation history を渡す + hook input に subagent identity を含める（hook 派生改善）。
+- exec-server websocket reconnect、auth recovery 後の retry、remote compaction v2 retry。
+- Windows TUI 描画崩れ修正（VT モード復元）。
+- workspace 単位の usage-limit エラー文言。
+- plugin skill 間で plugin-level icon asset を共有。
+- auto-review 起動時に active permission profile metadata を保持。
+- Node ベース tool が managed network proxy 環境を尊重。
+- docs: curl / PowerShell インストーラ追記、`just test` 優先、profile migration リンク。
+- packaging: DotSlash fetching の reusable 化、Codex 自前 V8 artifact 経由の release build、macOS x64 zsh artifact。
+- Bedrock Mantle GovCloud region 追加。
+
+## 業務インパクト（一般企業向け）
+
+**`--profile` 主セレクタ化と legacy profile v1 廃止** は、組織で Codex を運用しているチームにとっては **事実上の破壊的変更** として扱う必要があります。0.133 までの profile v1 形式の設定ファイル・配布スクリプトを持っている場合、0.134 アップグレード時に migration guidance に従って書き換える棚卸しが発生します。社内手順書で `--profile` 以外の経路（旧コマンド・設定ファイル直書き）で profile を切り替えていた箇所は、新方式に統一するチャンスでもあります。
+
+**MCP per-server environment + OAuth** は、複数の MCP server を並走させているチームの **MCP 設計** に効きます。これまで「全 MCP server が同じ環境変数を見る」前提だった設計を、「MCP server ごとに環境を切る」「特定の HTTP MCP に OAuth を当てる」前提に直せます。社内 MCP 一覧表（運用ドキュメント）を持っている組織は、`environment` 列と `auth` 列の追加が現実的になりました。
+
+**`readOnlyHint` を申告する MCP tool の並列化** は、複数の read-only MCP を一連の調査タスクで連続的に呼ぶ Codex agent ワークフローで効きます。MCP server 側に `readOnlyHint` を仕込めば、Codex が並列に投げてくれるようになるため、社内 MCP の **annotation 整備** がそのままパフォーマンス改善に直結します。
+
+**hook context 拡張**は、organization 配布の hook 設計を一段進める材料になります。「どの subagent から呼ばれたかで動作を変える hook」「会話履歴を見てフォーマット注入を切り替える hook」のような **context-aware hook** が、organization 配布の正規パターンとして書きやすくなりました。
+
+**会話履歴検索**は、Codex で長時間タスク（PR レビュー、リファクタ、設計議論など）を回しているチームのナレッジ追跡を変えます。「あのときの議論はどこにあったか」を grep ベースで辿れるため、knowledge 蓄積の手前にいるチームには即効性があります。
+
+## 副業・個人活用視点
+
+個人開発では、まず **会話履歴検索** が効きます。Codex で日々こなしているタスクから「あの時の問題、どう解決したっけ」を呼び戻すのは、これまで thread を順番に辿るしかなく実質できなかった操作でした。0.134 以降は本文検索が走るため、個人の knowledge base としても再利用しやすくなります。
+
+**`--profile` の整理** は、副業案件ごとに profile を切り替えているフリーランスにとって、設計を見直す機会になります。これまで「`--profile` と環境変数の組み合わせで状態を管理」していた人は、`--profile` を主とした切替に統一できます。0.133 までの profile v1 設定があるなら、案件中の作業に入る前に migration を済ませておくと安全です。
+
+**MCP per-server env** は、個人で自作 MCP server を複数走らせている人にとって、**「この MCP は API キー A、こちらは API キー B」を一発で切り分けられる**設計に変わります。OAuth option も組み合わせれば、自作 HTTP MCP の認証を Codex 側で完結できます。
+
+**hook context 拡張**は、自作 hook を持っている人にとって、**「subagent ごとに違う体裁を強制する hook」「会話履歴を踏まえてプロンプトを書き換える hook」**が現実的な設計選択肢になったことを意味します。Codex × Hooks を扱っている個人ブロガー・チュートリアル運営者にとっては、サンプル更新の余地が広い変更です。

--- a/src/content/ai-news/cursor/cursor-catch-up-2026-05.mdx
+++ b/src/content/ai-news/cursor/cursor-catch-up-2026-05.mdx
@@ -1,0 +1,93 @@
+---
+title: "Cursor 直近キャッチアップ（2026-05）— Composer 2.5、Cursor in Jira、v3.5 で Shared Canvases と `/loop` Skill、Cursor Automations の Agents Window 統合"
+tool: "cursor"
+toolLabel: "Cursor"
+date: 2026-05-20
+sourceUrl: "https://cursor.com/changelog"
+summary: "Cursor は 2026 年 5 月に **Composer 2.5（2026-05-18）**、**Cursor in Jira（2026-05-19）**、**v3.5 リリース（2026-05-20、Shared Canvases と `/loop` Skill、および Cursor Automations の Agents Window 統合）** と、立て続けに「Agents Window 中心の運用」を進化させる更新を出した。本記事は当サイトにとって Cursor 初回のキャッチアップ記事として、これら直近の流れを 1 本に集約する。**Composer 2.5** は持続的なタスク（長時間続く agent 実行）でのパフォーマンスを上げた次世代モデルで、Cursor の中核となる agentic ワークフローの土台。**Cursor in Jira** は Jira の work item を **Cursor agent にアサイン**できる統合で、課題管理ツールから直接 agent を呼び出す導線を作る。**v3.5** では、agent ワークスペースに対する **Shared Canvases**（canvas のライブスナップショットへのリンクをチームで共有）と、agent に対してプロンプトを **ローカルスケジュールで繰り返し実行できる** `/loop` Skill が追加された。あわせて、**Cursor Automations** は cursor.com/automations だけでなく **Agents Window 上でも** 作成・管理できるようになり、1 つの automation に **複数 repo を attach** したり、**repo を attach しない automation** を作ったりもできるようになった（新規 automation 実行に 7 日間 50% 割引）。Cursor 自体は 2026-05-26〜2026-05-28 の窓内には新規アップデートを出していないため、本記事は 5 月中の更新群をまとめた **初回キャッチアップ** という位置付けとなる。"
+impact: "Cursor の 2026-05 アップデート群は、いずれも **Agents Window を中心とした業務統合** を進めるベクトルで一致している。**Cursor in Jira** によって課題管理ツールから直接 agent を呼べる導線が整い、**Cursor Automations の Agents Window 統合 + 複数 repo / repo なし対応** で「automation = agent ワークスペース上で組み立てる継続ワークフロー」という設計が定着しつつある。**Shared Canvases** はチームで agent の作業面を共有する具体的な方法で、レビュー文化のあるチームに即時に効く。**`/loop` Skill** はローカルスケジュールでプロンプトを繰り返せるため、定常タスク（ログチェック、release 監視、定型レポート）を agent に張り付けやすい。**Composer 2.5** はこれらの土台を持続タスク性能で支える。これまで「Cursor は IDE / 補完中心」のイメージで導入を見送っていた組織は、現状の Cursor が **Jira 連携 + agent ワークスペース + automation + 共有 canvas + ローカル loop** のセットを抱える **agentic 統合ツール** に近づいていることを踏まえて再評価する価値がある。"
+tags: ["cursor", "composer", "agents-window", "jira", "automations", "shared-canvases", "loop", "catch-up"]
+status: "candidate"
+relatedKnowledge: []
+draft: false
+---
+
+## 要約
+
+Cursor は 2026 年 5 月に Agents Window を中心とした業務統合を加速する更新群を立て続けに公開しました。本記事は当サイトにとって Cursor 初回のキャッチアップ記事です。直近の窓（2026-05-26〜2026-05-28）には新規アップデートが出ていないため、ここでは **5 月中の主要アップデート群** を 1 本にまとめて整理します。
+
+### Composer 2.5（2026-05-18）
+
+Cursor の **持続的なタスク（長時間続く agent 実行）でのパフォーマンス**を向上させた次世代モデルです。Cursor の中核を担う agentic ワークフローの土台で、後述する `/loop` や Cursor Automations の効きを支えます。
+
+公式: https://cursor.com/changelog/composer-2-5
+
+### Cursor in Jira（2026-05-19）
+
+Jira の work item を **Cursor agent にアサイン**できる Jira 統合です。課題管理ツールから直接 agent を呼び出す導線ができ、「チケットを開く → agent に作業を投げる」という流れが Jira 起点で完結します。
+
+公式: https://cursor.com/changelog/05-19-26
+
+### v3.5: Shared Canvases と `/loop` Skill（2026-05-20）
+
+Cursor の Agents Window を **チーム協業の基盤**として強化する 2 つの追加が入りました。
+
+- **Shared Canvases**: agent ワークスペース上の canvas に対し、**ライブスナップショットへのリンク**を共有できます。チームで agent の作業面を共有してレビューする運用がそのまま回せます。
+- **`/loop` Skill**: agent にプロンプトを **ローカルスケジュールで繰り返し実行** させられます。release 監視・ログチェック・定型レポートのような **継続タスク** を agent に張り付けやすくなります。
+
+公式: https://cursor.com/changelog/shared-canvases
+
+### v3.5: Cursor Automations の Agents Window 統合（2026-05-20）
+
+これまで `cursor.com/automations` 専用だった **Cursor Automations** が、Agents Window でも作成・管理可能になりました。あわせて自動化の柔軟性が拡張されています。
+
+- 1 つの automation に **複数 repo を attach** でき、agent が複数 repo を横断して context を推論し、必要な箇所すべてで配信・テスト・検証を実行できるように。
+- **repo を attach しない automation** も作れるようになり、コードベース外の繰り返しタスク（外部 API 監視、定型通知など）にも適用できる。
+- 新規 automation の実行に **7 日間 50% 割引** が適用される。
+
+公式: https://cursor.com/changelog/05-20-26
+
+### 窓内アップデートの状況（2026-05-26〜2026-05-28）
+
+当サイトの今回の調査窓（2026-05-26 から 2026-05-28）には Cursor の新規アップデートはなく、最新が 2026-05-20 の v3.5 群でした。Cursor を当サイトの AIニュース対象に **初収載** したのが本リサーチサイクルのため、本記事は **初回キャッチアップ**として 5 月中の主要アップデートを整理しています。次回以降の窓では、Cursor の単発アップデート単位で記事化していく方針です。
+
+## 何が変わったか
+
+- **Composer 2.5（2026-05-18）**: 持続タスクのパフォーマンス改善。
+- **Cursor in Jira（2026-05-19）**: Jira work item を Cursor agent にアサイン可能に。
+- **v3.5（2026-05-20）**:
+  - **Shared Canvases**: agent ワークスペース上の canvas をライブスナップショットのリンクで共有。
+  - **`/loop` Skill**: agent にプロンプトをローカルスケジュールで繰り返し実行させる。
+  - **Cursor Automations の Agents Window 統合**: cursor.com/automations と同じ機能を Agents Window で操作可能に。
+  - **複数 repo を attach** できる automation。
+  - **repo なし automation** が作成可能。
+  - 新規 automation 実行に **7 日間 50% 割引**。
+
+## 業務インパクト（一般企業向け）
+
+2026-05 の Cursor アップデート群は **Agents Window を中心にした業務統合** という単一のベクトルでまとまっています。これまで Cursor を「IDE / 補完中心のツール」として位置付けて導入を見送っていた組織にとっては、現状の Cursor が **Jira 連携 + agent ワークスペース + automation + 共有 canvas + ローカル loop** のセットを抱える **agentic 統合ツール** に近づいていることを踏まえて、再評価する価値があります。
+
+特に、**Cursor in Jira** は課題管理ツール起点での agent 呼び出しを実現するため、開発チームの「チケット→着手」フローを Cursor 経由に統一できる組織にとっては導入インパクトが大きい更新です。**Cursor Automations の複数 repo / repo なし対応** は、microservices 構成や、コードベース外の繰り返しタスクを持つチームに直接効きます。
+
+**Shared Canvases** はレビュー文化のあるチームに即時に刺さります。agent の作業面（canvas）を **静的に共有する**のではなく **ライブスナップショットへのリンクで共有する**形なので、レビューワがそのまま続きを触れる体験につながります。
+
+**`/loop` Skill** は定常監視タスクとの相性が良く、release 通知・ログ確認・定型レポートを agent に張り付けて回す運用が現実的になります。Composer 2.5 の持続タスクパフォーマンス改善とセットで考えると、長時間続く agent 実行の安定運用に踏み込めるタイミングです。
+
+導入判断の論点としては、
+
+- Jira を使っているか（in Jira 統合の効きどころ）
+- 複数 repo を横断する作業が多いか（automation の複数 repo attach の効きどころ）
+- agent の作業面をチームで共有する慣習があるか（Shared Canvases の効きどころ）
+- 継続タスクを agent に張り付ける意思があるか（`/loop` Skill の効きどころ）
+
+の 4 点を中心に評価するのが整理しやすいです。
+
+## 副業・個人活用視点
+
+個人開発・副業の視点では、**`/loop` Skill** が一番手軽に効きます。ローカルスケジュールで agent にプロンプトを繰り返し実行させられるため、release watch、競合 changelog 監視、日次の自己レポート生成、SNS 用の定型ドラフトなどを agent に張り付けやすくなります。**Composer 2.5** が持続タスクのパフォーマンスを上げているので、長時間 loop でも体感品質が落ちにくいです。
+
+**Cursor Automations の repo なし対応** は、副業として 1 人で複数の小タスクを回す人にとって、コードベースに紐付かない繰り返し作業（外部 API 監視、定型通知、メール下書きなど）を Cursor 上に置ける選択肢を増やします。新規 automation 実行の 7 日間 50% 割引と組み合わせれば、低コストで実験して効くものだけ残す試行錯誤がやりやすくなります。
+
+**Shared Canvases** は、コーチングや教材レビュー、ペアプロ案件など、**作業面を他人と共有する仕事** をしている副業者にとって、画面共有や Zoom 録画を補完する手段になります。canvas のライブスナップショットをそのまま渡せるため、非同期レビュー型の副業案件と相性が良い機能です。
+
+Cursor を「IDE / 補完」としてのみ捉えていた人は、**Agents Window 中心の使い方** に一度寄せて試してみる価値がある時期です。本記事は当サイトの Cursor 初回キャッチアップなので、次回以降はリリース単位での速報になります。

--- a/src/content/ai-news/github-copilot/copilot-memory-controls-and-model-rules.mdx
+++ b/src/content/ai-news/github-copilot/copilot-memory-controls-and-model-rules.mdx
@@ -1,0 +1,76 @@
+---
+title: "GitHub Copilot、Memory の削除/スコープ/CLI 制御強化と Model rules を同日発表、Enterprise → 組織 → リポジトリの階層ガバナンスが整う"
+tool: "github-copilot"
+toolLabel: "GitHub Copilot"
+date: 2026-05-26
+sourceUrl: "https://github.blog/changelog/2026-05-26-copilot-memory-has-more-controls-for-deletion-scope-and-the-copilot-cli/"
+summary: "GitHub は 2026-05-26 に Copilot のガバナンス関連アップデートを 2 件同時に発表した。1 つ目は **Copilot Memory の制御強化（public preview、全有料 Copilot プラン）**。ユーザーが「忘れて」と依頼したときの削除ガイダンス、リポジトリ管理者がメモリ機能をリポジトリ単位で OFF にできる **リポジトリレベル off スイッチ**、`/memory on` / `/memory off` / `/memory show` の **`/memory` CLI**、保存時の scope（**user-level preference**: 個人 + 全リポジトリ、**repository-level fact**: 全貢献者 + 該当リポジトリ限定）の明示が入った。2 つ目は **Copilot Model rules**（Copilot Business / Copilot Enterprise）。Enterprise オーナーが **組織単位で利用可能な Copilot モデル**を制御でき、各組織のデフォルトモデル選択や `Enabled`（自動 ON）/ `Optional`（組織側が判断）の可用性切替が可能になる。これにより、企業全体一括の単一設定ではなく **組織ごとに異なるモデル配布** が現実的になる。同日発表のため、Copilot のガバナンスは **Enterprise → 組織 → リポジトリ → ユーザー** の階層で「何を制御できるか」が一段整理された。"
+impact: "Copilot Memory の制御強化は、これまで「Memory に何が貯まっていて、どう消すか」が見えにくかった問題に対する答え。`/memory show` で状態を即時確認でき、リポジトリ管理者がメモリ機能自体をリポジトリ単位で止められるようになるため、**OSS / 法務的に NG なリポジトリでは Memory を OFF にする** という運用が定常化できる。scope の明示（user-level preference か repository-level fact か）は、特に **repository-level fact が全貢献者に共有される** 前提を意識した運用に直結するため、社内ガイドの『Copilot Memory 利用ガイド』に明記しておきたい。Copilot Model rules は **Enterprise 配下の組織別モデル配布** を制御する機能で、規制業界・契約上のモデル制限が組織横断的に異なる場合の運用に直接効く。`Enabled` / `Optional` の挙動差を社内テンプレートに落とし込んでおけば、Enterprise オーナーと各組織管理者の責務分担が明確になる。両者を合わせると、Enterprise → 組織 → リポジトリ → ユーザーの階層ガバナンスを設計し直す材料が一気に揃った形になる。"
+tags: ["github-copilot", "memory", "model-rules", "governance", "enterprise", "business", "public-preview", "scope"]
+status: "candidate"
+relatedKnowledge:
+  - "/knowledge/ai-tools/github-copilot/governance"
+  - "/knowledge/ai-tools/github-copilot/memory"
+draft: false
+---
+
+## 要約
+
+GitHub は 2026 年 5 月 26 日に Copilot のガバナンス関連アップデートを 2 件同時に発表しました。Copilot を組織導入しているチームにとって、ガバナンス設計を一段整理し直せる内容です。
+
+### 1. Copilot Memory の制御強化（public preview、全有料 Copilot プラン）
+
+主な追加は 4 点です。
+
+- **削除ガイダンス**: ユーザーが「このメモリを忘れて」と依頼すると、削除可能な場所を案内し、可能なら downvote を提案。
+- **リポジトリレベル off スイッチ**: リポジトリ管理者が設定からメモリ機能をリポジトリ単位で無効化可能。OSS リポジトリや法務的に NG なリポジトリで Memory を強制 OFF にできる。
+- **`/memory` CLI**: `/memory on` / `/memory off` / `/memory show` で **セッション間維持の有効化 / 無効化 / 状態確認** が可能。`/memory show` で「いま自分の Copilot に何が記憶されているか」をその場で確認できる。
+- **scope の明示**: メモリ保存時に **user-level preference**（個人のみ表示、全リポジトリで使用）か **repository-level fact**（全貢献者に表示、特定リポジトリ限定）かを示す。特に repository-level fact は **全貢献者に共有される** 前提を意識した運用が必要。
+
+公式 docs: https://docs.github.com/copilot/how-tos/use-copilot-agents/copilot-memory
+
+### 2. Copilot Model rules（Copilot Business / Copilot Enterprise）
+
+Enterprise オーナーが **組織単位で利用可能な Copilot モデル**を制御できる機能。設定できることは次の通り。
+
+- 各組織のデフォルトモデルを選択。
+- モデル可用性を **`Enabled`（その組織で自動 ON）** または **`Optional`（組織側が判断）** として配布。
+
+これにより、セキュリティ要件の厳しいチームには限定モデル、その他チームには柔軟な選択肢、という **細粒度のモデル配布** を Enterprise 側で運用できます。
+
+公式: https://github.blog/changelog/2026-05-26-target-copilot-models-to-organizations-with-model-rules/
+
+### 同日発表の意味
+
+Memory が **リポジトリ単位 + ユーザー単位** の制御、Model rules が **Enterprise → 組織単位** の制御という形で、Copilot のガバナンス階層は次のように整理し直せます。
+
+- **Enterprise**: Model rules で組織ごとのモデル配布。
+- **組織（org）**: `Enabled` / `Optional` のモデル設定を受領し、組織内ポリシーを決定。
+- **リポジトリ**: リポジトリ管理者が Memory を ON / OFF。
+- **ユーザー**: `/memory` CLI でセッション状態を制御、scope を意識した保存。
+
+## 何が変わったか
+
+- Copilot Memory の削除ガイダンス追加（削除場所案内 + downvote 提案）。
+- リポジトリ管理者がメモリ機能をリポジトリ単位で無効化可能（**リポジトリレベル off スイッチ**）。
+- **`/memory on` / `/memory off` / `/memory show`** CLI を追加（セッション間維持）。
+- メモリ保存時に **user-level preference** か **repository-level fact** かを明示。
+- **Model rules**: Enterprise オーナーが組織単位でデフォルトモデルとモデル可用性（`Enabled` / `Optional`）を制御（Business / Enterprise プラン）。
+
+## 業務インパクト（一般企業向け）
+
+**Copilot Memory の制御強化** は、これまで「何が貯まっていて、どう消すのか」が見えにくかった部分に対する答えです。`/memory show` で状態を即時確認でき、リポジトリ管理者が **リポジトリ単位で Memory を OFF にできる** ため、OSS リポジトリ・法務的に NG なリポジトリでは Memory を強制 OFF にする運用が定常化できます。社内ガイドの「Copilot Memory 利用ルール」を見直す価値があります。
+
+scope の明示は、特に **repository-level fact が全貢献者に共有される** 前提を意識した運用に直結します。社内貢献者だけのリポジトリならまだしも、OSS リポジトリで repository-level fact を不用意に保存すると、「個人の好み」が外部貢献者に漏れる可能性があります。社内ガイドには **「OSS リポジトリで repository-level fact は保存しない」** を明示するのが安全です。
+
+**Copilot Model rules** は、Enterprise 配下で組織ごとに異なるモデルポリシーを持つ組織にとって、即時導入対象です。これまでは Enterprise 全体の一括設定しかなく、「セキュリティチームには限定モデル、開発チームには柔軟な選択肢」を運用するには手作業の運用ルールに頼るしかありませんでした。`Enabled` / `Optional` を組み合わせれば、**Enterprise オーナーが配布し、組織管理者が選ぶ** という責務分担が制度化されます。
+
+両者を合わせると、Copilot ガバナンスは **Enterprise → 組織 → リポジトリ → ユーザー** の 4 階層で何を制御できるかが整理されました。社内の「Copilot ガバナンス章立て」を持っている組織は、章のスコープ分けを階層に合わせて見直すチャンスです。
+
+## 副業・個人活用視点
+
+副業・フリーランスとして複数の組織で Copilot を使う人にとって、**`/memory show` でその場で状態を確認できる** のは大きな改善です。クライアント A の repository-level fact が、クライアント B の作業中の Copilot Chat に紛れ込んでいないかを、`/memory show` で即時チェックできます。
+
+repository-level fact が **全貢献者に共有される** 仕様は、外部協力者として参画する案件で注意が必要です。クライアントのリポジトリで自分が repository-level fact を保存すると、他のチームメンバーにも見えます。**「クライアントのリポジトリでは user-level preference のみ、repository-level fact は触らない」** という自分ルールを持っておくと事故が減ります。
+
+Model rules は基本的に Enterprise オーナー向けの機能ですが、副業先の組織から「うちの Copilot で使えるモデルが限定されているのはなぜ？」と聞かれた際に、`Enabled` / `Optional` の枠組みで答えられるようにしておくと、信頼が積み上がります。Enterprise 管理側に回ることは少なくても、**理解しているフリーランス** として振る舞える材料になります。

--- a/src/data/aiNews.ts
+++ b/src/data/aiNews.ts
@@ -22,6 +22,11 @@ export const aiNewsTools: AiNewsToolMeta[] = [
     description: "OpenAI CodexのCLI、アプリ、Hooks、プラグインの公式アップデート",
   },
   {
+    slug: "cursor",
+    label: "Cursor",
+    description: "Cursor IDE、Composer、Agents Window、Cursor Automationsの公式アップデート",
+  },
+  {
     slug: "gemini",
     label: "Gemini",
     description: "Geminiアプリ、Google AI、Workspace連携の公式アップデート",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -128,6 +128,7 @@ export type AiNewsTool =
   | "claude"
   | "claude-code"
   | "codex"
+  | "cursor"
   | "gemini"
   | "github-copilot"
   | "manus"


### PR DESCRIPTION
## Summary

直近 48 時間（2026-05-26T10:00+09:00 〜 2026-05-28T10:21+09:00）の AI 公式アップデート巡回結果を反映。

- **AIニュース 6 本 + 教材化メモ 6 本** を追加
  - Claude Code v2.1.152（`/code-review --fix`、`MessageDisplay` hook、`/reload-skills`、Auto mode 同意撤廃）
  - Claude Code v2.1.153（`/model` 既定保存切替、stateful MCP `tools/list` reconnect ループ修正、gateway クレデンシャル誤送信修正、`--strict-mcp-config` の subagent 適用）
  - OpenAI Codex rust-v0.134.0（会話履歴検索、`--profile` 主セレクタ昇格・legacy 廃止、MCP per-server env + OAuth、readOnly MCP 並列化、hook context 拡張）
  - Claude Managed Agents — Self-hosted sandboxes（public beta）+ MCP tunnels（research preview）（Code w/ Claude London 2026 発表）
  - GitHub Copilot — Memory 制御強化 + Model rules（同日発表 2 件統合、Enterprise → 組織 → リポジトリ → ユーザーの階層ガバナンス）
  - Cursor 直近キャッチアップ（2026-05）— Composer 2.5、Cursor in Jira、v3.5（Shared Canvases / `/loop` Skill / Cursor Automations の Agents Window 統合）
- **Cursor を新規ツールとして収載**
  - `src/content.config.ts` の `aiNews.tool` enum
  - `src/types/index.ts` の `AiNewsTool` 型
  - `src/data/aiNews.ts` の `aiNewsTools` メタ
  - `.claude/skills/daily-ai-update-monitor/references/source-catalog.md` に Cursor 行と注意書きを追加
- **perception-gaps を更新** — 「Genspark Slides 5.0」のユーザー認識ギャップを記録（公式に該当バージョンの発表は確認できず）

## Test plan

- [x] `npm run check` を実行: 0 errors / 0 warnings（既存 39 hints は変更なし）
- [x] frontmatter の YAML 検証（`/code-review --fix` 等のバッククォート文字列、二重引用符のエスケープを確認）
- [x] 全 ai-news 記事に対応する ai-news-notes（`noteFor` 一致）が存在
- [x] 公式 URL は一次情報を参照（GitHub Releases / 公式 Blog / Workspace Updates 個別ポスト）
- [x] `TODO` / `FIXME` / `要確認` の残置なし（OpenAI / xAI / Genspark Slides の 403 は日次サマリーに記録済み）
- [ ] レビュアー観点: `cursor-catch-up-2026-05.mdx` は窓外（2026-05-18〜20）の更新を含む初回キャッチアップ記事。次回以降は窓内の差分単位で速報化する方針

## 補足

- `docs/research/` は `.gitignore` 対象のため、日次サマリー `2026-05-28.md` と詳細メモ 13 本は本 PR に含まれない（ローカル運用のみ）
- 取得失敗ソース: OpenAI News / ChatGPT Release Notes / xAI docs / Genspark Slides Changelog（いずれも HTTP 403、CDN/ボット保護の影響推定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)