### PR TITLE
feat: 2026-07-13 AIニュース日次チェック（更新なし）

### DIFF
--- a/docs/research/daily-ai-updates/2026-07-13.md
+++ b/docs/research/daily-ai-updates/2026-07-13.md
@@ -1,0 +1,97 @@
+---
+date: 2026-07-13
+title: "AI公式アップデート日次チェック 2026-07-13"
+fetched_at: 2026-07-13T09:56:25+09:00
+window_start: 2026-07-11T16:11:30+09:00
+window_end: 2026-07-13T09:56:25+09:00
+---
+
+# AI公式アップデート日次チェック 2026-07-13
+
+## サマリー
+
+- 対象期間: 2026-07-11 16:11 JST 〜 2026-07-13 09:56 JST（約42時間）
+- 更新あり: 0件
+- 更新なし: 15サービス（ChatGPT/OpenAI、OpenAI Codex、Gemini、Claude、Claude Code、GitHub Copilot、Genspark、Manus、Dify、n8n、Meta AI、Runway、xAI/Grok、ByteDance Seed、Pika）
+- 保留（公式未確認）: 0件
+- 取得失敗: 0件（openai.com/help.openai.com/x.ai系は既知の403制約、WebSearch・GitHub API代替で確認済み）
+- Codex alpha: 0件（前回チェック時点の最新 `rust-v0.145.0-alpha.4` は2026-07-11T00:10:19Zで窓開始前）
+
+前回チェック（2026-07-11、window_end 2026-07-11T16:11 JST、Claude Code v2.1.207 / n8n 2.29.10・2.30.3のみ）に続き、本窓（約42時間）は**全15サービスで新規の公式発表・リリースを確認できなかった**。GitHub Releases（Claude Code、OpenAI Codex、Dify、n8n、GitHub Copilot CLI）は`gh api`のpagination込みで確認し、いずれも窓開始前（2026-07-11 07:11:30Z以前）が最新のままだった。
+
+## 更新あり
+
+該当なし。
+
+## Codex alpha（件数のみ）
+
+- 対象期間内の新規alpha/pre-releaseなし。直近は`rust-v0.145.0-alpha.4`（2026-07-11T00:10:19Z、前回チェック済み・窓開始前）。
+
+## 速報記事化済み
+
+該当なし（今回窓に新規更新がないため）。
+
+## 見送り
+
+該当なし。
+
+## 更新なし
+
+- **ChatGPT/OpenAI**: `help.openai.com`のChatGPT Release Notes、`openai.com/news/`各カテゴリ（Company/Research/Product/Safety/Engineering/Security/Global Affairs/AI Adoption）、日本語トップ、`openai.com/academy/`・`stories/`・`business/`・`solutions/`いずれも対象期間内の新規個別ポストなし。直近の個別ポストは`openai.com/business/customer-stories/`の「Australian Payments Plus moves faster with ChatGPT and Codex」（2026-07-10、窓開始前）、OpenAI Academyの「The End of Performance Reviews Written from Memory」（2026-07-08、窓開始前）。OpenAI Status（`status.openai.com`）も対象期間内のincidentなし（"We're not aware of any issues affecting our systems"）。
+- **OpenAI Codex**: GitHub Releases（`gh api repos/openai/codex/releases --paginate`確認、最新stableは`rust-v0.144.1`2026-07-09T23:02:40Z、最新alphaは`rust-v0.145.0-alpha.4`2026-07-11T00:10:19Zでいずれも窓開始前）、Codex changelog（`developers.openai.com/codex/changelog`→リダイレクト先`learn.chatgpt.com/docs/changelog`）ともに対象期間内の新規エントリなし。直近は2026-07-09「Codex joins the ChatGPT desktop app」。
+- **Gemini**: `blog.google/products-and-platforms/products/gemini/`、`ai.google.dev/gemini-api/docs/changelog`（直近2026-07-06、Interactions APIログ機能）、`gemini.google/release-notes/`（直近2026-06-30）いずれも対象期間内の新規エントリなし。
+- **Gemini Enterprise（補助）**: `docs.cloud.google.com/gemini/enterprise/docs/release-notes`の直近エントリは2026-07-09（AlphaEvolve GA、前回チェック済み）で、対象期間内（07-10〜07-13）の新規エントリなし。
+- **Workspace Updates**: 週次Recap（2026-07-10付、内容は前回チェック済みの07-06〜07-09分の再掲）以降、個別ポストの新規投稿なし。
+- **Claude**: `support.claude.com`Release Notesの最新日付見出しは2026-07-09（Reflect）のまま、対象期間内の新規日付なし。`anthropic.com/news`も同様に2026-07-09が最新。`claude.com/blog`は2026-07-10付「Working at the frontier: How Cognition trusts Claude Fable 5 to work through the night」（顧客事例、窓開始前かつ新製品発表ではないため前回チェックと同様に対象外）が最新で、対象期間内の新規ポストなし。AWS What's New / Machine Learning Blogも対象期間内のClaude Platform/Bedrock関連新規発表なし。
+- **Claude Code**: raw CHANGELOG.md・GitHub Releases（`gh api repos/anthropics/claude-code/releases --paginate`確認）とも最新は前回チェック済みの`v2.1.207`（2026-07-11T00:52:10Z、窓開始前）のまま、対象期間内の新規リリースなし。
+- **GitHub Copilot**: `github.blog/changelog/label/copilot/`に対象期間内の新規エントリなし（直近は2026-07-09）。補助確認したGitHub Copilot CLI（`gh api repos/github/copilot-cli/releases`）も最新`v1.0.71-0`（2026-07-10T22:00:20Z）が窓開始前で、対象期間内の新規リリースなし。
+- **Genspark**: 公式Blogに対象期間内の新規投稿なし。直近投稿は2026-07-06。
+- **Manus**: 公式Blogに対象期間内の新規投稿なし。直近投稿は2026-07-09（Branch、既報）。
+- **Dify**: GitHub Releases（`gh api repos/langgenius/dify/releases --paginate`確認、最新`1.16.0-rc1`2026-07-09T14:06:30Z）・公式Blog（直近2026-07-09「Dify's Official CLI: difyctl Ships」）とも対象期間内の新規エントリなし。
+- **n8n**: GitHub Releases（`gh api repos/n8n-io/n8n/releases --paginate`確認）の最新はstable `n8n@2.29.10`・pre-release `n8n@2.30.3`（いずれも2026-07-10、前回チェック済み・窓開始前）のまま、stable/pre-release/backport全チャンネルで対象期間内の新規リリースなし。
+- **Meta AI**: `ai.meta.com/blog/`に対象期間内の新規投稿なし。直近は2026-07-09（Muse Spark 1.1、既報）。
+- **Runway**: `runwayml.com/changelog`・`runwayml.com/news`・Runway Dev API changelog（`docs.dev.runwayml.com/api-details/api_changelog/`）いずれも対象期間内の新規エントリなし。直近はSeedream 5.0 Pro API対応（2026-07-08、既報）。
+- **xAI / Grok**: `docs.x.ai/docs/release-notes`・`x.ai/news`とも対象期間内の新規投稿なし（`x.ai`系は403のためWebSearch中心で確認）。直近はGrok 4.5関連（2026-07-08、既報）。2026-07-11にElon MuskがTesla/SpaceXへのGrok 4.5採用義務化報道を否定するXポストを出したが、x.ai公式Newsのエントリではなく製品リリースでもないため対象外とした。
+- **ByteDance Seed**: 公式Blogに対象期間内の新規投稿なし。直近は2026-07-08（Seedream 5.0 Pro、既報）。
+- **Pika**: 公式Blog・トップページとも対象期間内の新規投稿を確認できず（公式Blog自体が実質更新停止状態、既報の通り）。
+
+## 保留・取得失敗
+
+なし。openai.com本体・help.openai.com・x.ai系はWebFetchで403（既知の制約）だったため、WebSearchのスニペット・引用および複数の一次/二次報道でクロスチェックした。
+
+## チェック対象ソース
+
+- ChatGPT Release Notes: https://help.openai.com/en/articles/6825453-chatgpt-release-notes
+- OpenAI News: https://openai.com/news/ 、https://openai.com/ja-JP/news/ 、各カテゴリページ（Company/Research/Product/Safety/Engineering/Security/Global Affairs/AI Adoption）
+- OpenAI 個別ポスト: https://openai.com/index/<slug>/
+- OpenAI 1階層目セクション: https://openai.com/academy/ 、https://openai.com/stories/ 、https://openai.com/business/ 、https://openai.com/solutions/
+- OpenAI Status: https://status.openai.com/
+- OpenAI Codex GitHub Releases: https://github.com/openai/codex/releases
+- OpenAI Codex changelog: https://developers.openai.com/codex/changelog（→ https://learn.chatgpt.com/docs/changelog ）
+- Gemini Blog: https://blog.google/products-and-platforms/products/gemini/
+- Gemini API Changelog: https://ai.google.dev/gemini-api/docs/changelog
+- Gemini Release Notes: https://gemini.google/release-notes/
+- Gemini Enterprise Release Notes（補助）: https://docs.cloud.google.com/gemini/enterprise/docs/release-notes
+- Workspace Updates Blog: https://workspaceupdates.googleblog.com/
+- Claude Release Notes: https://support.claude.com/en/articles/12138966-release-notes
+- Anthropic News: https://www.anthropic.com/news
+- Claude Blog: https://claude.com/blog
+- Claude Code Changelog: https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md
+- Claude Code GitHub Releases: https://github.com/anthropics/claude-code/releases
+- GitHub Copilot Changelog: https://github.blog/changelog/label/copilot/
+- GitHub Copilot CLI Releases（補助）: https://github.com/github/copilot-cli/releases
+- Dify GitHub Releases: https://github.com/langgenius/dify/releases
+- Dify Blog: https://dify.ai/blog
+- n8n GitHub Releases: https://github.com/n8n-io/n8n/releases
+- Genspark Blog: https://www.genspark.ai/blog
+- Manus Blog: https://manus.im/blog
+- Meta AI Blog: https://ai.meta.com/blog/
+- Runway Changelog: https://runwayml.com/changelog 、Runway News: https://runwayml.com/news 、Runway API Changelog: https://docs.dev.runwayml.com/api-details/api_changelog/
+- xAI Release Notes: https://docs.x.ai/docs/release-notes 、xAI News: https://x.ai/news
+- ByteDance Seed Blog: https://seed.bytedance.com/en/blog/
+- Pika Blog: https://pika.art/blog
+
+## 補足メモ
+
+- 該当するユーザー認識ギャップの新規発生なし（`references/perception-gaps.md`参照、既存エントリからの転記対象もなし）。
+- 本窓（約42時間）は全15サービスで新規更新ゼロという、過去の日次チェックの中でも珍しく静かな期間だった。GitHub Releases系（Claude Code、Codex、Dify、n8n、Copilot CLI）はいずれも`gh api`のpagination込みで確認しており、取得漏れの可能性は低いと判断した。次回チェックでは、本窓の「静けさの反動」で大型発表が集中する可能性を念頭に置く。


### PR DESCRIPTION
## Summary

- 窓: 2026-07-11T16:11 → 2026-07-13T09:56 (JST、約42時間)
- 更新あり: 0件
- 公開記事化: 0件
- 見送り: 該当なし
- 取得失敗: 0件（openai.com/help.openai.com/x.ai系は既知の403制約、WebSearch・GitHub API代替で確認済み）

## Test plan

- [x] `npm run check` — 0 errors
- [x] 日次サマリーに全15サービスの確認結果を記録
- [x] `daily-ai-update-monitor` SKILL 規約に準拠

🤖 Generated with [Claude Code](https://claude.com/claude-code)