### PR TITLE
feat: 2026-07-11 AIニュース日次チェック（速報1件）

### DIFF
--- a/docs/research/daily-ai-updates/2026-07-11.md
+++ b/docs/research/daily-ai-updates/2026-07-11.md
@@ -1,0 +1,86 @@
+---
+date: 2026-07-11
+title: "AI公式アップデート日次チェック 2026-07-11"
+fetched_at: 2026-07-11T16:11:30+09:00
+window_start: 2026-07-10T10:12:00+09:00
+window_end: 2026-07-11T16:11:30+09:00
+---
+
+# AI公式アップデート日次チェック 2026-07-11
+
+## サマリー
+
+- 対象期間: 2026-07-10 10:12 JST 〜 2026-07-11 16:11 JST
+- 更新あり: 2件（Claude Code 1 / n8n 1組=2リリース）
+- 更新なし: 12サービス（ChatGPT/OpenAI、Claude、Gemini、Workspace Updates、GitHub Copilot、Genspark、Manus、Dify、Meta AI、Runway、xAI/Grok、ByteDance Seed、Pika）
+- 保留（公式未確認）: 0件
+- 取得失敗: 0件（openai.com/help.openai.comは既知の403制約、WebSearch代替で確認済み）
+- Codex alpha: 2件（summary言及のみ、詳細化対象外）
+
+前回チェック（2026-07-10、window_end 2026-07-10T10:12 JST）は同日中に大型発表（GPT-5.6 GA、ChatGPT Work、Claude Reflect等）が集中する日だったのに対し、本窓（2026-07-10 10:12〜2026-07-11 16:11 JST、約30時間）は全体的に静かで、Claude Code v2.1.207の機能変更と、n8nの軽微なバグ修正のみが該当した。
+
+## 更新あり
+
+| service | published_at | title | category | detail |
+| --- | --- | --- | --- | --- |
+| Claude Code | 2026-07-11T00:52:10Z | v2.1.207：Auto modeがBedrock/Vertex/Foundryでopt-in不要に、Opus 4.8がデフォルトへ | enhancement | ../zenn-claude-code-release-basic/official-updates/2026-07-11T005210-claude-code-v2-1-207.md |
+| n8n | 2026-07-10T07:57:16Z | n8n 2.29.10（stable）: エディタ切り替え時のAI Assistantスレッド状態保持を修正 | enhancement | ../zenn-n8n-basic/official-updates/2026-07-10T075716-n8n-2-29-10.md |
+| n8n | 2026-07-10T07:59:16Z | n8n 2.30.3（pre-release）: 2.29.10と同一のAI Assistantスレッド状態保持修正 | enhancement | ../zenn-n8n-basic/official-updates/2026-07-10T075916-n8n-2-30-3.md |
+
+n8nの`beta`ローリングタグ（2026-07-10T07:59:17Z）は`n8n@2.30.3`と本文が同一のため上表には含めていない（二重計上防止）。`stable`ローリングタグ（07:57:17Z）も`n8n@2.29.10`と同一のため同様に除外。
+
+Claude Code v2.1.207のリリース本文には、shell-injection対策（Plugin hooks/monitors/MCP headersHelperでの`${user_config.*}`直接展開拒否）というbreaking changeも含まれる。Plugin開発者への影響がある点は詳細ファイル参照。
+
+なお、前回2026-07-10レポートで「GitHub Releasesページ未作成のためCHANGELOG.md日付（2026-07-09T17:54:03Z）で記録した」と注記していたClaude Code v2.1.206は、本チェックでGitHub Release自体の`published_at`が2026-07-10T01:45:26Z（JST 10:45、本窓のwindow_start直後）であることを確認した。内容は前回記録済みのものと同一のため、本窓では新規項目として扱わず、追加の詳細ファイルも作成していない。
+
+## Codex alpha（件数のみ）
+
+- OpenAI Codex CLI: `rust-v0.145.0-alpha.3`（2026-07-10T23:11:40Z）、`rust-v0.145.0-alpha.4`（2026-07-11T00:10:19Z）の2件。GitHub Release本文（変更点テキスト）は取得不可（自動生成バイナリ配布のみ）。stableではないため詳細化対象外。
+
+## 速報記事化済み
+
+| 記事ファイル | 対象更新 | 教材化メモ |
+| --- | --- | --- |
+| `src/content/ai-news/claude-code/claude-code-v2-1-207.mdx` | Claude Code v2.1.207（Auto mode opt-in撤廃・Opus 4.8デフォルト化・Plugin shell injection対策） | `src/content/ai-news-notes/claude-code/claude-code-v2-1-207.mdx` |
+
+## 見送り
+
+- n8n 2.29.10（stable）/ 2.30.3（pre-release）: エディタ切り替え時のAI Assistantスレッド状態保持を修正するUIバグ修正のみで、教材読者への学習価値薄（selection-rubric D判定）。research詳細のみに留める。
+
+## 更新なし
+
+- ChatGPT/OpenAI: help.openai.com ChatGPT Release Notes、openai.com/news各カテゴリ（Company/Research/Product/Safety/Engineering/Security/Global Affairs/AI Adoption）、日本語トップ、academy/stories/business/solutionsいずれも対象期間内の新規エントリを特定できず。OpenAI Status も2026-07-10〜11にインシデントなし（"We're not aware of any issues affecting our systems"）。前回窓（2026-07-09）の大型発表デー（GPT-5.6 GA等）の翌日にあたり、静かな窓だった。
+- Claude: support.claude.com Release Notesの最新日付見出しは2026-07-09（Reflect/Time and focus）のまま、対象期間内の新規日付なし。anthropic.com/newsも同様に2026-07-09が最新。claude.com/blogに2026-07-10付で"Working at the frontier: How Cognition trusts Claude Fable 5 to work through the night"（顧客事例、Frontier Codeベンチマークで旧Opusの約10%からFable 5が約30%に向上という言及あり）が公開されているが、新製品・新機能の発表ではなく顧客インタビュー記事のため対象外とした。AWS What's New / Machine Learning Blogでも対象期間内のClaude Platform/Bedrock関連新規発表なし（直近のClaude Platform on AWS GAは2026-05のまま）。
+- Gemini（本体）: blog.google/products-and-platforms/products/gemini/ に対象期間内の新規投稿なし。直近は6月の"latest AI news"月次まとめ止まり。
+- Workspace Updates: 2026-07-10付で週次Recapが公開されたが、内容は"Pexip経由のMeetハードウェアSIP接続"「NeatハードウェアのOccupancy counting」（いずれもロールアウト開始2026-07-06、二次情報の公開日表記は2026-07-07）「Fill with Gemini in Sheets多言語拡大」（公開2026-07-07）「カレンダー共有権限」（公開2026-07-07）「Slidesの動画変換多言語対応」（公開2026-07-08）「受信SCIM GA」（公開2026-07-09、前回チェックで既報）の再掲であり、いずれも本窓のwindow_start（2026-07-10 10:12 JST）より前の公開日のため新規項目なし。
+- GitHub Copilot: github.blog/changelog/label/copilot/ に対象期間内の新規エントリなし。直近は2026-07-09（GPT-5.6 Sol/Terra/Luna、Ask Copilot for a repository overview、いずれも前回チェック済み）。
+- Genspark: 公式Blogに対象期間内の新規投稿なし。直近投稿は2026-07-06。
+- Manus: 公式Blogに対象期間内の新規投稿なし。直近投稿は2026-07-09（Branch、前回チェック済み）。
+- Dify: GitHub Releases・公式Blogいずれも対象期間内の新規エントリなし。直近リリースは1.16.0-rc1（2026-07-09、前回チェック済み）、直近Blogは"Dify's Official CLI: difyctl Ships"（2026-07-09）。
+- Meta AI: ai.meta.com/blogに対象期間内の新規投稿なし。直近は2026-07-09（Muse Spark 1.1、前回チェック済み）。
+- Runway: changelog・news・Runway Dev API changelogいずれも対象期間内の新規エントリなし。直近はRunway Dev発表（2026-07-08）とSeedream 5.0 Pro API対応（2026-07-08）。
+- xAI/Grok: release notes・newsいずれも対象期間内の新規エントリなし。直近はGrok 4.5関連（2026-07-08）。
+- ByteDance Seed: 公式Blogに対象期間内の新規投稿なし。直近はSeedream 5.0 Pro（2026-07-08）。
+- Pika: 公式Blog・トップページいずれも対象期間内の新規更新を確認できず。
+
+## 補足メモ
+
+該当するユーザー認識ギャップの新規発生なし（`references/perception-gaps.md`参照、既存エントリからの転記対象もなし）。
+
+## チェック対象
+
+- ChatGPT / OpenAI: https://help.openai.com/en/articles/6825453-chatgpt-release-notes
+- OpenAI Codex: https://github.com/openai/codex/releases
+- Gemini: https://blog.google/products-and-platforms/products/gemini/
+- Claude: https://support.claude.com/en/articles/12138966-release-notes
+- Claude Code: https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md
+- GitHub Copilot: https://github.blog/changelog/label/copilot/
+- Genspark: https://www.genspark.ai/blog
+- Manus: https://manus.im/blog
+- Dify: https://github.com/langgenius/dify/releases
+- n8n: https://github.com/n8n-io/n8n/releases
+- Meta AI: https://ai.meta.com/blog/
+- Runway: https://runwayml.com/changelog
+- xAI / Grok: https://docs.x.ai/docs/release-notes
+- ByteDance Seed: https://seed.bytedance.com/en/blog/
+- Pika: https://pika.art/blog

--- a/docs/research/zenn-claude-code-release-basic/official-updates/2026-07-11T005210-claude-code-v2-1-207.md
+++ b/docs/research/zenn-claude-code-release-basic/official-updates/2026-07-11T005210-claude-code-v2-1-207.md
@@ -1,0 +1,44 @@
+---
+date: 2026-07-11
+title: "Claude Code v2.1.207 — Auto mode がBedrock/Vertex/Foundryでopt-in不要に、Opus 4.8がデフォルトへ"
+service: "Claude Code"
+source: https://github.com/anthropics/claude-code/releases/tag/v2.1.207
+fetched_at: 2026-07-11T16:11:30+09:00
+published_at: 2026-07-11T00:52:10Z
+date_precision: timestamp
+category: enhancement
+---
+
+# 2026-07-11 Claude Code v2.1.207
+
+## 公式内容の日本語要約
+
+Auto modeがBedrock・Vertex AI・Foundry上で`CLAUDE_CODE_ENABLE_AUTO_MODE`のopt-inなしに利用可能になった（無効化する場合は設定の`disableAutoMode`を使用）。あわせてBedrock・Vertex・Claude Platform on AWSのデフォルトモデルがClaude Opus 4.8に変更された。auto modeの設定読み込み元がリポジトリ内`.claude/settings.local.json`から`~/.claude/settings.json`（ユーザー単位）に変更されている。
+
+セキュリティ関連では、Plugin hooks/monitors/MCP headersHelperのシェル形式コマンド内で`${user_config.*}`を使うことが拒否されるようになった（シェルインジェクション対策）。hooksはexec形式（`args`配列）または`$CLAUDE_PLUGIN_OPTION_<KEY>`を使う必要がある。またPlugin option値（`pluginConfigs`）はプロジェクトレベルの`.claude/settings.json`から読み込まれなくなり、ユーザー設定・`--settings`・管理設定のみが有効になった。
+
+他、長い応答ストリーミング時のターミナルフリーズ・キー入力遅延の修正、非対話実行（`claude -p`、SDK）時にセキュリティ同意ダイアログを表示せず同意済みとして記録されてしまう不具合の修正、無害なシステム生成メッセージへの誤ったプロンプトインジェクション警告の修正、自動アップデータが`~/.local/bin/claude`のカスタムランチャー/シンボリックリンクを毎リリース上書きしてしまう不具合の修正（`/doctor`が外部管理ランチャーを報告するように）、Deep researchのFetchフェーズエージェントが全て「unknown」表示になる不具合の修正、Bedrockが毎APIリクエストでAWS SSO認証情報を再取得してしまう不具合の修正など多数のバグ修正が含まれる。
+
+## できるようになったこと
+
+- Bedrock/Vertex AI/Foundry上でAuto modeがopt-inなしで利用可能に（`disableAutoMode`で無効化可）
+- Bedrock/Vertex/Claude Platform on AWSのデフォルトモデルがClaude Opus 4.8に変更
+- Plugin hooks等でのシェルインジェクション対策強化（`${user_config.*}`直接展開を拒否）
+- 自動アップデータのカスタムランチャー上書き問題を修正、`/doctor`が外部管理ランチャーを検知
+
+## 影響範囲
+
+- 対象ユーザー: Bedrock/Vertex AI/Microsoft Foundry経由でClaude Codeを利用する全ユーザー、Pluginを利用する開発者
+- 対象プラン: 制限なし（クラウド連携利用者はモデルデフォルト変更の影響を受ける）
+- API / UI / 管理者機能: Auto mode設定、Pluginのhooks/monitors/MCP headersHelper、`/usage-credits`
+
+## 教材化メモ
+
+- Auto modeのopt-in撤廃とOpus 4.8デフォルト化は、Bedrock/Vertex/Foundry経由の企業導入ユーザーへの影響が大きい。特にコスト影響（Opus 4.8がデフォルトになることでの利用料変化）は教材で注意喚起する価値がある。
+- Pluginのシェルインジェクション対策は、サードパーティPlugin開発者向けの互換性破壊変更（breaking change）である点に注意。
+
+## 原文確認
+
+- 公式見出し: "v2.1.207"
+- 公式URL: https://github.com/anthropics/claude-code/releases/tag/v2.1.207
+- 原文全文は公式ページで確認してください。

--- a/docs/research/zenn-n8n-basic/official-updates/2026-07-10T075716-n8n-2-29-10.md
+++ b/docs/research/zenn-n8n-basic/official-updates/2026-07-10T075716-n8n-2-29-10.md
@@ -1,0 +1,40 @@
+---
+date: 2026-07-10
+title: "n8n 2.29.10（stable）— エディタ切り替え時のAI Assistantスレッド状態保持を修正"
+service: "n8n"
+source: https://github.com/n8n-io/n8n/releases/tag/n8n%402.29.10
+fetched_at: 2026-07-11T16:11:30+09:00
+published_at: 2026-07-10T07:57:16Z
+release_date: 2026-07-10
+version: "2.29.10"
+channel: stable
+official_url: https://github.com/n8n-io/n8n/releases/tag/n8n%402.29.10
+date_precision: timestamp
+category: enhancement
+---
+
+# 2026-07-10 n8n 2.29.10（stable）
+
+## 公式内容の日本語要約
+
+エディタのAI Assistantスレッド状態が、エディタ切り替え（hand-off）時に失われる不具合を修正（#33925）。同一の修正がpre-release系列の n8n@2.30.3 にも反映されている。
+
+## できるようになったこと
+
+- エディタを切り替えてもAI Assistantのスレッド状態（会話コンテキスト）が維持されるようになった
+
+## 影響範囲
+
+- 対象ユーザー: n8nエディタでAI Assistantを利用する全ユーザー
+- 対象プラン: stable系列（2.29.x）
+- API / UI / 管理者機能: エディタUI、AI Assistant
+
+## 教材化メモ
+
+- バグ修正のみで教材読者への学習価値は薄い。research詳細のみに留める。
+
+## 原文確認
+
+- 公式見出し: "n8n@2.29.10"
+- 公式URL: https://github.com/n8n-io/n8n/releases/tag/n8n%402.29.10
+- 原文全文は公式ページで確認してください。

--- a/docs/research/zenn-n8n-basic/official-updates/2026-07-10T075916-n8n-2-30-3.md
+++ b/docs/research/zenn-n8n-basic/official-updates/2026-07-10T075916-n8n-2-30-3.md
@@ -1,0 +1,40 @@
+---
+date: 2026-07-10
+title: "n8n 2.30.3（pre-release）— エディタ切り替え時のAI Assistantスレッド状態保持を修正"
+service: "n8n"
+source: https://github.com/n8n-io/n8n/releases/tag/n8n%402.30.3
+fetched_at: 2026-07-11T16:11:30+09:00
+published_at: 2026-07-10T07:59:16Z
+release_date: 2026-07-10
+version: "2.30.3"
+channel: pre-release
+official_url: https://github.com/n8n-io/n8n/releases/tag/n8n%402.30.3
+date_precision: timestamp
+category: enhancement
+---
+
+# 2026-07-10 n8n 2.30.3（pre-release）
+
+## 公式内容の日本語要約
+
+エディタのAI Assistantスレッド状態が、エディタ切り替え（hand-off）時に失われる不具合を修正（#33924）。n8n@2.29.10（stable）と同一の修正で、2.30系pre-releaseへの反映。なお`beta`ローリングタグも同一コミットで同時更新されているが、本ファイルに統合し二重計上しない。
+
+## できるようになったこと
+
+- エディタを切り替えてもAI Assistantのスレッド状態（会話コンテキスト）が維持されるようになった
+
+## 影響範囲
+
+- 対象ユーザー: n8nエディタでAI Assistantを利用する全ユーザー（pre-release系列利用者）
+- 対象プラン: pre-release系列（2.30.x）
+- API / UI / 管理者機能: エディタUI、AI Assistant
+
+## 教材化メモ
+
+- バグ修正のみで教材読者への学習価値は薄い。research詳細のみに留める。
+
+## 原文確認
+
+- 公式見出し: "n8n@2.30.3"
+- 公式URL: https://github.com/n8n-io/n8n/releases/tag/n8n%402.30.3
+- 原文全文は公式ページで確認してください。

--- a/src/content/ai-news-notes/claude-code/claude-code-v2-1-207.mdx
+++ b/src/content/ai-news-notes/claude-code/claude-code-v2-1-207.mdx
@@ -1,0 +1,17 @@
+---
+noteFor: "claude-code/claude-code-v2-1-207"
+title: "教材化メモ：Claude Code v2.1.207"
+tool: "claude-code"
+date: 2026-07-11
+draft: false
+---
+
+## 教材化ポイント
+
+### 1. Auto Mode解説教材への追記候補
+
+`src/content/knowledge/ai-tools/claude-code/auto-mode.mdx`は現状Maxプラン向けの説明が中心。Bedrock/Vertex/Foundry経由のopt-in撤廃・Opus 4.8デフォルト化はクラウド連携固有の変更で、既存記事の前提を誤りにするものではないため、今回はKnowledge最小反映を見送り。クラウド連携版のAuto mode運用について独立した教材が必要になった場合に、この更新を起点として追記する。
+
+### 2. Pluginセキュリティ教材の素材
+
+Plugin hooks/monitors/MCP headersHelperのシェルインジェクション対策（`${user_config.*}`直接展開拒否）は、Plugin開発のベストプラクティス教材（exec形式推奨、`$CLAUDE_PLUGIN_OPTION_<KEY>`の使い方）の素材になる。既存のPlugin/hooks系教材があれば、破壊的変更の注意書きとして追記候補。

--- a/src/content/ai-news/claude-code/claude-code-v2-1-207.mdx
+++ b/src/content/ai-news/claude-code/claude-code-v2-1-207.mdx
@@ -1,0 +1,44 @@
+---
+title: "Claude Code v2.1.207：Auto modeがBedrock/Vertex/Foundryでopt-in不要に、Opus 4.8がデフォルトへ"
+tool: "claude-code"
+toolLabel: "Claude Code"
+date: 2026-07-11
+sourceUrl: "https://github.com/anthropics/claude-code/releases/tag/v2.1.207"
+summary: "Claude Code v2.1.207で、Auto modeがAmazon Bedrock・Google Vertex AI・Microsoft Foundry上で環境変数によるopt-inなしに利用可能になった。あわせてこれらクラウド連携のデフォルトモデルがClaude Opus 4.8に変更。Plugin hooks等でのシェルインジェクション対策強化という互換性破壊変更も含まれる。"
+description: "Auto modeのopt-in撤廃とOpus 4.8デフォルト化、Plugin hooksのシェルインジェクション対策、多数のバグ修正。"
+impact: "Bedrock/Vertex/Foundry経由でClaude Codeを利用する企業ユーザーと、Pluginを開発するサードパーティ開発者に直接影響する変更。"
+tags: ["claude-code", "auto-mode", "bedrock", "vertex-ai", "security", "release"]
+status: "candidate"
+relatedKnowledge:
+  - "/knowledge/ai-tools/claude-code/auto-mode"
+draft: false
+---
+
+## 要約
+
+Claude Code v2.1.207（2026-07-11公開）は、クラウド連携まわりの挙動変更とセキュリティ強化が中心のリリースです。
+
+**Auto mode**が、Amazon Bedrock・Google Vertex AI・Microsoft Foundry上で`CLAUDE_CODE_ENABLE_AUTO_MODE`によるopt-inなしに利用可能になりました。無効化したい場合は設定の`disableAutoMode`を使います。あわせて、Bedrock・Vertex・Claude Platform on AWSのデフォルトモデルが**Claude Opus 4.8**に変更されました。Auto modeの設定読み込み元も、リポジトリ内`.claude/settings.local.json`からユーザー単位の`~/.claude/settings.json`に変更されています。
+
+セキュリティ面では、Plugin hooks・monitors・MCP headersHelperのシェル形式コマンド内で`${user_config.*}`を直接展開することが拒否されるようになりました。シェルインジェクション対策で、hooksはexec形式（`args`配列）または`$CLAUDE_PLUGIN_OPTION_<KEY>`を使う必要があります。Plugin option値（`pluginConfigs`）もプロジェクトレベルの`.claude/settings.json`からは読み込まれなくなり、ユーザー設定・`--settings`・管理設定のみが有効になりました。
+
+このほか、長い応答ストリーミング時のターミナルフリーズ・キー入力遅延の修正、非対話実行（`claude -p`、SDK）時にセキュリティ同意ダイアログを表示せず同意済みとして記録してしまう不具合の修正、自動アップデータが`~/.local/bin/claude`のカスタムランチャーを毎リリース上書きしてしまう不具合の修正（`/doctor`が外部管理ランチャーを報告するように）など、多数のバグ修正が含まれます。
+
+## 何が変わったか
+
+- **Auto mode**がBedrock/Vertex AI/Foundry上でopt-inなしに利用可能に（`disableAutoMode`で無効化可）
+- Bedrock/Vertex/Claude Platform on AWSの**デフォルトモデルがClaude Opus 4.8**へ変更
+- Auto mode設定の読み込み元がプロジェクト単位からユーザー単位（`~/.claude/settings.json`）に変更
+- **Plugin hooks等でのシェルインジェクション対策強化**（`${user_config.*}`直接展開を拒否、破壊的変更）
+- 自動アップデータのカスタムランチャー上書き問題を修正、`/doctor`が外部管理ランチャーを検知
+- 非対話実行時のセキュリティ同意記録の不具合、ストリーミング時のターミナルフリーズなど多数のバグ修正
+
+## 業務インパクト（一般企業向け）
+
+Bedrock・Vertex AI・Foundry経由でClaude Codeを導入している組織は、これまで明示的なopt-inが必要だったAuto modeが既定で有効になる点に注意が必要です。承認ダイアログの自動化が進む一方、デフォルトモデルがOpus 4.8に切り替わることで**利用料が変化する可能性**があります。予算管理を厳密に行っているチームは、`disableAutoMode`設定とモデル選定を早めに確認しておくとよいでしょう。
+
+Pluginを配布・利用している組織は、シェルインジェクション対策によって既存のhooks/monitors設定が動かなくなる可能性がある**互換性破壊変更**です。`${user_config.*}`をシェル形式コマンドで直接使っている箇所がないか、アップデート前に棚卸しすることを推奨します。
+
+## 副業・個人活用視点
+
+個人でBedrock/Vertex経由のClaude Codeを使っている場合も、Opus 4.8への切り替わりで体感速度や出力の質、コストが変わる可能性があります。Pluginを自作している人は、hooksの実装をexec形式に寄せておくと今後の破壊的変更にも強くなります。


### PR DESCRIPTION
## Summary

- 窓: 2026-07-10T10:12 → 2026-07-11T16:11 (JST)
- 更新あり: 2件（Claude Code v2.1.207 / n8n 2.29.10・2.30.3）
- 公開記事化: 1件（Claude Code v2.1.207 — Auto mode opt-in撤廃・Opus 4.8デフォルト化・Plugin shell injection対策）
- 見送り: n8n 2.29.10/2.30.3（AI Assistantスレッド状態保持のUIバグ修正のみ、学習価値薄のためD判定）
- 取得失敗: なし（openai.com/help.openai.comの既知403制約はWebSearch代替で確認済み）

## Test plan

- [x] `npm run check` — 0 errors
- [x] 日次サマリーから詳細メモ・公開記事・教材化メモへのリンクが解決
- [x] frontmatter（aiNews / aiNewsNotes スキーマ）に合致
- [x] `daily-ai-update-monitor` と `ai-news-publisher` の SKILL 規約に準拠

🤖 Generated with [Claude Code](https://claude.com/claude-code)