### PR TITLE
feat: 2026-06-15 AIニュース日次チェック（直近24h・更新なし）

### DIFF
--- a/docs/research/daily-ai-updates/2026-06-15.md
+++ b/docs/research/daily-ai-updates/2026-06-15.md
@@ -1,0 +1,86 @@
+---
+date: 2026-06-15
+title: "AI公式アップデート日次チェック 2026-06-15"
+fetched_at: 2026-06-15T09:42:14+09:00
+window_start: 2026-06-14T11:46:51+09:00
+window_end: 2026-06-15T09:42:14+09:00
+---
+
+# AI公式アップデート日次チェック 2026-06-15
+
+## サマリー
+
+- 対象期間: 2026-06-14T11:46:51+09:00 → 2026-06-15T09:42:14+09:00
+- 更新あり: 0件（窓内新規アップデートなし）
+- 更新なし: Claude Code / GitHub Copilot / n8n / OpenAI Codex（stable なし）/ Claude / Gemini / Cursor / ChatGPT/OpenAI（403 継続）/ Dify / xAI / Meta AI / Runway / Genspark / ByteDance Seed / Manus / Pika
+- 取得失敗・保留: OpenAI `help.openai.com` / `openai.com/news`（403）、xAI `x.ai/news`（403）、Pika ブログ（一覧ページに記事情報なし）
+
+## 更新あり
+
+窓内の新規公式アップデートなし。
+
+## 退役フォロー（本日実施）
+
+| service | retire_date | title | category | detail |
+| --- | --- | --- | --- | --- |
+| Claude / Anthropic | 2026-06-15 | Claude Sonnet 4・Opus 4 — **本日**退役実施（June 15, 2026 9AM PT、Claude API から削除済み） | policy | ../zenn-claude-release-basic/official-updates/2026-06-14T000000-claude-sonnet4-opus4-retire-2026-06-15.md |
+
+## 速報記事化済み（前日掲載分）
+
+| service | title | 記事 | 教材化メモ |
+| --- | --- | --- | --- |
+| Claude / Anthropic | Claude Sonnet 4・Opus 4 が 2026-06-15 に退役 — Sonnet 4.6・Opus 4.8 への移行が必須（前日掲載済み） | src/content/ai-news/claude/claude-sonnet4-opus4-retire-2026-06-15.mdx | src/content/ai-news-notes/claude/claude-sonnet4-opus4-retire-2026-06-15.mdx |
+
+## 見送り
+
+- OpenAI Codex rust-v0.140.0-alpha.19（2026-06-14T02:03:02Z）: 窓外（窓開始 11:46:51+09:00 より 43 分前）かつ alpha。件数記録のみ。
+
+## 更新なし
+
+- Claude Code: CHANGELOG.md 最新 v2.1.177（2026-06-13T01:25Z）。窓内新規リリースなし。GitHub Releases API で確認。
+- GitHub Copilot: changelog 最新 2026-06-12（code review: New configurations and controls）。窓内更新なし。
+- n8n: 最新 n8n@2.26.3（2026-06-11T14:56Z）。窓内更新なし。GitHub Releases API で確認。
+- OpenAI Codex: stable なし（alpha.19 のみ、窓外）。
+- Claude: 公式 Release Notes 最新 2026-06-12（Fable 5/Mythos 5 一時停止）。窓内新規なし。
+- Gemini: Google Gemini Blog 最新 2026年5月末〜6月上旬。Workspace Updates 最新 2026-06-12 週次Recap（窓外）。Gemini API Changelog 最新 2026-06-01。
+- Cursor: changelog 最新 2026-06-10（Bugbot 改善）。窓内更新なし。
+- Dify: GitHub Releases 最新 v1.14.2（2026-05-19）。窓内更新なし。
+- Meta AI: 公式ブログ最新 2026-04-08（Muse Spark）。窓内更新なし。
+- Runway: changelog 最新 2026-05-21（Aleph 2.0 & Edit Studio）。窓内更新なし。
+- Genspark: 最新 2026-05-17。窓内更新なし。
+- ByteDance Seed: 最新 2026-04-23（Seed3D 2.0）。窓内更新なし。
+- Manus: ブログ最新 2026-06-12（Canva Connector）。窓内更新なし。
+- claude.com/blog: 最新 2026-06-10（Building with Claude Managed Agents）。窓内新規なし。
+- xAI Grok Release Notes: 最新 2026-06-11（Grok Build Plugin Marketplace）。窓内更新なし（公式 `x.ai/news` は 403 継続）。
+
+## 取得失敗・保留
+
+- OpenAI `help.openai.com`（ChatGPT Release Notes）/ `openai.com/news`：403 継続（前回同様）。OpenAI Developers Changelog（最新 2026-06-09）は取得可能。
+- xAI `x.ai/news`：403 継続。`docs.x.ai/developers/release-notes` で最新 2026-06-11 確認済み。
+- Pika: `pika.art/blog` は一覧ページに記事情報なし。保留継続。
+
+## 補足メモ
+
+- **【退役当日】** Claude Sonnet 4（`claude-sonnet-4-20250514`）と Claude Opus 4（`claude-opus-4-20250514`）が本日 2026-06-15 9AM PT に Claude API から正式退役。未移行の本番 API 利用者は本日よりリクエストエラーが発生する。速報記事は前日（2026-06-14）に掲載済み（`claude-sonnet4-opus4-retire-2026-06-15.mdx`）。
+- **【次の退役予告フォロー】** Claude Opus 4.1（`claude-opus-4-1-20250805`）は 2026-08-05 退役予定（移行先: `claude-opus-4-8`）。claude-mythos-preview は 2026-06-30 退役予定（移行先: `claude-mythos-5`）。
+- **【xAI 動向】** V9-Medium（1.5兆パラメーター）が6月中旬リリース予定との報道あり（TechTimes 2026-05-28、公式未確認）。公式リリース次第、次回窓で記録。
+- ユーザー認識ギャップ該当なし。
+
+## チェック対象
+
+- ChatGPT / OpenAI: https://help.openai.com/en/articles/6825453-chatgpt-release-notes（403）, https://openai.com/news/（403）, https://developers.openai.com/changelog
+- OpenAI Codex: https://github.com/openai/codex/releases
+- Gemini: https://blog.google/products-and-platforms/products/gemini/, https://workspaceupdates.googleblog.com/
+- Claude: https://support.claude.com/en/articles/12138966-release-notes, https://www.anthropic.com/news, https://claude.com/blog, https://platform.claude.com/docs/en/about-claude/model-deprecations
+- Claude Code: https://github.com/anthropics/claude-code/releases, https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md
+- Cursor: https://cursor.com/changelog
+- GitHub Copilot: https://github.blog/changelog/label/copilot/, https://github.blog/changelog/month/06-2026/
+- n8n: https://github.com/n8n-io/n8n/releases
+- Dify: https://github.com/langgenius/dify/releases
+- Genspark: https://www.genspark.ai/blog
+- Manus: https://manus.im/blog
+- Meta AI: https://ai.meta.com/blog/
+- Runway: https://runwayml.com/changelog, https://runwayml.com/news
+- xAI / Grok: https://docs.x.ai/developers/release-notes（x.ai/news は 403）
+- ByteDance Seed: https://seed.bytedance.com/en/blog/
+- Pika: https://pika.art/blog（一覧ページ内容なし）


### PR DESCRIPTION
## Summary

- 窓: 2026-06-14T11:46:51+09:00 → 2026-06-15T09:42:14+09:00
- 更新あり: 0件（窓内新規公式アップデートなし）
- 公開記事化: なし（前日掲載の Claude Sonnet 4・Opus 4 退役記事で対応済み）
- 見送り: OpenAI Codex alpha.19（窓外・alpha のため）
- 取得失敗: OpenAI help.openai.com / openai.com/news（403 継続）、xAI x.ai/news（403 継続）、Pika blog（一覧ページ内容なし）

### 退役フォロー（本日実施）

Claude Sonnet 4（`claude-sonnet-4-20250514`）・Opus 4（`claude-opus-4-20250514`）が本日 2026-06-15 9AM PT に正式退役。速報記事は前日（2026-06-14）掲載済み。

### 次の注意点

- Claude Opus 4.1（`claude-opus-4-1-20250805`）: 2026-08-05 退役予定
- claude-mythos-preview: 2026-06-30 退役予定（移行先: `claude-mythos-5`）
- xAI V9-Medium の公式リリース動向を次回以降フォロー

## Test plan

- [x] `npm run check` — 0 errors
- [x] 日次サマリーから詳細メモ・速報記事へのリンクが解決（前日記事）
- [x] frontmatter（日次サマリースキーマ）に合致
- [x] `daily-ai-update-monitor` SKILL 規約に準拠（-f オプションで強制 add）

🤖 Generated with [Claude Code](https://claude.com/claude-code)