### PR TITLE
feat: robots.txt を追加（AI検索許可・AI学習拒否）

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,13 @@
+# Allow all crawlers including AI search
+User-agent: *
+Allow: /
+
+# Block AI training only
+User-agent: CCBot
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+# Sitemap
+Sitemap: https://shogoworks.com/sitemap-index.xml


### PR DESCRIPTION
## 概要
`public/robots.txt` を新規追加。AI検索（RAG・引用）向けクローラーは許可しつつ、AI学習データ収集用のクローラーのみブロックする方針。

## 内容
- 全クローラー（AI検索含む）に `Allow: /`
- AI学習用途の `CCBot` / `Amazonbot` を `Disallow: /`
- `Sitemap: https://shogoworks.com/sitemap-index.xml` を記載

## 備考
- sitemap-index.xml は #179（@astrojs/sitemap 導入）のマージ後に生成される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)