### PR TITLE
feat: 2026-06-08 AIニュース日次チェック（直近24h・更新なし）

### DIFF
--- a/docs/research/daily-ai-updates/2026-06-08.md
+++ b/docs/research/daily-ai-updates/2026-06-08.md
@@ -1,0 +1,71 @@
+---
+date: 2026-06-08
+title: "AI公式アップデート日次チェック 2026-06-08"
+fetched_at: 2026-06-08T10:56:58+09:00
+window_start: 2026-06-07T12:50:00+09:00
+window_end: 2026-06-08T10:56:58+09:00
+---
+
+# AI公式アップデート日次チェック 2026-06-08
+
+## サマリー
+
+- 対象期間: 2026-06-07T12:50:00+09:00 → 2026-06-08T10:56:58+09:00（前日サマリーの window_end を引き継ぎ）
+- 更新あり: 0件
+- 更新なし: 全対象ソース（下記）
+- 取得失敗・保留: OpenAI `help.openai.com` / `openai.com/news`（403）、xAI 公式（403）
+- incident: OpenAI 2件・Claude 2件（いずれも 06-07、短時間で復旧。記事化せず記録のみ）
+
+窓内に製品・モデル・API・機能の公式新規発表は確認できなかった。GitHub Releases 系（Claude Code / Codex / n8n / Dify）も窓内（2026-06-07T03:50Z → 2026-06-08T01:56Z）に新規タグなし。直近の発表はいずれも 06-06 以前で前日までに記事化済み。
+
+## 更新あり
+
+なし。
+
+## 更新なし
+
+- ChatGPT / OpenAI: `developers.openai.com/api/docs/changelog` は最新 06-04、`openai.com/news` 系は 403。窓内の新規製品・API 発表なし。
+- OpenAI Codex: GitHub Releases の最新は `rust-v0.138.0-alpha.6`（06-06 03:23Z、窓外）。窓内は stable・alpha とも新規なし。
+- Claude / Anthropic: `support.claude.com` Release Notes（最新 06-02）、`anthropic.com/news`（最新 06-03）、`claude.com/blog`（最新 06-05）、`platform.claude.com` Release Notes（最新 06-05、Opus 4.1 deprecation）。AWS What's New 側にも窓内の Claude 関連 GA なし。
+- Claude Code: GitHub Releases / CHANGELOG とも最新は v2.1.168（06-06 23:41Z、窓外）。窓内の新規リリースなし。
+- Cursor: `cursor.com/changelog`・`cursor.com/blog` とも最新 06-05（Design Mode Improvements）。`status.cursor.com` は incident なし。
+- GitHub Copilot: `github.blog/changelog` の最新は 06-05。窓内の新規エントリなし。
+- Gemini / Workspace: Gemini Apps Release Notes（最新 05-19）、Gemini API Changelog（最新 06-01）、Workspace Updates（最新 06-05 週次 Recap）。窓内の個別ポストなし。
+- n8n: GitHub Releases の最新は n8n@2.23.4（06-05、窓外）。窓内の新規リリースなし。
+- Dify: 最新 1.14.2（05-19）。窓内更新なし。
+- Genspark / Manus / Meta AI / Runway / ByteDance Seed / Pika / xAI Grok: 公式ソースに窓内の新規発表なし。
+
+## 取得失敗・保留
+
+- OpenAI `help.openai.com`（ChatGPT Release Notes）/ `openai.com/news`：403 で一次本文取得不可。補助として `developers.openai.com/api/docs/changelog`（窓内更新なし）と `status.openai.com/history` を確認。
+- xAI `x.ai/news` / `x.ai/build/changelog`：403 でアクセス不可。`docs.x.ai` の release-notes には窓内記載なし。
+
+## incident（記事化せず記録のみ）
+
+- OpenAI（`status.openai.com/history`）: 2026-06-07 18:06 UTC 頃 Free / Go ユーザー向けのサービス中断、同 19:25 UTC 頃 Go ユーザー向けのサービス中断。いずれも復旧済み。
+- Claude（`status.claude.com`）: 2026-06-07 03:31〜04:28 UTC 複数モデルでパフォーマンス低下（エラー率上昇）、同 14:35〜15:41 UTC Claude Opus 4.7 でエラー増加。いずれも解決済み。
+
+## 補足メモ
+
+- 【予告・窓外】Gemini Enterprise リリースノートに「2026-06-09 をもって Gemini 3.5 Flash の機能管理トグルを廃止し、デフォルト有効化」との予告あり（06-08 時点で未実施）。次回（06-09 以降）の確認候補。
+- 【前回からの繰越】OpenAI API moderation scores（Responses / Chat Completions に `moderation` オブジェクト、`omni-moderation-latest`）は公式 changelog 上 06-04 付（過去窓）。06-05 サマリーで未記載のため追補候補として継続記録。今窓でも新規動きなし。
+- ユーザー認識ギャップ該当なし。
+
+## チェック対象
+
+- ChatGPT / OpenAI: https://help.openai.com/en/articles/6825453-chatgpt-release-notes（403）, https://openai.com/news/（403）, https://developers.openai.com/api/docs/changelog, https://status.openai.com/history
+- OpenAI Codex: https://github.com/openai/codex/releases
+- Gemini: https://blog.google/products-and-platforms/products/gemini/, https://workspaceupdates.googleblog.com/, https://ai.google.dev/gemini-api/docs/changelog
+- Claude: https://support.claude.com/en/articles/12138966-release-notes, https://www.anthropic.com/news, https://claude.com/blog, https://platform.claude.com/docs/en/release-notes/overview, https://status.claude.com/
+- Claude Code: https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md
+- Cursor: https://cursor.com/changelog, https://cursor.com/blog, https://status.cursor.com/
+- GitHub Copilot: https://github.blog/changelog/label/copilot/
+- n8n: https://github.com/n8n-io/n8n/releases
+- Dify: https://github.com/langgenius/dify/releases
+- Genspark: https://www.genspark.ai/blog
+- Manus: https://manus.im/blog
+- Meta AI: https://ai.meta.com/blog/
+- Runway: https://runwayml.com/changelog, https://runwayml.com/news
+- xAI / Grok: https://docs.x.ai/docs/release-notes, https://x.ai/news（403）
+- ByteDance Seed: https://seed.bytedance.com/en/blog/
+- Pika: https://pika.art/blog


### PR DESCRIPTION
## Summary

- 窓: 2026-06-07T12:50:00 → 2026-06-08T10:56:58 (JST)。前日(06-07)の window_end を引き継ぎ。
- 更新あり: **0件**。全対象ソース（OpenAI / Codex / Claude / Claude Code / Cursor / GitHub Copilot / Gemini・Workspace / n8n / Dify / Genspark / Manus / Meta AI / Runway / xAI Grok / ByteDance Seed / Pika）で窓内の製品・モデル・API・機能の新規発表を確認できず。
- GitHub Releases 系も窓内（2026-06-07T03:50Z → 2026-06-08T01:56Z）に新規タグなし。最新は v2.1.168（Claude Code, 06-06）/ rust-v0.138.0-alpha.6（Codex, 06-06）/ n8n@2.23.4（06-05）でいずれも前日までに記事化・記録済み。
- **incident（記事化せず記録のみ）**: OpenAI 2件（06-07、Free/Go 向けサービス中断）/ Claude 2件（06-07、複数モデルの性能低下・Opus 4.7 のエラー増）。いずれも短時間で復旧。
- 取得失敗・保留: OpenAI `help.openai.com`・`openai.com/news`（403）、xAI 公式（403）。
- 補足: Gemini Enterprise で「Gemini 3.5 Flash の機能管理トグル廃止・デフォルト有効化」が **2026-06-09 予定**（次回確認候補）。

更新なしのため速報記事・教材化メモの追加はなし。日次サマリーのみ（既存運用どおり `git add -f`）。

## Test plan

- [x] `npm run check` — 0 errors
- [x] 全対象ソースを巡回し、窓内更新ゼロを一次情報で確認（403 ソースは補助ソース・status で代替確認）
- [x] `daily-ai-update-monitor` の「更新なしも有効な結果として記録」「incident は記録のみ」規約に準拠

🤖 Generated with [Claude Code](https://claude.com/claude-code)