### PR TITLE
feat: 2026-06-03 AIニュース日次チェック（速報3件）

### DIFF
--- a/docs/research/daily-ai-updates/2026-06-03.md
+++ b/docs/research/daily-ai-updates/2026-06-03.md
@@ -1,0 +1,75 @@
+---
+date: 2026-06-03
+title: "AI公式アップデート日次チェック 2026-06-03（OpenAI モデル＆Codex が AWS で GA、Codex 役割別プラグイン／Sites、Workspace Studio ループ処理 ほか）"
+fetched_at: 2026-06-03T10:13:03+09:00
+window_start: 2026-06-02T09:08:09+09:00
+window_end: 2026-06-03T10:13:03+09:00
+---
+
+# AI公式アップデート日次チェック 2026-06-03
+
+このファイルは日次サマリー専用です。詳細メモは各ツールの `official-updates/` 配下、公開候補は `src/content/ai-news/`、教材化メモは `src/content/ai-news-notes/` へ追加します。
+
+## サマリー
+
+- 対象期間: 2026-06-02T09:08:09+09:00 → 2026-06-03T10:13:03+09:00（前日サマリーの window_end を引き継ぎ）
+- 更新あり: 4件（OpenAI×2、Gemini/Workspace×1、Claude Code×1）
+- 公開記事化: 3件（OpenAI×2、Gemini×1）
+- 見送り: 2件（Claude Code 連日パッチ、n8n 保守パッチ）
+- 更新なし: 9件
+- 取得失敗: OpenAI 公式（help.openai.com / openai.com）WebFetch 403 → 一次は AWS 公式・OpenAI index URL・公開トラッカーで確認
+
+## 更新あり
+
+| service | published_at | title | category | detail |
+| --- | --- | --- | --- | --- |
+| ChatGPT / OpenAI | 2026-06-01 (date-only) | OpenAI フロンティアモデル＆Codex が Amazon Bedrock で GA | rollout | ../zenn-chatgpt-openai-basic/official-updates/2026-06-02T000000-openai-models-codex-aws-ga.md |
+| OpenAI Codex | 2026-06-02 (date-only) | Codex for every role, tool, and workflow（役割別プラグイン・アノテーション・Codex Sites） | release | ../openai-codex/official-updates/2026-06-02T000000-codex-role-plugins-sites.md |
+| Gemini / Workspace | 2026-06-02 | Workspace Studio に「Repeat for each」ループ処理 | rollout | ../zenn-gemini-release-basic/official-updates/2026-06-02T000000-workspace-studio-loop-items.md |
+| Claude Code | 2026-06-03T06:58:22+09:00 | v2.1.160 / v2.1.161（設定書込み前確認・`ultracode` 改称・並列ツール独立化） | enhancement | ../zenn-claude-code-release-basic/official-updates/2026-06-03T065822-claude-code-2-1-160-161.md |
+
+## 公開記事化
+
+- `src/content/ai-news/chatgpt-openai/openai-models-codex-aws-ga.mdx`（+ 教材化メモ）
+- `src/content/ai-news/codex/codex-role-plugins-sites.mdx`（+ 教材化メモ）
+- `src/content/ai-news/gemini/workspace-studio-loop-items.mdx`（+ 教材化メモ）
+
+## 更新なし
+
+- Claude: 公式 Release Notes に対象期間内の新規日付なし。
+- Cursor: changelog に窓内の新規ポストなし。
+- GitHub Copilot: changelog に窓内更新なし。
+- Dify: 最新は 1.14.2（2026-05-19）で窓外。
+- Genspark / Manus / Meta AI / Runway / ByteDance Seed / Pika: 窓内更新なし。
+- xAI / Grok: 窓内の新規 release-notes なし。
+
+## 取得失敗・保留
+
+- ChatGPT / OpenAI 公式（help.openai.com、openai.com/news）: WebFetch が HTTP 403。一次確認は AWS 公式 ML ブログ（GA 告知 2026-06-01）と OpenAI 公式 index ページ URL（`openai.com/index/...`）、および公開リリーストラッカー／報道（VentureBeat・9to5Mac、2026-06-02）で実施。各発表自体は公式 URL の存在を確認済みのため「公式確認済み」扱いとし、本文取得制限のみを記録する。
+
+## 見送り
+
+| service | title | 理由 |
+| --- | --- | --- |
+| Claude Code | v2.1.160 / v2.1.161 | ほぼ連日のパッチリリース。セキュリティ強化（設定書込み前確認・MCP シークレットのリダクト）や `workflow`→`ultracode` 改称など有用な変更を含むが、単一の見出し機能ではなく改善・修正の束のため、記事化は見送り。詳細メモに記録し教材（起動語の更新）へ反映余地を残す。 |
+| n8n | n8n@2.25.1（2026-06-02） | バグ修正中心の保守パッチ。Features に「Add Knowledge Base to agents」等を含むが増分的で、ほぼ連日のリリース頻度のため記事化は見送り。 |
+
+## 補足メモ
+
+- Google I/O 2026（Gemini Omni / Gemini 3.5 Flash / Antigravity / Gemini CLI→Antigravity CLI 移行 / Search の AI Mode 既定化 など）は **発表が 2026-05-19 で窓外**のため、本日の記事化対象外（既報）。なお Gemini CLI は 2026-06-18 に無料・Pro/Ultra 向け提供終了予定という将来日程のみ窓内で再言及されているが、発表自体は 5/19 のため新規ニュースとしては扱わない。
+- OpenAI Codex GitHub Releases の安定版 `rust-v0.136.0`（2026-06-01T17:49:22Z）は前日（2026-06-02）サマリーで取得済み。本窓では新規の安定版なし（alpha のみ）。
+- 認識ギャップ該当なし。
+
+## チェック対象
+
+- ChatGPT / OpenAI: https://help.openai.com/en/articles/6825453-chatgpt-release-notes ／ https://openai.com/news/
+- OpenAI Codex: https://github.com/openai/codex/releases ／ https://developers.openai.com/codex/changelog
+- Gemini: https://blog.google/products-and-platforms/products/gemini/ ／ https://workspaceupdates.googleblog.com/
+- Claude: https://support.claude.com/en/articles/12138966-release-notes
+- Claude Code: https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md
+- Cursor: https://cursor.com/changelog
+- GitHub Copilot: https://github.blog/changelog/label/copilot/
+- n8n: https://github.com/n8n-io/n8n/releases
+- Dify: https://github.com/langgenius/dify/releases
+- xAI / Grok: https://docs.x.ai/docs/release-notes
+- その他（Genspark / Manus / Meta AI / Runway / ByteDance Seed / Pika）: source-catalog.md 記載の公式ソース

--- a/docs/research/openai-codex/official-updates/2026-06-02T000000-codex-role-plugins-sites.md
+++ b/docs/research/openai-codex/official-updates/2026-06-02T000000-codex-role-plugins-sites.md
@@ -1,0 +1,43 @@
+---
+date: 2026-06-02
+title: "Codex for every role, tool, and workflow — 役割別プラグイン・アノテーション・Codex Sites"
+service: "OpenAI Codex"
+source: https://openai.com/index/codex-for-every-role-tool-workflow/
+fetched_at: 2026-06-03T10:13:03+09:00
+published_at: 2026-06-02T00:00:00Z
+date_precision: date-only
+category: release
+---
+
+# 2026-06-02 Codex を全職種・全ツール・全ワークフローへ
+
+## 公式内容の日本語要約
+
+OpenAI が Codex の新しい使い方を発表した。(1) 役割とツールに合わせる **プラグイン**、(2) 結果をその場で修正する **アノテーション**、(3) 共有可能なインタラクティブ Web サイト・アプリを作る **Codex Sites（プレビュー）** の 3 本柱。コーディング不要で多様なナレッジワークに Codex を使えるよう、**6 つの役割特化プラグイン**を新たに提供。これらは合計 **62 の人気アプリと 110 のスキル**を含む。9to5Mac は「Codex を ChatGPT アプリのあらゆる場所に組み込む」動きとも報じている。
+
+## できるようになったこと
+
+- **役割特化プラグイン（6種）**: 非エンジニアの業務向けに Codex を最適化。
+  - データ分析プラグイン: Snowflake / Databricks Genie / Hex / Tableau 等で、アナリスト・事業チームがデータから問いに答える。
+  - クリエイティブ制作プラグイン: Figma / Canva / Shutterstock / Picsart / Fal 等で、ブリーフからアセットを生成。
+  - 今後追加予定: Corporate Finance、Private Equity Investing、Marketing Strategy、Strategy Consulting、Legal。
+- **アノテーション**: 出力をその場で指定して結果を精緻化。
+- **Codex Sites（プレビュー）**: アイデア・分析・計画を、ダッシュボード・プランナー・レビュー用ワークスペース・プロジェクトボード・ギャラリー・軽量ツールに変換し、ワークスペース内の誰とでも URL で共有できるホスト済みアプリ／サイトを作成。
+
+## 影響範囲
+
+- 対象ユーザー / プラン: ナレッジワーカー全般（非エンジニアを含む）。ChatGPT アプリ内での Codex 提供拡大。プラン別の詳細は公式・開発者向け changelog を要確認。
+- API / UI / 管理者機能: プラグイン経由でアプリ／スキルを呼び出し。Codex Sites は URL 共有でワークスペース内配布。
+
+## 教材化メモ
+
+- Codex 教材（plugins-overview / codex-app / marketplace）に「役割特化プラグイン（6種・62アプリ・110スキル）」と「Codex Sites」を追記。
+- 「Codex = エンジニア向けコーディングエージェント」という前提を更新し、**非エンジニアのナレッジワーク（データ分析・クリエイティブ・将来は財務／法務／戦略）** に広がった点を強調。
+- Codex Sites は「成果物を社内に URL 共有できる軽量内製アプリ基盤」として、業務自動化・社内ツール内製の文脈に接続。
+
+## 原文確認
+
+- 公式見出し: Codex for every role, tool, and workflow
+- 公式URL: https://openai.com/index/codex-for-every-role-tool-workflow/
+- 補助（報道）: VentureBeat / 9to5Mac（2026-06-02）, The Next Web
+- 原文全文は公式ページで確認してください。

--- a/docs/research/zenn-chatgpt-openai-basic/official-updates/2026-06-02T000000-openai-models-codex-aws-ga.md
+++ b/docs/research/zenn-chatgpt-openai-basic/official-updates/2026-06-02T000000-openai-models-codex-aws-ga.md
@@ -1,0 +1,45 @@
+---
+date: 2026-06-02
+title: "OpenAI フロンティアモデルと Codex が AWS（Amazon Bedrock）で GA"
+service: "ChatGPT / OpenAI"
+source: https://openai.com/index/openai-frontier-models-and-codex-are-now-available-on-aws/
+fetched_at: 2026-06-03T10:13:03+09:00
+published_at: 2026-06-01T00:00:00Z
+date_precision: date-only
+category: rollout
+---
+
+# 2026-06-02 OpenAI モデルと Codex が Amazon Bedrock で GA
+
+## 公式内容の日本語要約
+
+OpenAI と AWS が、OpenAI のフロンティアモデル **GPT-5.5 / GPT-5.4** と **Codex**（OpenAI のコーディングエージェント）を **Amazon Bedrock で一般提供（GA）** したと告知した。2026-04 の Limited Preview からの昇格。企業は、すでに使っている AWS のセキュリティ・ガバナンス・調達・課金のワークフローの中で OpenAI モデルと Codex を本番利用できる。GPT-5.5 は「OpenAI の最も高度なフロンティアモデル」と位置づけられ、Bedrock 上の価格は OpenAI ファーストパーティ料金と一致し、AWS 側の追加マージンはない。Codex はシート課金なしの従量課金（pay-per-token）。
+
+（注: openai.com / help.openai.com は当環境では本文取得が制限されたため、一次確認は AWS 公式 ML ブログ（GA 告知, 2026-06-01）と OpenAI 公式 index ページの URL で行い、両者を出典として記録している。）
+
+## できるようになったこと
+
+- **対象モデル**: GPT-5.5、GPT-5.4、および Codex が Amazon Bedrock で GA。
+- **価格**: GPT-5.5 / GPT-5.4 は OpenAI 直販と同額で、AWS の追加課金なし。Codex はシートライセンス不要の従量課金。
+- **エンタープライズ統制**: IAM 権限、VPC 分離、KMS 暗号化、CloudTrail 監査など既存の AWS ガバナンスをそのまま適用。プロンプト・応答はモデル学習に使われず、モデル提供元とも共有されない。
+- **Codex の開発統合**: VS Code / JetBrains / Xcode の IDE 連携に対応し、選択リージョン内でデータレジデンシーを維持しつつ大規模コードベースで記述・デバッグ・リファクタが可能。
+- **基盤**: Bedrock の推論基盤（隔離キュー、自動キャパシティ管理、耐久的な状態保持）上で動作。
+
+## 影響範囲
+
+- 対象ユーザー / プラン: AWS commit と Bedrock アクセスを持つ企業全般。
+- リージョン: GPT-5.5 は US East (Ohio)、GPT-5.4 は US East (Ohio) / US West (Oregon) で提供（詳細は AWS Regions ページ）。
+- API / UI / 管理者機能: Amazon Bedrock の API・コンソール経由。AWS のセキュリティ／調達フローに統合。
+
+## 教材化メモ
+
+- Codex / OpenAI モデルのエンタープライズ導入教材に「Amazon Bedrock での GA」を追記。「OpenAI 直販 / Azure / Bedrock」という調達経路の選択肢として整理。
+- 「既存の AWS 契約・ガバナンス（IAM/VPC/KMS/CloudTrail）の中でフロンティアモデルを本番投入できる」点を、情シス・調達向けの論点として記述。
+- リージョン制約（GPT-5.5 は Ohio のみ等）とデータレジデンシーは導入判断の前提として明示。
+
+## 原文確認
+
+- 公式見出し: OpenAI frontier models and Codex are now available on AWS
+- 公式URL: https://openai.com/index/openai-frontier-models-and-codex-are-now-available-on-aws/
+- AWS 一次: https://aws.amazon.com/blogs/machine-learning/openai-models-and-codex-on-amazon-bedrock-are-now-generally-available/
+- 原文全文は公式ページで確認してください。

--- a/docs/research/zenn-claude-code-release-basic/official-updates/2026-06-03T065822-claude-code-2-1-160-161.md
+++ b/docs/research/zenn-claude-code-release-basic/official-updates/2026-06-03T065822-claude-code-2-1-160-161.md
@@ -1,0 +1,41 @@
+---
+date: 2026-06-02
+title: "Claude Code v2.1.160 / v2.1.161 — 設定ファイル書込み前の確認・ultracode への名称変更・並列ツール独立化"
+service: "Claude Code"
+source: https://github.com/anthropics/claude-code/releases
+fetched_at: 2026-06-03T10:13:03+09:00
+published_at: 2026-06-03T06:58:22+09:00
+date_precision: timestamp
+category: enhancement
+---
+
+# 2026-06-02〜03 Claude Code v2.1.160 / v2.1.161
+
+## 公式内容の日本語要約
+
+Claude Code が v2.1.160（2026-06-02）と v2.1.161（2026-06-03）をリリース。セキュリティ強化と運用安定化が中心。v2.1.160 では、シェル起動ファイル（`.zshenv` 等）やコード実行を許す各種ビルド設定ファイル（`.npmrc`、`.yarnrc*`、`bunfig.toml`、`.devcontainer/` 等）への書込み前に確認プロンプトを表示するようになった。また動的ワークフローのトリガーキーワードが `workflow` から **`ultracode`** に変更された。v2.1.161 では並列ツール呼び出しで 1 つの Bash 失敗が他の呼び出しを巻き込まないよう独立化し、`claude mcp` がシークレットを端末に出力しないようリダクションを追加した。
+
+## できるようになったこと
+
+- **書込み前確認（v2.1.160）**: シェル起動ファイル・`~/.config/git/`・ビルドツール設定への書込み前にプロンプト。意図しないコマンド実行を防止。
+- **トリガーキーワード変更（v2.1.160）**: 動的ワークフローの起動語が `workflow` → `ultracode`（violet でハイライト）。`workflow` の語では起動しなくなった。
+- **並列ツールの独立化（v2.1.161）**: 同一バッチ内で 1 つの Bash 失敗が他のツール呼び出しをキャンセルしなくなり、各ツールが個別に結果を返す。
+- **シークレット保護（v2.1.161）**: `claude mcp` の list/get/add が `${VAR}` を展開せず、認証ヘッダ・URL シークレットをリダクト。
+- その他多数のバグ修正・レンダリング性能改善・Windows/WSL 対応改善。
+
+## 影響範囲
+
+- 対象ユーザー: Claude Code 利用者全般（CLI / IDE）。
+- API / UI / 管理者機能: CLI 挙動、managed-settings、OpenTelemetry ラベル等。
+
+## 教材化メモ
+
+- Claude Code 教材で「動的ワークフローの起動語が `ultracode` に変更」を反映（旧 `workflow` 記述の更新）。
+- セキュリティ系の挙動（設定ファイル書込み前確認・MCP シークレットのリダクト）は、企業導入時のガードレール説明に有用。
+
+## 原文確認
+
+- 公式見出し: claude-code CHANGELOG 2.1.161 / 2.1.160
+- 公式URL: https://github.com/anthropics/claude-code/releases
+- raw: https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md
+- 原文全文は公式ページで確認してください。

--- a/docs/research/zenn-gemini-release-basic/official-updates/2026-06-02T000000-workspace-studio-loop-items.md
+++ b/docs/research/zenn-gemini-release-basic/official-updates/2026-06-02T000000-workspace-studio-loop-items.md
@@ -1,0 +1,40 @@
+---
+date: 2026-06-02
+title: "Workspace Studio でリストの各項目をループ処理できる「Repeat for each」ステップ"
+service: "Gemini / Google Workspace"
+source: https://workspaceupdates.googleblog.com/2026/06/introducing-ability-to-loop-over-list-of-items-in-Workspace-Studio.html
+fetched_at: 2026-06-03T10:13:03+09:00
+published_at: 2026-06-02T00:00:00Z
+date_precision: date-only
+category: rollout
+---
+
+# 2026-06-02 Workspace Studio に「リストをループ処理」する機能
+
+## 公式内容の日本語要約
+
+2026-06-02 の Google Workspace Updates で、Workspace Studio のフローに **ループ処理（「Repeat for each」ステップ）** が追加されたと告知された。リストや Google スプレッドシートの行を 1 件ずつ反復処理できる。あわせて **「Ask Gemini」ステップに「Response format」** が追加され、出力をテキスト形式またはリスト形式で返せるようになった。これにより「ミーティングノートのアクションアイテムごとにタスクを作成」「トラッキングシートの営業リードごとにメールを下書き」といった反復作業をエージェント的フローで自動化できる。
+
+## できるようになったこと
+
+- **Repeat for each ステップ**: リストの各項目／スプレッドシートの各行に対して同じアクション群を反復実行。
+- **Ask Gemini の Response format**: Gemini の出力をテキストまたはリストで返し、後続のループ入力に渡しやすくする。
+- ユースケース例: 議事録のアクションアイテムごとのタスク生成、リードリストごとのメール下書き。
+
+## 影響範囲
+
+- 対象エディション: Business Starter / Standard / Plus、Enterprise Standard / Plus、Education Fundamentals / Standard / Plus。アドオン: Google AI Pro for Education、Teaching and Learning、AI Expanded Access。
+- ロールアウト: Rapid Release / Scheduled Release ともに 2026-06-02 から全面展開（表示まで 1〜3 日）。
+- 管理者 / エンドユーザー: 管理者は Workspace Studio のステップ／スターターのアクセス管理が可能。エンドユーザーは Workspace Studio 内で直接利用。
+
+## 教材化メモ
+
+- Gemini / Workspace Studio の業務自動化教材に「Repeat for each（ループ）」「Ask Gemini の Response format」を追記。
+- 「ノーコードの反復処理 × スプレッドシート行ループ」という、Zapier/Make 的な自動化を Workspace 内で完結できる点を強調。
+- 対象エディションが Business/Enterprise/Education と広い点、ロールアウト日（6/2）を明示。
+
+## 原文確認
+
+- 公式見出し: Introducing the ability to loop over a list of items in Workspace Studio（2026-06-02）
+- 公式URL: https://workspaceupdates.googleblog.com/2026/06/introducing-ability-to-loop-over-list-of-items-in-Workspace-Studio.html
+- 原文全文は公式ページで確認してください。

--- a/src/content/ai-news-notes/chatgpt-openai/openai-models-codex-aws-ga.mdx
+++ b/src/content/ai-news-notes/chatgpt-openai/openai-models-codex-aws-ga.mdx
@@ -1,0 +1,14 @@
+---
+title: "OpenAI モデル・Codex の AWS（Bedrock）GA 教材化メモ"
+noteFor: "chatgpt-openai/openai-models-codex-aws-ga"
+date: 2026-06-02
+tags: ["openai", "codex", "aws", "amazon-bedrock", "enterprise"]
+---
+
+Codex / OpenAI モデルのエンタープライズ導入教材に「Amazon Bedrock での GA」を追記。OpenAI モデルの調達経路を **OpenAI 直販 / Azure / Amazon Bedrock** の 3 系統で整理し、それぞれのガバナンス・課金・リージョンの違いを比較表にできる。
+
+訴求の軸は「既存の AWS ガバナンス（IAM/VPC/KMS/CloudTrail）の中でフロンティアモデルを本番投入できる」点。情シス・調達・法務向けに、ベンダー審査をやり直さずに導入できることと、価格が直販と同額（AWS 追加マージンなし）・学習非利用である点を強調する。
+
+リージョン制約（GPT-5.5 は US East (Ohio) のみ等）とデータレジデンシーは、日本企業の導入判断の前提として必ず併記。国内データ保管要件があるケースでは提供経路の比較が必要になる旨を注記。
+
+副業・受託の文脈では、「AWS 中心のクライアントでも OpenAI / Codex を提案・実装できる」「Codex は従量課金でスポット案件と相性が良い」を活用フックとして接続できる。

--- a/src/content/ai-news-notes/codex/codex-role-plugins-sites.mdx
+++ b/src/content/ai-news-notes/codex/codex-role-plugins-sites.mdx
@@ -1,0 +1,14 @@
+---
+title: "Codex 役割特化プラグイン・Codex Sites 教材化メモ"
+noteFor: "codex/codex-role-plugins-sites"
+date: 2026-06-02
+tags: ["codex", "openai", "plugins", "codex-sites", "no-code"]
+---
+
+Codex 教材（plugins-overview / codex-app / marketplace）に「役割特化プラグイン（6種・62アプリ・110スキル）」と「Codex Sites」を追記。「Codex = エンジニア向けコーディングエージェント」という前提を更新し、**非エンジニアのナレッジワーク（データ分析・クリエイティブ、今後は財務／法務／戦略）** に広がった点を軸に再構成する。
+
+プラグイン教材では、データ分析（Snowflake/Databricks Genie/Hex/Tableau）とクリエイティブ制作（Figma/Canva/Shutterstock/Picsart/Fal）の接続アプリ例を具体的に示し、「自部門ツールに Codex を接続する」イメージを持たせる。今後追加予定（Corporate Finance / PE / Marketing Strategy / Strategy Consulting / Legal）も将来像として併記。
+
+Codex Sites は「成果物を URL で社内共有できる軽量内製アプリ基盤」として、業務自動化・社内ツール内製の教材に接続。ガバナンス注記として、Sites の共有範囲（誰がどの URL を閲覧できるか）と、接続アプリの権限・データアクセスを利用ガイドに明記すべき旨を 1 行入れる。
+
+非エンジニア向け副業・コンサル文脈では「コーディングなしで業務ツールを自動化」「クライアントに簡易ダッシュボードを URL で渡す」を活用フックとして展開できる。

--- a/src/content/ai-news-notes/gemini/workspace-studio-loop-items.mdx
+++ b/src/content/ai-news-notes/gemini/workspace-studio-loop-items.mdx
@@ -1,0 +1,14 @@
+---
+title: "Workspace Studio ループ処理（Repeat for each）教材化メモ"
+noteFor: "gemini/workspace-studio-loop-items"
+date: 2026-06-02
+tags: ["gemini", "google-workspace", "workspace-studio", "automation", "no-code"]
+---
+
+Gemini / Workspace Studio の業務自動化教材に「Repeat for each（ループ）」「Ask Gemini の Response format（テキスト／リスト出力）」を追記。Workspace Studio を「単発フロー」から「リスト・スプレッドシート行の反復処理」まで扱えるツールとして再整理する。
+
+「ノーコードの反復処理 × スプレッドシート行ループ × Gemini ステップ」で、Zapier/Make 的な自動化を Workspace 内で完結できる点を軸に解説。代表ユースケース（議事録アクションアイテムごとのタスク生成、リードごとのメール下書き）を手順例として示す。
+
+ガバナンス注記: ループはスプレッドシート行起点で大量実行が可能なため、管理者向け教材には「ステップ／スターターのアクセス管理」「外部送信アクションは下書き止め・件数上限」を誤実行防止策として記述。
+
+対象エディション（Business/Enterprise/Education + AI アドオン）とロールアウト日（2026-06-02、表示まで 1〜3 日）を必ず併記。個人・副業向けには「顧客／案件シートを 1 行ずつ処理する定型業務自動化」を活用フックとして接続。

--- a/src/content/ai-news/chatgpt-openai/openai-models-codex-aws-ga.mdx
+++ b/src/content/ai-news/chatgpt-openai/openai-models-codex-aws-ga.mdx
@@ -1,0 +1,46 @@
+---
+title: "OpenAI のフロンティアモデルと Codex が AWS（Amazon Bedrock）で GA — GPT-5.5 / GPT-5.4 と Codex を既存の AWS ガバナンス内で本番利用、価格は直販と同額・追加マージンなし"
+tool: "chatgpt-openai"
+toolLabel: "ChatGPT / OpenAI"
+date: 2026-06-02
+sourceUrl: "https://openai.com/index/openai-frontier-models-and-codex-are-now-available-on-aws/"
+summary: "OpenAI と AWS が、OpenAI のフロンティアモデル **GPT-5.5 / GPT-5.4** と コーディングエージェント **Codex** を **Amazon Bedrock で一般提供（GA）** したと告知した（2026-04 の Limited Preview からの昇格）。企業は IAM・VPC・KMS・CloudTrail といった既存の AWS セキュリティ／ガバナンスと、調達・課金・コンプラのワークフローをそのまま使って OpenAI モデルと Codex を本番投入できる。Bedrock 上の価格は OpenAI ファーストパーティ料金と一致し AWS の追加マージンはなく、Codex はシート課金なしの従量課金（pay-per-token）。プロンプト・応答はモデル学習に使われず、提供元とも共有されない。GPT-5.5 は US East (Ohio)、GPT-5.4 は US East (Ohio) / US West (Oregon) で提供。（openai.com / help.openai.com は当環境で本文取得が制限されたため、一次確認は AWS 公式 ML ブログの GA 告知と OpenAI 公式 index URL で行い、両者を出典として記録している。）"
+impact: "「OpenAI を使いたいが、調達・セキュリティ・データガバナンスの都合で AWS の外には出せない」という企業の障壁を取り除く動き。既存の AWS 契約・IAM・VPC・KMS・CloudTrail の枠内でフロンティアモデルと Codex を本番投入でき、稟議・ベンダー審査をやり直さずに導入を進められる。価格が直販と同額（AWS 追加マージンなし）で、プロンプト／応答が学習に使われない点も、情シス・法務・調達の論点をクリアしやすい。一方で GPT-5.5 が US East (Ohio) 限定などリージョン制約があり、データレジデンシー要件のある日本企業は提供リージョンとレイテンシを前提に設計する必要がある。"
+tags: ["openai", "codex", "aws", "amazon-bedrock", "gpt-5-5", "enterprise", "ga"]
+status: "candidate"
+relatedKnowledge:
+  - "/knowledge/ai-tools/chatgpt/overview"
+  - "/knowledge/ai-tools/codex/enterprise-admin"
+draft: false
+---
+
+## 要約
+
+OpenAI と AWS が、OpenAI のフロンティアモデル **GPT-5.5 / GPT-5.4** とコーディングエージェント **Codex** を **Amazon Bedrock で一般提供（GA）** したと告知しました。2026-04 の Limited Preview からの昇格です。
+
+ポイントは、企業が **すでに使っている AWS のセキュリティ・ガバナンス・調達・課金のワークフローの中で** OpenAI モデルと Codex を本番利用できるようになったことです。GPT-5.5 は「OpenAI の最も高度なフロンティアモデル」と位置づけられ、Bedrock 上の価格は OpenAI 直販料金と一致し、AWS 側の追加マージンはありません。Codex はシートライセンス不要の従量課金（pay-per-token）です。
+
+> openai.com / help.openai.com は当環境では本文の直接取得が制限されるため、日付・内容は AWS 公式 ML ブログの GA 告知（2026-06-01）と OpenAI 公式 index ページの URL で確認し、両者を出典として記録しています。
+
+## 何が変わったか
+
+- **対象**: GPT-5.5、GPT-5.4、Codex が Amazon Bedrock で GA。
+- **価格**: GPT-5.5 / GPT-5.4 は OpenAI 直販と同額で、AWS の追加課金なし。Codex はシート課金なしの従量課金。
+- **エンタープライズ統制**: IAM 権限、VPC 分離、KMS 暗号化、CloudTrail 監査など既存の AWS ガバナンスをそのまま適用。プロンプト・応答はモデル学習に使われず、モデル提供元とも共有されない。
+- **Codex の開発統合**: VS Code / JetBrains / Xcode の IDE 連携に対応し、選択リージョン内でデータレジデンシーを維持しつつ大規模コードベースで記述・デバッグ・リファクタが可能。
+- **リージョン**: GPT-5.5 は US East (Ohio)、GPT-5.4 は US East (Ohio) / US West (Oregon)（詳細は AWS Regions ページ）。
+- **基盤**: Bedrock の推論基盤（隔離キュー、自動キャパシティ管理、耐久的な状態保持）上で動作。
+
+## 業務インパクト（一般企業向け）
+
+これは「OpenAI を使いたいが、調達・セキュリティ・データガバナンスの都合で AWS の外には出せない」という企業にとって、導入障壁を大きく下げる発表です。既存の AWS 契約・IAM・VPC・KMS・CloudTrail の枠内でフロンティアモデルと Codex を本番投入できるため、ベンダー審査や稟議をやり直さずに導入を進められます。
+
+価格が直販と同額（AWS 追加マージンなし）で、プロンプト・応答が学習に使われない点も、情シス・法務・調達の論点をクリアしやすい設計です。AWS を主基盤にしている企業は、OpenAI モデルを「新規ベンダー追加」ではなく「既存 Bedrock の延長」として評価できます。
+
+注意点はリージョン制約です。GPT-5.5 が US East (Ohio) 限定であるなど、提供リージョンが限られます。データレジデンシー要件のある日本企業は、利用可能リージョン・レイテンシ・国内データ保管の要否を前提に設計し、要件に合わない場合は他の提供経路（OpenAI 直販 / Azure）との比較が必要です。
+
+## 副業・個人活用視点
+
+個人開発者・フリーランスにとっては、**クライアントが AWS 中心の環境でも OpenAI モデル・Codex を提案・実装しやすくなる**のが直接の恩恵です。「このクライアントは AWS だから OpenAI は使いにくい」という制約が外れ、Bedrock 上で GPT-5.5 / Codex を組み込む案件を取りに行けます。
+
+Codex がシート課金なしの従量課金である点は、小規模・スポット案件と相性が良く、使った分だけのコストで AI コーディング支援を組み込めます。受託で「AWS ガバナンス準拠のまま AI 機能を載せる」要件に応えられることは、提案時の差別化材料になります。

--- a/src/content/ai-news/codex/codex-role-plugins-sites.mdx
+++ b/src/content/ai-news/codex/codex-role-plugins-sites.mdx
@@ -1,0 +1,49 @@
+---
+title: "Codex が「全職種・全ツール・全ワークフロー」へ — 6つの役割特化プラグイン（62アプリ・110スキル）、その場修正のアノテーション、URL 共有できる Codex Sites を発表"
+tool: "codex"
+toolLabel: "OpenAI Codex"
+date: 2026-06-02
+sourceUrl: "https://openai.com/index/codex-for-every-role-tool-workflow/"
+summary: "OpenAI が Codex の新しい使い方を発表した。(1) 役割とツールに合わせる **プラグイン**、(2) 結果をその場で修正する **アノテーション**、(3) 共有可能なインタラクティブ Web サイト・アプリを作る **Codex Sites（プレビュー）** の 3 本柱。コーディング不要で多様なナレッジワークに Codex を使えるよう、**6 つの役割特化プラグイン**を新たに提供し、合計 **62 の人気アプリと 110 のスキル**を含む。データ分析（Snowflake / Databricks Genie / Hex / Tableau）やクリエイティブ制作（Figma / Canva / Shutterstock / Picsart / Fal）などで、非エンジニアの業務に Codex を最適化する。今後 Corporate Finance・Private Equity・Marketing Strategy・Strategy Consulting・Legal 向けも追加予定。Codex Sites は、アイデア・分析・計画をダッシュボード／プランナー／レビュー用ワークスペース／プロジェクトボード等に変換し、ワークスペース内の誰とでも URL で共有できる。"
+impact: "Codex を「エンジニアのコーディングエージェント」から「全職種のナレッジワーク基盤」へ広げる戦略転換。データ分析・マーケ・クリエイティブといった非開発部門が、コーディングなしで自部門のツール（Snowflake・Tableau・Figma・Canva 等）に Codex を接続して業務を回せるようになる。Codex Sites は、成果物をワークスペース内に URL 共有できる軽量な内製アプリ基盤として、社内ツール内製・業務自動化の入口になりうる。企業の情シス・各部門は、Codex が接続するアプリ範囲（62アプリ）と権限・データアクセス、社内共有される Sites のガバナンス（誰がどの URL を見られるか）を導入前に整理する必要がある。"
+tags: ["codex", "openai", "plugins", "codex-sites", "no-code", "enterprise", "knowledge-work"]
+status: "candidate"
+relatedKnowledge:
+  - "/knowledge/ai-tools/codex/plugins-overview"
+  - "/knowledge/ai-tools/codex/codex-app"
+draft: false
+---
+
+## 要約
+
+OpenAI が Codex の新しい使い方を発表しました。柱は 3 つです。
+
+1. **プラグイン**: 役割とツールに合わせて Codex を最適化する。
+2. **アノテーション**: 出力結果をその場で指定して精緻化する。
+3. **Codex Sites（プレビュー）**: 共有可能なインタラクティブ Web サイト・アプリを作る。
+
+最大の変化は、**コーディング不要で多様なナレッジワークに Codex を使える 6 つの役割特化プラグイン**が追加されたことです。これらは合計 **62 の人気アプリと 110 のスキル**を含みます。Codex を「エンジニア向け」から「全職種向け」に広げる方向性が明確になりました。
+
+## 何が変わったか
+
+- **役割特化プラグイン（6種）**: 非エンジニアの業務向けに Codex を最適化。
+  - データ分析: Snowflake / Databricks Genie / Hex / Tableau 等で、アナリスト・事業チームがデータから問いに答える。
+  - クリエイティブ制作: Figma / Canva / Shutterstock / Picsart / Fal 等で、ブリーフからアセットを生成。
+  - 今後追加予定: Corporate Finance、Private Equity Investing、Marketing Strategy、Strategy Consulting、Legal。
+- **アノテーション**: 出力をその場で指定して結果を修正・精緻化。
+- **Codex Sites（プレビュー）**: アイデア・分析・計画を、ダッシュボード・プランナー・レビュー用ワークスペース・プロジェクトボード・ギャラリー・軽量ツールに変換し、ワークスペース内の誰とでも URL で共有できるホスト済みアプリ／サイトを作成。
+- 報道（9to5Mac, VentureBeat 等）では、Codex を ChatGPT アプリのあらゆる場所に組み込む動きとして位置づけられている。
+
+## 業務インパクト（一般企業向け）
+
+これは Codex を「エンジニアのコーディングエージェント」から「全職種のナレッジワーク基盤」へ広げる戦略転換です。データ分析・マーケティング・クリエイティブといった**非開発部門が、コーディングなしで自部門のツール（Snowflake・Tableau・Figma・Canva 等）に Codex を接続して業務を回せる**ようになります。
+
+Codex Sites は、分析や計画を**ワークスペース内に URL 共有できる軽量な内製アプリ基盤**として機能します。これまで「スプレッドシート＋手作業」で回していたレビューやプロジェクト管理を、その場で作った簡易ツールに置き換えられる可能性があります。
+
+導入にあたっては、情シスと各部門で論点整理が必要です。Codex が接続するアプリ範囲（62アプリ）と、それぞれの権限・データアクセス、そして社内共有される Sites のガバナンス（誰がどの URL を閲覧できるか、機微情報を含む成果物の共有範囲）を、利用ガイドラインに落とし込んでおくべきです。
+
+## 副業・個人活用視点
+
+非エンジニアの副業・個人事業にとっては、**コーディングなしで業務ツールを自動化・内製できる**のが大きな利点です。データ分析やクリエイティブ制作のプラグインを使えば、自分が普段使うツール（Figma・Canva・Tableau 等）の作業を Codex に任せ、納品物の制作・分析を高速化できます。
+
+Codex Sites は、クライアントや協業相手に**簡易ダッシュボードやレビュー用ワークスペースを URL で渡す**用途に向きます。提案資料や進行管理を「その場で作る軽量アプリ」として共有できれば、個人でも見栄えと実用性のある成果物を低コストで提供できます。将来追加予定の Marketing Strategy・Legal・Finance 系プラグインは、専門領域の副業・コンサル業務の効率化に直結します。

--- a/src/content/ai-news/gemini/workspace-studio-loop-items.mdx
+++ b/src/content/ai-news/gemini/workspace-studio-loop-items.mdx
@@ -1,0 +1,43 @@
+---
+title: "Workspace Studio に「Repeat for each」ループ処理が追加 — リスト／スプレッドシート行を 1 件ずつ反復、Ask Gemini はリスト出力に対応（Business/Enterprise/Education で 6/2 から展開）"
+tool: "gemini"
+toolLabel: "Gemini / Google Workspace"
+date: 2026-06-02
+sourceUrl: "https://workspaceupdates.googleblog.com/2026/06/introducing-ability-to-loop-over-list-of-items-in-Workspace-Studio.html"
+summary: "2026-06-02 の Google Workspace Updates で、Workspace Studio のフローに **ループ処理（「Repeat for each」ステップ）** が追加された。リストや Google スプレッドシートの行を 1 件ずつ反復処理でき、あわせて **「Ask Gemini」ステップに「Response format」** が追加されて出力をテキストまたはリスト形式で返せるようになった。これにより「議事録のアクションアイテムごとにタスクを作成」「トラッキングシートの営業リードごとにメールを下書き」といった反復作業を、ノーコードのエージェント的フローで自動化できる。対象は Business（Starter/Standard/Plus）、Enterprise（Standard/Plus）、Education（Fundamentals/Standard/Plus）と AI 系アドオンで、Rapid / Scheduled Release ともに 2026-06-02 から全面展開（表示まで 1〜3 日）。"
+impact: "Workspace Studio が「単発のフロー」から「リスト・スプレッドシート行に対する繰り返し処理」までカバーするようになり、Zapier / Make 的な反復自動化を Google Workspace の内側で完結できるようになる。営業リードごとのメール下書き、議事録のアクションアイテムごとのタスク生成など、これまで人手で繰り返していた定型業務を Gemini ステップ込みで自動化できる。対象エディションが Business / Enterprise / Education と広く、追加コストなしで既存契約の範囲で使える点も大きい。情シス・業務部門は、ループがスプレッドシート行を起点に大量処理を回せるため、誤送信・大量実行・権限（Studio のステップ／スターター管理）を前提にガードレールを設計しておくとよい。"
+tags: ["gemini", "google-workspace", "workspace-studio", "automation", "no-code", "rollout"]
+status: "candidate"
+relatedKnowledge:
+  - "/knowledge/ai-tools/gemini/workspace-features"
+draft: false
+---
+
+## 要約
+
+2026-06-02 の Google Workspace Updates で、Workspace Studio のフローに **ループ処理（「Repeat for each」ステップ）** が追加されました。リストや Google スプレッドシートの行を **1 件ずつ反復処理**できます。
+
+あわせて **「Ask Gemini」ステップに「Response format」** が追加され、Gemini の出力を**テキスト形式またはリスト形式**で返せるようになりました。リスト出力は後続のループ入力に渡しやすく、「Gemini で項目リストを作る → 各項目に対して処理を繰り返す」という流れを 1 本のフローで組めます。
+
+## 何が変わったか
+
+- **Repeat for each ステップ**: リストの各項目／スプレッドシートの各行に対して、同じアクション群を反復実行。
+- **Ask Gemini の Response format**: Gemini の出力をテキストまたはリストで返し、ループの入力に渡しやすくする。
+- **ユースケース例**: 議事録のアクションアイテムごとのタスク生成、トラッキングシートの営業リードごとのメール下書き。
+- **対象エディション**: Business Starter / Standard / Plus、Enterprise Standard / Plus、Education Fundamentals / Standard / Plus。アドオン: Google AI Pro for Education、Teaching and Learning、AI Expanded Access。
+- **ロールアウト**: Rapid Release / Scheduled Release ともに 2026-06-02 から全面展開（表示まで 1〜3 日）。
+- **権限**: 管理者は Workspace Studio のステップ／スターターのアクセスを管理可能。
+
+## 業務インパクト（一般企業向け）
+
+Workspace Studio はこれまで「単発のフロー」を組むツールでしたが、ループ処理の追加で**リスト・スプレッドシート行に対する繰り返し処理**までカバーするようになりました。Zapier / Make のような反復自動化を、**Google Workspace の内側で完結**できる点が要点です。
+
+営業リードごとのメール下書き、議事録のアクションアイテムごとのタスク生成など、これまで人手で繰り返していた定型業務を Gemini ステップ込みで自動化できます。対象エディションが Business / Enterprise / Education と広く、追加コストなしで既存契約の範囲で使えるため、すでに Workspace を使っている企業はすぐに試せます。
+
+一方で、ループはスプレッドシート行を起点に**大量処理を一気に回せる**ため、誤送信や意図しない大量実行のリスクがあります。情シス・業務部門は、Studio のステップ／スターター権限管理を使って利用範囲を絞り、メール送信など外部影響のあるアクションは下書き止まりにする・件数上限を設けるといったガードレールを前提に設計しておくと安全です。
+
+## 副業・個人活用視点
+
+個人事業・フリーランスにとっては、**スプレッドシートを起点にした定型業務の自動化**がノーコードで組めるのが利点です。顧客リストや案件管理シートを 1 行ずつ処理し、「各顧客向けに Gemini で文面を生成 → 下書きメール作成」「各案件のステータスを要約」といった反復作業を Workspace 内で回せます。
+
+Google AI Pro / Workspace を使っている個人なら追加ツールなしで実現でき、外部の自動化 SaaS を契約せずに済むのも小規模運用ではコストメリットになります。まずは「下書き生成・要約・タスク化」など、誤実行しても影響の小さい用途から組み立てるのが現実的です。


### PR DESCRIPTION
## Summary

- 窓: 2026-06-02T09:08 → 2026-06-03T10:13 (JST、前日 window_end を継承)
- 更新あり: 4件
  - ChatGPT / OpenAI: フロンティアモデル（GPT-5.5/5.4）＆Codex が Amazon Bedrock で GA（rollout）
  - OpenAI Codex: Codex for every role, tool, and workflow（役割別プラグイン・アノテーション・Codex Sites / release）
  - Gemini / Workspace: Workspace Studio に「Repeat for each」ループ処理（rollout）
  - Claude Code: v2.1.160 / v2.1.161（enhancement・記事は見送り）
- 公開記事化: 3件（chatgpt-openai / codex / gemini、各記事＋教材化メモの対）
- 見送り: Claude Code（連日パッチ・単一見出し機能なし）、n8n@2.25.1（保守パッチ）
- 取得失敗: OpenAI 公式（help.openai.com / openai.com）WebFetch 403 → AWS 公式 ML ブログ・OpenAI 公式 index URL・報道（VentureBeat/9to5Mac）で一次確認
- 補足: Google I/O 2026 関連（Gemini Omni / 3.5 Flash / Antigravity / Gemini CLI 移行 等）は発表 2026-05-19 で窓外のため対象外（既報）

## Test plan

- [x] `npm run check` — 0 errors（warnings 0 / hints 39、いずれも既存分）
- [x] 日次サマリーから詳細メモ・公開記事・教材化メモへのリンク/パスが解決
- [x] frontmatter（aiNews / aiNewsNotes スキーマ）に合致、tool は content.config.ts の enum 内
- [x] relatedKnowledge は実在する knowledge 記事のみ参照
- [x] \`daily-ai-update-monitor\` と \`ai-news-publisher\` の SKILL 規約に準拠

🤖 Generated with [Claude Code](https://claude.com/claude-code)