### PR TITLE
feat: About に職務経歴・学歴・資格セクションを追加し、AI顧問/PoC実績を反映

### DIFF
--- a/src/components/sections/About.astro
+++ b/src/components/sections/About.astro
@@ -10,14 +10,13 @@
     <div class="max-w-3xl mx-auto animate-on-scroll stagger-1">
       <div class="glass rounded-2xl p-8">
         <p class="text-muted-foreground leading-relaxed mb-4">
-          Webアプリケーション開発とAI技術指導やAI導入支援を専門としています。
+          中小企業・製造業向けのAI活用伴走支援を専門としています。AIツールの使い方指導ではなく、「何から始めるべきか」「どこにAIを適用すべきか」といった意思決定の整理から入り、PoC・導入・運用までを一貫してサポートします。
         </p>
         <p class="text-muted-foreground leading-relaxed mb-4">
-          企業・個人向けにAI活用セミナーやレッスンも開催中。
-          Next.js / React を中心としたモダンなWeb開発と、ChatGPT / Dify 等のAIツールを活用した業務効率化をサポートしています。
+          現在は中小製造業向けにAI顧問契約1社を継続中で、複数社でPoC（実証実験）案件を並行して推進しています。あわせてbyTechにてAI活用講師・社内SEとして、ChatGPT・Claude・Dify・n8n・Make.com など10種類超のAIツール研修や、LangGraphによるAIエージェント・MCPサーバ開発などの業務自動化も手がけています。
         </p>
         <p class="text-muted-foreground leading-relaxed">
-          テクノロジーの力でビジネスの課題を解決し、より良い未来を創ることを目指しています。
+          製造業の現場改善・業務システム開発・モダンWeb開発を経てきた背景を活かし、現場の制約と技術の現実を両面から押さえた「使えるAI活用」を一緒に作っていきます。
         </p>
       </div>
     </div>

--- a/src/components/sections/Career.astro
+++ b/src/components/sections/Career.astro
@@ -1,0 +1,82 @@
+---
+import { careerExperiences } from "@/data";
+import SectionHeader from "@/components/ui/SectionHeader.astro";
+import Badge from "@/components/ui/Badge.astro";
+---
+
+<section id="career" class="py-20">
+  <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+    <SectionHeader title="Career" subtitle="これまでの職務経歴" />
+
+    <div class="relative">
+      <div
+        class="absolute left-4 top-0 bottom-0 w-px bg-gradient-to-b from-teal-500/50 via-emerald-500/50 to-transparent hidden sm:block"
+      >
+      </div>
+
+      <div class="space-y-6">
+        {
+          careerExperiences.map((exp, index) => (
+            <div
+              class={`relative sm:pl-12 animate-on-scroll stagger-${(index % 5) + 1}`}
+            >
+              <div class="absolute left-4 top-6 w-3 h-3 rounded-full bg-teal-500 -translate-x-1.5 hidden sm:block ring-4 ring-background z-10" />
+
+              <div class="glass rounded-2xl p-5 sm:p-6 transition-all duration-300 hover:border-teal-500/20">
+                <div class="flex flex-wrap items-start justify-between gap-3 mb-3">
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-center gap-2 text-xs text-muted-foreground mb-1">
+                      <svg
+                        class="w-3.5 h-3.5"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      >
+                        <circle cx="12" cy="12" r="10" />
+                        <polyline points="12 6 12 12 16 14" />
+                      </svg>
+                      <span>{exp.period}</span>
+                    </div>
+                    <h3 class="font-semibold text-foreground leading-snug">
+                      {exp.company}
+                    </h3>
+                    <p class="text-sm text-teal-600 mt-0.5">{exp.role}</p>
+                  </div>
+                  <div class="flex flex-wrap items-center gap-2 shrink-0">
+                    {exp.current && <Badge variant="emerald">現職</Badge>}
+                    <Badge variant="teal">{exp.employment}</Badge>
+                    {exp.teamSize && (
+                      <Badge variant="default">チーム {exp.teamSize}</Badge>
+                    )}
+                  </div>
+                </div>
+
+                <p class="text-sm text-muted-foreground leading-relaxed mb-4">
+                  {exp.summary}
+                </p>
+
+                <ul class="space-y-1.5 mb-4">
+                  {exp.highlights.map((item) => (
+                    <li class="flex gap-2 text-sm text-muted-foreground leading-relaxed">
+                      <span class="text-teal-500 mt-1.5 shrink-0 w-1 h-1 rounded-full bg-teal-500" />
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+
+                <div class="flex flex-wrap gap-1.5">
+                  {exp.technologies.map((tech) => (
+                    <Badge variant="default">{tech}</Badge>
+                  ))}
+                </div>
+              </div>
+            </div>
+          ))
+        }
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/components/sections/Education.astro
+++ b/src/components/sections/Education.astro
@@ -1,0 +1,77 @@
+---
+import { certifications, educationHistory } from "@/data";
+import SectionHeader from "@/components/ui/SectionHeader.astro";
+---
+
+<section id="education" class="py-20">
+  <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+    <SectionHeader
+      title="Education & Certifications"
+      subtitle="学歴・取得資格"
+    />
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <div class="glass rounded-2xl p-6 animate-on-scroll stagger-1">
+        <h3 class="font-semibold text-foreground mb-4 flex items-center gap-2">
+          <svg
+            class="w-4 h-4 text-teal-500"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M22 10v6M2 10l10-5 10 5-10 5z" />
+            <path d="M6 12v5c3 3 9 3 12 0v-5" />
+          </svg>
+          学歴
+        </h3>
+        <ul class="space-y-3">
+          {
+            educationHistory.map((edu) => (
+              <li>
+                <p class="text-xs text-muted-foreground">{edu.period}</p>
+                <p class="font-medium text-foreground mt-0.5">{edu.school}</p>
+                {edu.department && (
+                  <p class="text-sm text-muted-foreground">{edu.department}</p>
+                )}
+                <p class="text-xs text-teal-600 mt-0.5">{edu.status}</p>
+              </li>
+            ))
+          }
+        </ul>
+      </div>
+
+      <div class="glass rounded-2xl p-6 animate-on-scroll stagger-2">
+        <h3 class="font-semibold text-foreground mb-4 flex items-center gap-2">
+          <svg
+            class="w-4 h-4 text-teal-500"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <circle cx="12" cy="8" r="6" />
+            <path d="M15.477 12.89 17 22l-5-3-5 3 1.523-9.11" />
+          </svg>
+          資格
+        </h3>
+        <ul class="space-y-2.5">
+          {
+            certifications.map((cert) => (
+              <li class="flex items-baseline justify-between gap-3">
+                <span class="text-sm text-foreground">{cert.name}</span>
+                <span class="text-xs text-muted-foreground shrink-0">
+                  {cert.date}
+                </span>
+              </li>
+            ))
+          }
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/data/career.ts
+++ b/src/data/career.ts
@@ -11,8 +11,10 @@ export const careerExperiences: CareerExperience[] = [
     role: "AI活用講師・コンサルタント・社内SE",
     employment: "業務委託",
     summary:
-      "法人・個人向けAIツール活用のレクチャーとコンサルティングに加え、社内向けのAIエージェント・業務自動化ツールを設計から運用まで一人称で担当。",
+      "中小企業・製造業向けのAI活用伴走支援を軸に、AI顧問契約・PoC推進・社内SE業務・研修コンサルまでを一貫して提供。",
     highlights: [
+      "中小製造業1社とAI顧問契約を締結し、業務課題の整理から導入方針策定までを継続支援",
+      "複数社で PoC（実証実験）案件を並行推進し、本格導入に向けた検証フェーズを伴走",
       "ChatGPT / Gemini / Claude / Claude Code / Microsoft Copilot / Dify / Make.com / n8n / Microsoft Copilot Studio など10種類以上のAIツールについて研修・コンサルを実施",
       "GA4・Google広告・Microsoft ClarityのデータをMCPサーバ経由で取得するマーケティング効率化ツールを開発",
       "LangGraph・n8nを用いたAIエージェントを複数構築（X投稿自動化、AIニュース自動収集・記事化、Discord連携カスタムBotなど）",

--- a/src/data/career.ts
+++ b/src/data/career.ts
@@ -1,0 +1,153 @@
+import type {
+  CareerExperience,
+  Certification,
+  EducationRecord,
+} from "@/types";
+
+export const careerExperiences: CareerExperience[] = [
+  {
+    period: "2025年6月 - 現在",
+    company: "byTech（業務委託）",
+    role: "AI活用講師・コンサルタント・社内SE",
+    employment: "業務委託",
+    summary:
+      "法人・個人向けAIツール活用のレクチャーとコンサルティングに加え、社内向けのAIエージェント・業務自動化ツールを設計から運用まで一人称で担当。",
+    highlights: [
+      "ChatGPT / Gemini / Claude / Claude Code / Microsoft Copilot / Dify / Make.com / n8n / Microsoft Copilot Studio など10種類以上のAIツールについて研修・コンサルを実施",
+      "GA4・Google広告・Microsoft ClarityのデータをMCPサーバ経由で取得するマーケティング効率化ツールを開発",
+      "LangGraph・n8nを用いたAIエージェントを複数構築（X投稿自動化、AIニュース自動収集・記事化、Discord連携カスタムBotなど）",
+      "営業CRMを内製化し、SaaS費用を抑えつつ業務フローに最適化したシステムを構築",
+      "Zoom議事録のDiscord通知やGoogle検索の定期通知などGASによる業務自動化を多数実装",
+      "Remotionを活用した動画制作ワークフローのAI効率化を推進",
+    ],
+    technologies: [
+      "TypeScript",
+      "Python",
+      "LangGraph",
+      "n8n",
+      "Dify",
+      "Make.com",
+      "Supabase",
+      "Vercel",
+      "Cloudflare Workers",
+      "GAS",
+      "Claude Code",
+      "Remotion",
+    ],
+    current: true,
+  },
+  {
+    period: "2025年3月 - 2025年5月",
+    company: "Web制作会社（業務委託）",
+    role: "フロントエンドエンジニア",
+    employment: "業務委託",
+    summary:
+      "Nuxt.js と Tailwind CSS / SCSS を用いた Web サイト制作のフロントエンド実装を担当。",
+    highlights: [
+      "Nuxt.js による Web サイト構築・実装",
+      "HTML/CSS によるレスポンシブデザインの実装",
+      "詳細設計から実装・テスト・運用保守まで対応",
+    ],
+    technologies: [
+      "Nuxt.js",
+      "Tailwind CSS",
+      "SCSS",
+      "HTML5",
+      "CSS3",
+      "JavaScript",
+    ],
+  },
+  {
+    period: "2023年3月 - 2023年5月",
+    company: "横山システム経営研究所株式会社 / TDS社向け hWAO",
+    role: "メンバー（詳細設計・実装）",
+    employment: "正社員",
+    teamSize: "3名",
+    summary:
+      "web-EDIによる購買管理システム hWAO の TDS 社向けカスタマイズで詳細設計と実装を担当。",
+    highlights: [
+      "DB定義と各画面の詳細機能設計",
+      "Node.js / MongoDB による実装",
+    ],
+    technologies: ["JavaScript", "Node.js", "MongoDB", "HTML5", "CSS3"],
+  },
+  {
+    period: "2021年11月 - 2023年3月",
+    company: "横山システム経営研究所株式会社 / NDK社向け hWAO",
+    role: "サブリーダー",
+    employment: "正社員",
+    teamSize: "5名",
+    summary:
+      "購買管理システム hWAO の NDK 社向け開発でサブリーダーを担当。要件定義から本番リリース・不具合対応まで一連の工程を経験。",
+    highlights: [
+      "要件定義・詳細設計・実装・システムテスト・本番リリース対応",
+      "実装フェーズから参画したメンバーへの仕様説明、追加要件の仕様検討、お客様ヒアリング",
+      "システム利用トレーニングと本番稼働後の不具合対応",
+      "Microsoft Azure（Storage / Functions）を利用したシステム構成",
+    ],
+    technologies: [
+      "JavaScript",
+      "Node.js",
+      "MongoDB",
+      "Microsoft Azure",
+      "HTML5",
+      "CSS3",
+    ],
+  },
+  {
+    period: "2021年10月 - 2021年12月",
+    company: "横山システム経営研究所株式会社 / HDK社向け hWAO",
+    role: "メンバー（詳細設計・実装）",
+    employment: "正社員",
+    teamSize: "2名",
+    summary:
+      "購買管理システム hWAO の HDK 社向け開発で詳細設計と実装を担当。",
+    highlights: ["DB定義と各画面の詳細機能設計", "Node.js / MongoDB による実装"],
+    technologies: ["JavaScript", "Node.js", "MongoDB", "HTML5", "CSS3"],
+  },
+  {
+    period: "2021年4月 - 2021年10月",
+    company: "横山システム経営研究所株式会社 / KD社向け hWAO",
+    role: "サポートメンバー",
+    employment: "正社員",
+    teamSize: "3名",
+    summary:
+      "購買管理システム hWAO の KD 社向け開発に要件定義サポートから参画し、詳細設計・実装・不具合対応を担当。",
+    highlights: [
+      "仕様の検討・仕様書作成・お客様向けの機能説明",
+      "Node.js / MongoDB による実装と不具合対応",
+    ],
+    technologies: ["JavaScript", "Node.js", "MongoDB", "HTML5", "CSS3"],
+  },
+  {
+    period: "2016年4月 - 2020年12月",
+    company: "ダイキン工業株式会社",
+    role: "生産ライン現場管理・改善",
+    employment: "正社員",
+    summary:
+      "滋賀製造部にて、ルームエアコン室外機ラインを中心に生産・現場改善・新人教育に従事。",
+    highlights: [
+      "新生産ライン立ち上げ応援（RA室内機）。作業手順・レイアウト変更によるサイクルタイム短縮を実施",
+      "RA室外機ラインでの生産業務・現場改善・突発的な設備/製品不具合対応",
+      "新人メンバーへの作業手順・品質・安全教育",
+      "危険予知トレーニング（KYT）のチームリーダーを担当",
+    ],
+    technologies: ["生産管理", "現場改善", "KYT", "新人教育"],
+  },
+];
+
+export const educationHistory: EducationRecord[] = [
+  {
+    period: "2011年4月 - 2016年3月",
+    school: "佐世保工業高等専門学校",
+    department: "電子制御工学科",
+    status: "卒業",
+  },
+];
+
+export const certifications: Certification[] = [
+  { name: "応用情報技術者", date: "2023年10月" },
+  { name: "基本情報技術者", date: "2022年6月" },
+  { name: "品質管理検定3級", date: "2019年9月" },
+  { name: "普通自動車免許一種", date: "2015年3月" },
+];

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -16,3 +16,8 @@ export { featuredKnowledge } from "./featuredKnowledge";
 export { mediaOutlets } from "./mediaOutlets";
 export { resources } from "./resources";
 export { techStack } from "./techStack";
+export {
+  careerExperiences,
+  educationHistory,
+  certifications,
+} from "./career";

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,12 +1,16 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import AboutSection from "@/components/sections/About.astro";
+import Career from "@/components/sections/Career.astro";
+import Education from "@/components/sections/Education.astro";
 import Teaching from "@/components/sections/Teaching.astro";
 import Seminars from "@/components/sections/Seminars.astro";
 ---
 
 <BaseLayout title="About | shogoworks" description="田中省伍について - Web開発とAI技術指導の専門家">
   <AboutSection />
+  <Career />
+  <Education />
   <Teaching />
   <Seminars />
 </BaseLayout>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -191,3 +191,31 @@ export interface TechCategory {
   label: string;
   items: TechItem[];
 }
+
+// --- About page: career / education / certifications ---
+
+export type EmploymentType = "正社員" | "業務委託" | "フリーランス";
+
+export interface CareerExperience {
+  period: string;
+  company: string;
+  role: string;
+  employment: EmploymentType;
+  teamSize?: string;
+  summary: string;
+  highlights: string[];
+  technologies: string[];
+  current?: boolean;
+}
+
+export interface EducationRecord {
+  period: string;
+  school: string;
+  department?: string;
+  status: string;
+}
+
+export interface Certification {
+  name: string;
+  date: string;
+}


### PR DESCRIPTION
## Summary
- About ページに Career（職務経歴タイムライン）と Education & Certifications（学歴・資格）セクションを追加
- 紹介文を「中小企業・製造業向け AI 活用伴走支援」軸に再構成し、AI 顧問契約 1 社継続中・複数社で PoC 推進中である旨を明示
- 経歴データは master フォルダ（profile.yaml / career_summary.md / projects/*.md）を元に作成。住所/電話/メールなど個人情報は含めない

## 変更ファイル
- 追加: \`src/data/career.ts\`, \`src/components/sections/Career.astro\`, \`src/components/sections/Education.astro\`
- 修正: \`src/types/index.ts\`（型追加）, \`src/data/index.ts\`（re-export）, \`src/pages/about.astro\`（セクション挿入）, \`src/components/sections/About.astro\`（紹介文差し替え）

## Test plan
- [ ] \`npm run check\` がエラー 0 で通る（ローカル確認済み）
- [ ] \`npm run build\` が成功する（ローカル確認済み）
- [ ] \`/about\` を開き、About → Career → Education → Teaching → Seminars の順で表示される
- [ ] Career タイムラインの各カードに期間・社名・役割・雇用形態バッジ・サマリ・ハイライト・技術スタックが正しく出る
- [ ] byTech カードに「AI 顧問契約継続」「PoC 並行推進」のハイライトが含まれる
- [ ] モバイル幅（〜640px）でレイアウトが崩れない
- [ ] 個人情報（住所/電話/メール）が DOM に出ていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)