### PR TITLE
feat: 2026-06-14 AIニュース日次チェック（退役予告フォロー1件）

### DIFF
--- a/docs/research/daily-ai-updates/2026-06-14.md
+++ b/docs/research/daily-ai-updates/2026-06-14.md
@@ -1,0 +1,84 @@
+---
+date: 2026-06-14
+title: "AI公式アップデート日次チェック 2026-06-14"
+fetched_at: 2026-06-14T11:46:51+09:00
+window_start: 2026-06-13T11:04:44+09:00
+window_end: 2026-06-14T11:46:51+09:00
+---
+
+# AI公式アップデート日次チェック 2026-06-14
+
+## サマリー
+
+- 対象期間: 2026-06-13T11:04:44+09:00 → 2026-06-14T11:46:51+09:00
+- 更新あり: 0件（窓内新規アップデートなし）
+- 更新なし: ChatGPT/OpenAI / Gemini / Claude / Claude Code / OpenAI Codex（stable なし）/ GitHub Copilot / Cursor / n8n / Dify / Meta AI / Runway / Genspark / ByteDance Seed / Pika
+- 取得失敗・保留: OpenAI `help.openai.com`/`openai.com/news`（403）、xAI `x.ai/news`（403）、xAI June更新（日付不明確・保留）
+
+## 更新あり
+
+窓内の新規公式アップデートなし。
+
+## 退役予告フォロー（重要）
+
+| service | retire_date | title | category | detail |
+| --- | --- | --- | --- | --- |
+| Claude / Anthropic | 2026-06-15 | Claude Sonnet 4・Opus 4 — **明日**退役（Claude API から削除、Sonnet 4.6・Opus 4.8 へ移行必須） | policy | ../zenn-claude-release-basic/official-updates/2026-06-14T000000-claude-sonnet4-opus4-retire-2026-06-15.md |
+
+## 速報記事化済み
+
+| service | title | 記事 | 教材化メモ |
+| --- | --- | --- | --- |
+| Claude / Anthropic | Claude Sonnet 4・Opus 4 が明日 2026-06-15 に退役 — Sonnet 4.6・Opus 4.8 への移行が必須 | src/content/ai-news/claude/claude-sonnet4-opus4-retire-2026-06-15.mdx | src/content/ai-news-notes/claude/claude-sonnet4-opus4-retire-2026-06-15.mdx |
+
+## 見送り
+
+- OpenAI Codex rust-v0.140.0-alpha.18（2026-06-13T17:30:26Z）・alpha.19（2026-06-14T02:03:02Z）: stable 未リリース。件数記録のみ。
+
+## 更新なし
+
+- ChatGPT/OpenAI: `help.openai.com`（403）、`openai.com/news`（403）。OpenAI API changelog 最新 2026-06-09（窓外）。
+- OpenAI Codex: stable なし（alpha.18・alpha.19 の 2件のみ）。
+- Gemini: Google Gemini Blog 最新 Gemini Omni（2026-05-29）。Workspace Updates 最新 2026-06-12 週次Recap（窓外）。
+- Claude: 公式 Release Notes 最新 2026-06-12（Fable 5/Mythos 5 停止）。窓内新規なし。
+- Claude Code: CHANGELOG.md 最新 v2.1.176。窓内新規エントリなし。
+- GitHub Copilot: changelog 最新 2026-06-12。窓内新規なし。
+- Cursor: changelog 最新 2026-06-10（Bugbot 改善）。窓内更新なし。
+- n8n / Dify: 窓内更新なし（GitHub Releases 確認）。
+- Meta AI Blog: 最新 2026-04-08。窓内更新なし。
+- Runway: changelog 最新 2026-05-21。窓内更新なし。
+- Genspark: 最新 2026-05-17。窓内更新なし。
+- ByteDance Seed: 最新 2026-04-23。窓内更新なし。
+- Pika: ブログ更新なし。
+- claude.com/blog: 最新 2026-06-10（Building with Claude Managed Agents）。窓内新規なし。
+
+## 取得失敗・保留
+
+- OpenAI `help.openai.com`（ChatGPT Release Notes）/ `openai.com/news`：403 継続。
+- xAI `x.ai/news`：403。`docs.x.ai/docs/release-notes` の June 2026 エントリ（Public URLs for Files API / Imagine 統合）は月単位の日付のみで窓内確定不可 → 保留。
+- Manus: `manus.im/blog` に公式発表なし（保留継続）。
+
+## 補足メモ
+
+- **【退役当日前日アラート】** Claude Sonnet 4（`claude-sonnet-4-20250514`）と Claude Opus 4（`claude-opus-4-20250514`）は **明日 2026-06-15 に Claude API から退役**。API で固定指定している実装は今日中に Sonnet 4.6 / Opus 4.8 へ移行しておく必要がある。
+- **【追加退役予告】** Claude Opus 4.1（`claude-opus-4-1-20250805`）は 2026-08-05 退役予定（次回以降フォロー継続）。
+- ユーザー認識ギャップ該当なし。
+
+## チェック対象
+
+- ChatGPT / OpenAI: https://help.openai.com/en/articles/6825453-chatgpt-release-notes（403）, https://openai.com/news/（403）, https://developers.openai.com/api/docs/changelog
+- OpenAI Codex: https://github.com/openai/codex/releases
+- Gemini: https://blog.google/products-and-platforms/products/gemini/, https://workspaceupdates.googleblog.com/
+- Claude: https://support.claude.com/en/articles/12138966-release-notes, https://www.anthropic.com/news, https://claude.com/blog, https://platform.claude.com/docs/en/release-notes/overview
+- Claude Code: https://github.com/anthropics/claude-code/releases, https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md
+- Cursor: https://cursor.com/changelog
+- GitHub Copilot: https://github.blog/changelog/label/copilot/, https://github.blog/changelog/month/06-2026/
+- n8n: https://github.com/n8n-io/n8n/releases
+- Dify: https://github.com/langgenius/dify/releases
+- Genspark: https://www.genspark.ai/blog
+- Manus: https://manus.im/blog
+- Meta AI: https://ai.meta.com/blog/
+- Runway: https://runwayml.com/changelog
+- xAI / Grok: https://docs.x.ai/docs/release-notes, https://x.ai/news（403）
+- ByteDance Seed: https://seed.bytedance.com/en/blog/
+- Pika: https://pika.art/blog

--- a/docs/research/zenn-claude-release-basic/official-updates/2026-06-14T000000-claude-sonnet4-opus4-retire-2026-06-15.md
+++ b/docs/research/zenn-claude-release-basic/official-updates/2026-06-14T000000-claude-sonnet4-opus4-retire-2026-06-15.md
@@ -1,0 +1,52 @@
+---
+date: 2026-06-14
+title: "Claude Sonnet 4 / Opus 4 — 2026-06-15 Claude API 退役（移行先: Sonnet 4.6 / Opus 4.8）"
+service: "Claude / Anthropic"
+source: https://platform.claude.com/docs/en/docs/about-claude/models/overview
+fetched_at: 2026-06-14T11:46:51+09:00
+published_at: 2026-06-05T00:00:00Z
+date_precision: date-only
+category: policy
+---
+
+# 2026-06-14 Claude Sonnet 4 / Opus 4 — Claude API 退役は明日 2026-06-15
+
+## 公式内容の日本語要約
+
+Anthropic の公式モデル一覧ページにて、以下の 2 モデルの退役警告が掲示されている。
+
+- **Claude Sonnet 4**（`claude-sonnet-4-20250514`）: Claude API 上での退役は **2026-06-15**
+- **Claude Opus 4**（`claude-opus-4-20250514`）: Claude API 上での退役は **2026-06-15**
+
+退役後は上記モデル ID へのリクエストがエラーを返すようになる。
+
+推奨移行先:
+
+- Sonnet 4 → **Claude Sonnet 4.6**（`claude-sonnet-4-6`）
+- Opus 4 → **Claude Opus 4.8**（`claude-opus-4-8`）
+
+退役告知は、Anthropic が Claude Opus 4.1 の非推奨（2026-08-05 退役）を発表した 2026-06-05 の Platform リリースノートと同日に公式ドキュメント上で確認できる。
+
+## できるようになったこと（変化）
+
+- 退役以降: `claude-sonnet-4-20250514` / `claude-opus-4-20250514` へのリクエストがエラー
+- Sonnet 4.6 は同価格（$3 / $15 per MTok）かつコンテキスト 1M トークン対応
+- Opus 4.8 は価格 $15 / $75 → $5 / $25 に大幅値下げ、1M コンテキスト対応
+
+## 影響範囲
+
+- 対象ユーザー: Claude API / Bedrock / Vertex AI / Microsoft Foundry を通じて上記モデル ID を固定指定している開発者・企業
+- 対象プラン: API 利用者全般
+- API: 退役後はエラー応答。UI（claude.ai）のエンドユーザーへの直接影響なし
+
+## 教材化メモ
+
+- モデル退役は Anthropic のモデルライフサイクル管理の定期イベント。モデル ID ハードコードの危険性を具体例として教材に使える
+- Opus 4.8 の $5 / $25 は Opus 4 の $15 / $75 から 2/3 値下げという大きな変化
+- 退役 → エラー発生の影響を最小化するには「モデル ID を設定外出し」「移行テストを本番前に実施」の 2 点がポイント
+
+## 原文確認
+
+- 公式見出し: "Claude Sonnet 4 (claude-sonnet-4-20250514) and Claude Opus 4 (claude-opus-4-20250514) are deprecated and will be retired on June 15, 2026."
+- 公式URL: https://platform.claude.com/docs/en/docs/about-claude/models/overview
+- 原文全文は公式ページで確認してください。

--- a/src/content/ai-news-notes/claude/claude-sonnet4-opus4-retire-2026-06-15.mdx
+++ b/src/content/ai-news-notes/claude/claude-sonnet4-opus4-retire-2026-06-15.mdx
@@ -1,0 +1,45 @@
+---
+title: "教材化メモ: Claude Sonnet 4・Opus 4 退役（2026-06-15）— モデルライフサイクル管理の教訓"
+noteFor: "claude/claude-sonnet4-opus4-retire-2026-06-15"
+date: 2026-06-14
+tags: ["claude", "model-deprecation", "claude-api", "lifecycle"]
+---
+
+## 教材化ポイント
+
+### モデル退役の仕組みと周期
+
+Claude のモデルライフサイクルは概ね以下のパターンで進む。
+
+1. 新モデルリリース（例: Claude Sonnet 4 — 2025-05 リリース）
+2. 後継モデルリリース（例: Sonnet 4.6 — 2026-01 頃）
+3. 旧モデルへの非推奨宣言（公式ドキュメントに Warning 表示）
+4. 退役（例: 2026-06-15。リリースから約 13 ヶ月後）
+
+Anthropic は「最低 90 日前に告知」を方針としており、[Commitments on model deprecation and preservation](https://www.anthropic.com/research/deprecation-commitments) に明記されている。
+
+### 価格変化のモデル
+
+- Sonnet 4（$3/$15）→ Sonnet 4.6（$3/$15）: 価格は同じだがコンテキスト窓が 200k → 1M に拡大（実質改善）
+- Opus 4（$15/$75）→ Opus 4.8（$5/$25）: 約 67% 値下がり。Anthropic はフラッグシップモデルを数ヶ月ごとに更新し、価格を引き下げる傾向がある
+
+### 実装上の教訓
+
+「モデル ID をハードコードしない」が最も重要な設計原則。
+
+```python
+# 悪い例（ハードコード）
+client.messages.create(model="claude-sonnet-4-20250514", ...)
+
+# 良い例（設定で外部化）
+model_id = os.environ.get("CLAUDE_MODEL", "claude-sonnet-4-6")
+client.messages.create(model=model_id, ...)
+```
+
+退役スケジュールの確認先: `platform.claude.com/docs/en/about-claude/model-deprecations`
+
+### 教材での使い方
+
+- 「APIを使ったプロダクト開発」の単元で、運用フェーズの注意点として紹介できる
+- 「コスト管理」の観点から、モデル更新に追随することのメリット（Opus 4.8 への移行で 67% コスト削減）を実例として使える
+- Anthropic のモデル命名規則（世代 + バリアント + 日付）の解説にも活用できる

--- a/src/content/ai-news/claude/claude-sonnet4-opus4-retire-2026-06-15.mdx
+++ b/src/content/ai-news/claude/claude-sonnet4-opus4-retire-2026-06-15.mdx
@@ -1,0 +1,60 @@
+---
+title: "Claude Sonnet 4・Opus 4 が明日 2026-06-15 に退役 — Sonnet 4.6・Opus 4.8 への移行が必須"
+tool: "claude"
+toolLabel: "Claude"
+date: 2026-06-14
+sourceUrl: "https://platform.claude.com/docs/en/docs/about-claude/models/overview"
+summary: "Claude Sonnet 4（claude-sonnet-4-20250514）と Claude Opus 4（claude-opus-4-20250514）が 2026年6月15日に Claude API から退役する。退役後はこれらのモデル ID へのリクエストがエラーを返すようになる。移行先はそれぞれ Claude Sonnet 4.6（claude-sonnet-4-6）と Claude Opus 4.8（claude-opus-4-8）。Opus 4.8 は Opus 4 と比べて大幅な価格改善（$15/$75 → $5/$25 per MTok）を伴う。"
+impact: "Claude API で Sonnet 4 または Opus 4 のモデル ID を固定指定している実装は、本日中（2026-06-14）に Sonnet 4.6 または Opus 4.8 へ切り替えておく必要がある。退役後は当該 ID へのリクエストがエラーを返すため、対応が遅れると本番障害に直結する。"
+tags: ["claude", "anthropic", "model-deprecation", "claude-api", "policy", "sonnet-4", "opus-4"]
+status: "candidate"
+relatedKnowledge: []
+draft: false
+---
+
+## 要約
+
+Claude Sonnet 4（`claude-sonnet-4-20250514`）と Claude Opus 4（`claude-opus-4-20250514`）の退役が**明日 2026年6月15日**に迫っている。Anthropic の公式モデル一覧ページに退役警告が掲示されており、退役後は上記モデル ID へのリクエストがエラーを返すようになる。
+
+移行先は以下の通り。
+
+- Sonnet 4 → **Claude Sonnet 4.6**（`claude-sonnet-4-6`）: 同価格（$3 / $15 per MTok）、コンテキスト窓は 200k → 1M トークンに拡大
+- Opus 4 → **Claude Opus 4.8**（`claude-opus-4-8`）: 価格が $15 / $75 → $5 / $25 per MTok と大幅に値下がり、コンテキスト窓は 200k → 1M トークンに拡大
+
+Claude のアプリ（claude.ai）をブラウザや iOS などから使っているエンドユーザーへの直接的な影響はない。影響を受けるのは API 経由でモデル ID を固定指定している開発者・企業。
+
+なお、Claude Opus 4.1（`claude-opus-4-1-20250805`）は別途 2026年8月5日に退役予定。
+
+## 何が変わったか
+
+- `claude-sonnet-4-20250514` および `claude-ops-4-20250514` が **2026-06-15 に Claude API から退役**
+- 退役後: 上記 ID へのリクエストはエラーを返す
+- Bedrock / Vertex AI / Microsoft Foundry 上のエイリアス（`claude-sonnet-4-0`、`claude-opus-4-0`）も同様
+- 後継モデルの価格と性能：
+
+| モデル | 移行前（退役） | 移行後（推奨）| 価格変化 |
+|-------|--------------|------------|--------|
+| Sonnet 4 → Sonnet 4.6 | $3 / $15 per MTok | $3 / $15 per MTok | 変化なし |
+| Opus 4 → Opus 4.8 | $15 / $75 per MTok | $5 / $25 per MTok | 約 67% 値下がり |
+
+## 業務インパクト（一般企業向け）
+
+**自社サービスや社内ツールで Claude API を使っている場合は本日中に確認が必要**。
+
+確認すべきポイントは次の 3 点。
+
+1. **コード内のモデル ID**: `claude-sonnet-4-20250514`・`claude-opus-4-20250514`・`claude-sonnet-4-0`・`claude-opus-4-0` を grep してハードコードされている箇所を洗い出す
+2. **Bedrock / Vertex AI の設定**: クラウドプロバイダー側のモデル指定も確認する
+3. **ベンダー管理のツール**: SaaS や社内ツールが Claude を内部利用している場合は、ベンダー側の対応状況を確認する
+
+Opus 4 → Opus 4.8 への移行は価格が大幅に下がるため、コスト面でのメリットが大きい。ただし出力傾向や挙動が変わる可能性があるため、本番適用前に主要ユースケースで差分検証を実施しておくのが安全。
+
+退役後に障害が発生すると、API リクエストが即座にエラーを返すため、ユーザー向けサービスの場合は稼働停止につながる。
+
+## 副業・個人活用視点
+
+個人開発や受託案件で Claude API を組み込んでいる場合、今すぐモデル ID を確認しておきたい。
+
+- **受託案件**: 納品済みの成果物やクライアント向けシステムで Sonnet 4 / Opus 4 を固定指定していると、明日から動かなくなる。今日中に Sonnet 4.6 / Opus 4.8 へ差し替えて動作確認しておく。
+- **個人プロダクト**: `.env` やコード内のモデル ID を確認。特に Opus 4 → Opus 4.8 は価格が 2/3 下がるため、移行後のコスト削減効果も大きい。
+- **今後の備え**: モデル ID を設定ファイルや環境変数で外部化しておくと、今後の退役にも素早く対応できる。退役スケジュールは Anthropic の [モデル退役ページ](https://platform.claude.com/docs/en/about-claude/model-deprecations) で定期確認する習慣を持つと安心。


### PR DESCRIPTION
## Summary

- 窓: 2026-06-13T11:04:44+09:00 → 2026-06-14T11:46:51+09:00
- 更新あり: 0件（窓内新規アップデートなし）
- 公開記事化: 1件（Claude Sonnet 4・Opus 4 退役直前アラート）
- 見送り: OpenAI Codex alpha.18/alpha.19（stable なし）
- 取得失敗継続: OpenAI help.openai.com / openai.com/news（403）、xAI x.ai/news（403）

### 退役予告フォロー（最重要）

Claude Sonnet 4（`claude-sonnet-4-20250514`）と Claude Opus 4（`claude-opus-4-20250514`）が **2026-06-15（明日）に Claude API から退役**。公式モデル一覧ページで確認済み。Anthropic は Sonnet 4.6 / Opus 4.8 への移行を推奨。特に Opus 4 → Opus 4.8 は価格が約 67% 値下がり（$15/$75 → $5/$25 per MTok）。

## 成果物

| 種別 | ファイル |
|------|---------|
| 日次サマリー | `docs/research/daily-ai-updates/2026-06-14.md` |
| 詳細メモ | `docs/research/zenn-claude-release-basic/official-updates/2026-06-14T000000-claude-sonnet4-opus4-retire-2026-06-15.md` |
| AIニュース記事 | `src/content/ai-news/claude/claude-sonnet4-opus4-retire-2026-06-15.mdx` |
| 教材化メモ | `src/content/ai-news-notes/claude/claude-sonnet4-opus4-retire-2026-06-15.mdx` |

## Test plan

- [x] `npm run check` — 0 errors
- [x] 日次サマリーから詳細メモ・公開記事・教材化メモへのリンクが解決
- [x] frontmatter（aiNews / aiNewsNotes スキーマ）に合致
- [x] `daily-ai-update-monitor` と `ai-news-publisher` の SKILL 規約に準拠

🤖 Generated with [Claude Code](https://claude.com/claude-code)