### PR TITLE
feat: 2026-07-20 AIニュース日次チェック（更新なし）

### DIFF
--- a/docs/research/daily-ai-updates/2026-07-20.md
+++ b/docs/research/daily-ai-updates/2026-07-20.md
@@ -1,0 +1,108 @@
+---
+date: 2026-07-20
+title: "AI公式アップデート日次チェック 2026-07-20"
+fetched_at: 2026-07-20T14:23:58+09:00
+window_start: 2026-07-18T10:58:20+09:00
+window_end: 2026-07-20T14:23:58+09:00
+---
+
+# AI公式アップデート日次チェック 2026-07-20
+
+## サマリー
+
+- 対象期間: 2026-07-18 10:58 JST 〜 2026-07-20 14:23 JST（約51.5時間）
+- 更新あり: 4件（Claude Code 1件 / OpenAI Codex stable 1件 / ChatGPT・OpenAI Status incident 3件束ね1件 / ByteDance Seed 1件）
+- 更新なし: 10サービス（ChatGPT・OpenAI公式Blog本体、Gemini、Claude本体、GitHub Copilot、Genspark、Manus、Dify、n8n、Meta AI、Runway、xAI/Grok、Pika）
+- 保留（公式未確認）: 0件
+- 取得失敗: 0件（openai.com本体は既知の403制約があるがWebSearchで代替確認）
+- 要確認: ByteDance Seed Audio 1.0の個別記事URLスラッグ未特定（下記「取得失敗・保留」参照）
+- Codex alpha: 1件（`rust-v0.145.0-alpha.24`、窓内。stable化前のため件数のみ言及）
+
+前回チェック（2026-07-18、window_end 2026-07-18T10:58 JST）から約51.5時間の本窓は、対象期間がやや長めだったにもかかわらず大型リリースは少なく、Claude Codeのセキュリティ寄りリリース（v2.1.215、権限チェックの抜け穴修正多数＋`EndConversation`ツール追加）、OpenAI Codexの軽微なホットフィックス（GPT-5.6系モデルのコンテキスト長修正）、OpenAI Statusの短時間incident 3件、ByteDance Seedの新オーディオ生成モデル「Seed Audio 1.0」公式Blog記事が中心だった。ChatGPT/OpenAI本体、Gemini、Claude本体、Dify、n8n、GitHub Copilotはいずれも窓内の新規公式発表なし。
+
+## 更新あり
+
+| service | published_at | title | category | detail |
+| --- | --- | --- | --- | --- |
+| Claude Code | 2026-07-19T02:56:01Z | v2.1.215 — 権限チェック脆弱性一括修正、`EndConversation`ツール追加 | enhancement | ../zenn-claude-code-release-basic/official-updates/2026-07-19T025601-claude-code-v2-1-215.md |
+| OpenAI Codex (stable) | 2026-07-18T13:51:52Z | rust-v0.144.6 — GPT-5.6 Sol/Terra/Lunaのバンドル指示・コンテキスト長ホットフィックス | enhancement | ../openai-codex/official-updates/2026-07-18T135152-codex-rust-v0-144-6.md |
+| ChatGPT / OpenAI | 2026-07-18T08:05:37Z〜2026-07-20T03:34:06Z | OpenAI Status — Codexアクセス障害・ChatGPT障害（Major）・GitHub連携障害の3件 | incident | ../zenn-chatgpt-openai-basic/official-updates/2026-07-18T080537-status-incidents-3x.md |
+| ByteDance Seed | 2026-07-20 (date-only) | Seed Audio 1.0 — 音声・BGM・効果音を1回の生成でまとめて作るオーディオ生成モデル紹介Blog | release | ../zenn-bytedance-seed-basic/official-updates/2026-07-20T000000-seed-audio-1-0.md |
+
+`category` は次のいずれか: `release`（新規発表・新製品・新バージョン）、`enhancement`（既存機能の派生改善・対応拡大）、`rollout`（言語・地域・GA展開）、`policy`（料金・プラン・ポリシー変更）、`incident`（障害・廃止予告）。
+
+## 更新なし
+
+- ChatGPT/OpenAI 公式Blog・Release Notes（Status以外）: `help.openai.com`のChatGPT Release Notes、Enterprise/EDU Release Notes、`openai.com/news/`各カテゴリ（Product/Engineering/Security含む）、`openai.com/index/<slug>/`個別ポスト、`developers.openai.com`（API changelog・Codex changelogとも `learn.chatgpt.com/docs/changelog` にリダイレクト確認済み）いずれも窓内の新規投稿なし。検索結果に「ChatGPT Work」「GPT-5.6」「モデルピッカー更新」等が繰り返し出たが、いずれも2026-07-09以前の既発表（既存日次チェックで記録済み）で窓外のため対象外。
+- OpenAI Codex (alpha): `rust-v0.145.0-alpha.24`（2026-07-18T22:26:23Z）が窓内にあるが、alphaのため件数のみ言及し詳細ファイル化はしない。
+- Gemini: `blog.google/products/gemini`、`developers.googleblog.com`、Workspace Updates Blog（週次Recap・個別ポスト）、`gemini.google/release-notes/`いずれも窓内の新規投稿なし。直近の個別ポストは2026-07-16（Gemini Omni in Vids、Gemini in Docs多言語拡大）で窓外。
+- Claude: Release Notes（`support.claude.com`）直近は2026-07-14で窓内の新規日付なし。`anthropic.com/news`も直近は2026-07-14で窓外。`claude.com/blog`は2026-07-17に2件（Cursor×Claude Fable 5ケーススタディ、CISO向けagentic AIガイド）確認したが、いずれも前回2026-07-18チェックで確認・見送り済みで窓内の新規投稿なし。AWS What's New / Machine Learning Blogも窓内の新規Claude関連発表なし（直近はBedrockコンソール刷新、2026-07-13で窓外）。
+- GitHub Copilot: `github.blog/changelog/label/copilot/`直近は2026-07-17（リポジトリ単位メトリクスGA等、前回チェックで記録済み）で窓内の新規投稿なし。GitHub Copilot CLI GitHub Releasesも窓内の新規stable/prereleaseなし（直近はv1.0.72-1、2026-07-17T17:33:31Z、窓外）。
+- Dify: GitHub Releases窓内の新規リリースなし（直近は1.16.0、2026-07-17T11:14:06Z、窓外）。Blog側は2026-07-17「Qubrid AIマーケットプレイス追加」（窓外）、2026-07-20「AIコスト削減ガイド」を確認したが、後者は製品機能変更を伴わない一般的なコスト最適化解説記事のため対象外（下記「見送り」参照）。
+- n8n: GitHub Releases（`gh api` pagination確認済み）で窓内の新規リリースなし。直近はn8n@2.30.7/2.31.3/1.123.66（2026-07-17、窓外）。
+- Genspark: 公式Blog窓内の新規投稿なし。直前投稿は2026-07-13（Finance Intern事例）。
+- Manus: 公式Blog窓内の新規投稿なし。直前投稿は2026-07-17「Ascendea 90×output shift」事例（前回チェックで見送り済み）。
+- Meta AI: 公式Blog窓内の新規投稿なし。直前投稿は2026-07-09「Muse Spark 1.1」。
+- Runway: changelog・News・Runway Dev API changelogいずれも窓内の新規更新なし。直前はchangelog 2026-07-02（Agent Skills）。
+- xAI / Grok: Release Notes（`docs.x.ai/docs/release-notes`）・News（`x.ai/news`）いずれも窓内の新規更新なし。Grok 4.5は2026-07-08発表（窓外）で検索結果に混入したが対象外。
+- Pika: 公式Blog窓内の新規投稿なし（公式Blogは実質更新が少ないソース、直近確認できる投稿は2024年のシリーズA記事のみ）。
+
+## 保留・取得失敗
+
+- ByteDance Seed Audio 1.0の公式Blog個別記事URL: ブログ一覧ページ（`seed.bytedance.com/en/blog`）でタイトル・日付（Jul 20, 2026）は確認できたが、個別記事のURLスラッグを巡回時に特定できなかった。日次サマリー・詳細ファイルではブログ一覧URLを`source`として暫定記録。次回チェック時に個別URLを再確認する。
+
+## selection-rubricメモ（重要度・持続性・実務影響・既存教材影響・公式情報十分性）
+
+- **Claude Code v2.1.215（EndConversation・権限チェック修正）**: セキュリティ関連の修正が多く持続性・実務影響は中〜高（長時間運用者・エンタープライズ利用者に関係）。ただし修正内容自体は「バグがあった」という性質のため、単独記事より次のセキュリティまとめ記事向き。`EndConversation`ツールは「AIエージェントの安全装置」という切り口で単体でも紹介価値あり。公式情報は十分（CHANGELOG.mdに詳細記載）。
+- **OpenAI Codex rust-v0.144.6**: 重要度・実務影響ともに低い（既存モデルのメタデータ修正のみ）。記事化不要。
+- **OpenAI Status incident 3件**: いずれも短時間で解消済み。2件目（ChatGPT全体、Major）はやや影響範囲が広いが単発の短時間障害のため記事化は見送り。
+- **ByteDance Seed Audio 1.0**: 重要度・持続性は中〜高（音声・BGM・効果音を1モデルで統合するアプローチは動画生成・音声生成AIの比較教材で扱う価値がある）。ただし実質のモデル提供開始は2026-06-23で、今回の公式Blog記事はその技術紹介という位置づけ。公式情報の十分性はやや低い（個別記事URL未特定、詳細技術情報が乏しい）。記事化する場合は「提供開始日と公式Blog掲載日のズレ」を明記する必要がある。
+
+## 速報記事化済み
+
+なし（本窓の更新はいずれもバグ修正・軽微なホットフィックス・短時間障害・詳細不足のため、速報記事化は見送り）。
+
+## 見送り（記事化しないもの）
+
+- Claude Code v2.1.215: バグ修正・セキュリティ修正中心のため単独記事は見送り。`EndConversation`部分のみ次のセキュリティ関連まとめ記事の候補として保持。
+- OpenAI Codex rust-v0.144.6: モデルメタデータ修正のみのため見送り。
+- OpenAI Status incident 3件: いずれも短時間で解消済みのため見送り。
+- ByteDance Seed Audio 1.0: 公式情報の十分性がやや低い（個別URL未特定）ため、次回チェックで一次情報を補強してから記事化を検討する。
+- Dify Blog「How to Reduce AI Costs Without Losing Control of Your Stack」（2026-07-20）: 製品機能変更を伴わない一般的なコスト最適化解説記事のため対象外。
+
+## 補足メモ
+
+- **検索ノイズの注意点（継続）**: 「GPT-5.6」「ChatGPT Work」「モデルピッカー更新（Medium/High/Extra High）」「Grok 4.5」等が検索結果に繰り返し混入したが、いずれも2026-07-08〜09以前の既発表で、既存の日次チェック（`2026-07-09.md`ほか）で記録済みのため本窓には含めていない。今回もGensparkの一覧に「Jul 22, 2026」という未来日付表示のエントリが見えたが、実行時点（2026-07-20）より後の日付であり信頼できないため対象外とした。
+- 該当するユーザー認識ギャップの新規発生なし（`references/perception-gaps.md`参照）。
+
+## チェック対象ソース
+
+- ChatGPT Release Notes: https://help.openai.com/en/articles/6825453-chatgpt-release-notes
+- ChatGPT Enterprise & Edu Release Notes: https://help.openai.com/en/articles/10128477-chatgpt-enterprise-edu-release-notes
+- OpenAI News: https://openai.com/news/ 、https://openai.com/ja-JP/news/ 、各カテゴリページ（Company/Research/Product/Safety/Engineering/Security/Global Affairs/AI Adoption）
+- OpenAI 個別ポスト: https://openai.com/index/<slug>/
+- OpenAI 1階層目セクション: https://openai.com/academy/ 、https://openai.com/stories/ 、https://openai.com/business/ 、https://openai.com/solutions/
+- OpenAI Status: https://status.openai.com/ 、https://status.openai.com/history
+- OpenAI Codex GitHub Releases: https://github.com/openai/codex/releases（`gh api` pagination確認済み）
+- OpenAI API Changelog: https://developers.openai.com/api/docs/changelog （`learn.chatgpt.com/docs/changelog`にリダイレクト）
+- Gemini Blog: https://blog.google/products-and-platforms/products/gemini/
+- Google Developers Blog: https://developers.googleblog.com/
+- Workspace Updates Blog: https://workspaceupdates.googleblog.com/（個別ポストURL確認）
+- Gemini Apps Release Notes: https://gemini.google/release-notes/
+- Claude Release Notes: https://support.claude.com/en/articles/12138966-release-notes
+- Anthropic News: https://www.anthropic.com/news
+- Claude Blog: https://claude.com/blog
+- AWS What's New / Machine Learning Blog: https://aws.amazon.com/about-aws/whats-new/ 、https://aws.amazon.com/blogs/machine-learning/
+- Claude Code GitHub Releases: https://github.com/anthropics/claude-code/releases（`gh api` pagination確認済み）
+- GitHub Copilot Changelog: https://github.blog/changelog/label/copilot/
+- GitHub Copilot CLI GitHub Releases: https://github.com/github/copilot-cli/releases（`gh api` pagination確認済み）
+- Dify GitHub Releases: https://github.com/langgenius/dify/releases（`gh api` pagination確認済み）
+- Dify Blog: https://dify.ai/blog
+- n8n GitHub Releases: https://github.com/n8n-io/n8n/releases（`gh api` pagination確認済み）
+- Genspark Blog: https://www.genspark.ai/blog
+- Manus Blog: https://manus.im/blog
+- Meta AI Blog: https://ai.meta.com/blog/
+- Runway Changelog: https://runwayml.com/changelog 、Runway News: https://runwayml.com/news 、Runway API Changelog: https://docs.dev.runwayml.com/api-details/api_changelog/
+- xAI Release Notes: https://docs.x.ai/docs/release-notes 、xAI News: https://x.ai/news
+- ByteDance Seed Blog: https://seed.bytedance.com/en/blog/
+- Pika Blog: https://pika.art/blog

--- a/docs/research/openai-codex/official-updates/2026-07-18T135152-codex-rust-v0-144-6.md
+++ b/docs/research/openai-codex/official-updates/2026-07-18T135152-codex-rust-v0-144-6.md
@@ -1,0 +1,37 @@
+---
+date: 2026-07-18
+title: "OpenAI Codex rust-v0.144.6 — GPT-5.6 Sol/Terra/Lunaのバンドル指示・コンテキスト長ホットフィックス"
+service: "OpenAI Codex"
+source: https://github.com/openai/codex/releases/tag/rust-v0.144.6
+fetched_at: 2026-07-20T14:23:58+09:00
+published_at: 2026-07-18T13:51:52Z
+date_precision: timestamp
+category: enhancement
+---
+
+# 2026-07-18 OpenAI Codex rust-v0.144.6
+
+## 公式内容の日本語要約
+
+0.144系のホットフィックスリリース。GPT-5.6 Sol・Terra・Luna向けにバンドルされていた指示（instructions）を更新し、コンテキストウィンドウの表示を正しい272,000トークンに修正した。0.144.5からのバックポート限定パッチで、新機能追加はない。
+
+## できるようになったこと
+
+- GPT-5.6系モデル（Sol/Terra/Luna）使用時のコンテキストウィンドウ表示・挙動が正しい272,000トークンに修正される。
+- バンドル指示が最新化され、モデルの実際の仕様とのズレが解消される。
+
+## 影響範囲
+
+- 対象ユーザー: Codex CLI（stable channel）で GPT-5.6系モデルを使うユーザー
+- 対象プラン: 全プラン
+- API / UI / 管理者機能: CLI本体のモデルメタデータ
+
+## 教材化メモ
+
+単体記事化は不要（バグ修正のみ）。GPT-5.6系モデルの仕様解説記事があれば、コンテキスト長の注記として反映する程度でよい。
+
+## 原文確認
+
+- 公式見出し: GitHub Releases「rust-v0.144.6」Bug Fixes
+- 公式URL: https://github.com/openai/codex/releases/tag/rust-v0.144.6
+- 原文全文は公式ページで確認してください。

--- a/docs/research/zenn-bytedance-seed-basic/official-updates/2026-07-20T000000-seed-audio-1-0.md
+++ b/docs/research/zenn-bytedance-seed-basic/official-updates/2026-07-20T000000-seed-audio-1-0.md
@@ -1,0 +1,41 @@
+---
+date: 2026-07-20
+title: "Seed Audio 1.0 — 音声・音楽・効果音を1回の生成でまとめて作るオーディオ生成モデル"
+service: "ByteDance Seed"
+source: https://seed.bytedance.com/en/blog
+fetched_at: 2026-07-20T14:23:58+09:00
+published_at: 2026-07-20
+date_precision: date-only
+category: release
+---
+
+# 2026-07-20 ByteDance Seed Audio 1.0
+
+## 公式内容の日本語要約
+
+ByteDance Seed公式Blogに「From Speech to Audio Creation | Introducing the Seed Audio 1.0 Audio Creation Model」として、統合型オーディオ生成モデル「Seed Audio 1.0」の紹介記事が公開された。単一プロンプトから、音声（複数話者・感情・ペース差込み）、BGM、環境音・効果音を1回の生成でまとめた完成トラックとして出力できる点が特徴。3クリップ・約30秒程度の参照音声からゼロショットで声質クローンも可能。
+
+なお、モデル自体は2026-06-23のVolcano Engine FORCE 2026カンファレンスで先行披露されており、Volcano Ark経由でAPI提供・CapCut（剪映）やJimeng、Fanqie等のByteDance製品への統合が進んでいた。今回の公式Blog記事（2026-07-20付）は、モデルの正式な技術紹介・詳細解説としての位置づけと考えられる。
+
+## できるようになったこと
+
+- 1つのテキストプロンプトから、音声・BGM・効果音を一体化した完成音源を生成できる。
+- 30秒程度の参照音声からゼロショットで声質クローンができる。
+- 複数話者の対話を、話者ごとに異なる声質・感情・ペースで生成できる。
+- 声質の一貫性を保ったまま最長2分程度の音源を生成・拡張できる。
+
+## 影響範囲
+
+- 対象ユーザー: Volcano Engine / Volcano Ark経由の開発者、CapCut・Jimeng・Fanqie等ByteDance製品ユーザー
+- 対象プラン: Volcano Ark API（従量課金、$0.002〜$0.00325/秒目安）
+- API / UI / 管理者機能: Volcano Ark API、一部ByteDance製品への統合
+
+## 教材化メモ
+
+「音声・BGM・効果音を分業させず1モデルで完結」という設計思想は、動画生成・音声生成系AIツールの比較教材で扱う価値がある。ただし公式Blogの正確な公開URLスラッグが確認できず、ブログ一覧ページのみ確認できた点に注意（要再確認）。モデル自体の実質提供開始は2026-06-23である点も記事化時に明記する。
+
+## 原文確認
+
+- 公式見出し: ByteDance Seed Blog「From Speech to Audio Creation | Introducing the Seed Audio 1.0 Audio Creation Model」（Jul 20, 2026）
+- 公式URL: https://seed.bytedance.com/en/blog （個別記事URLは巡回時に特定できず、一覧ページで日付・タイトルのみ確認。要再確認）
+- 原文全文は公式ページで確認してください。

--- a/docs/research/zenn-chatgpt-openai-basic/official-updates/2026-07-18T080537-status-incidents-3x.md
+++ b/docs/research/zenn-chatgpt-openai-basic/official-updates/2026-07-18T080537-status-incidents-3x.md
@@ -1,0 +1,40 @@
+---
+date: 2026-07-18
+title: "OpenAI Status — Codexアクセス障害・ChatGPT障害・GitHub連携障害の3件（窓内）"
+service: "ChatGPT / OpenAI"
+source: https://status.openai.com/history
+fetched_at: 2026-07-20T14:23:58+09:00
+published_at: 2026-07-18T08:05:37Z
+date_precision: timestamp
+category: incident
+---
+
+# 2026-07-18〜2026-07-20 OpenAI Status incident 3件
+
+## 公式内容の日本語要約
+
+対象期間（2026-07-18 10:58 JST 〜 2026-07-20 14:23 JST）に、OpenAI Statusで新規発生・解消したincidentが3件あった。いずれも解消済みで、短時間の障害。
+
+1. **Some users are unable to access Codex**（2026-07-18T08:05:37Z作成〜2026-07-18T12:58:14Z解消、Impact: Minor）: Codexデスクトップアプリ・CLIでaccess-denied エラーが発生。
+2. **Elevated errors affecting ChatGPT**（2026-07-19T14:49:42Z作成〜2026-07-19T17:05:02Z解消、Impact: Major）: ChatGPTの会話・Voice・Work Modeでエラー増加。原因特定・緩和済み。
+3. **Elevated errors for GitHub-dependent ChatGPT and Codex workflows**（2026-07-20T00:34:34Z作成〜2026-07-20T03:34:06Z解消、Impact: Minor）: GitHub連携に依存するChatGPT・Codexワークフローで失敗・遅延が発生。
+
+## できるようになったこと
+
+（機能追加ではなく障害情報のため該当なし）
+
+## 影響範囲
+
+- 対象ユーザー: Codex（デスクトップ・CLI）利用者、ChatGPT（Chat/Voice/Work Mode）利用者、GitHub連携ワークフロー利用者
+- 対象プラン: 影響範囲は各incidentのステータスページ記載に準拠
+- API / UI / 管理者機能: プロダクト障害情報
+
+## 教材化メモ
+
+いずれも短時間で解消済みのincidentのため、単体記事化は見送り。研究ログのみで十分。2番目（ChatGPT全体エラー増加、Major）は影響範囲が広いため、次回大規模障害まとめ記事があれば言及候補。
+
+## 原文確認
+
+- 公式見出し: OpenAI Status History
+- 公式URL: https://status.openai.com/history 、https://status.openai.com/
+- 原文全文は公式ページで確認してください。

--- a/docs/research/zenn-claude-code-release-basic/official-updates/2026-07-19T025601-claude-code-v2-1-215.md
+++ b/docs/research/zenn-claude-code-release-basic/official-updates/2026-07-19T025601-claude-code-v2-1-215.md
@@ -1,0 +1,48 @@
+---
+date: 2026-07-19
+title: "Claude Code v2.1.215 — EndConversationツール追加、権限チェック脆弱性の一括修正"
+service: "Claude Code"
+source: https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md
+fetched_at: 2026-07-20T14:23:58+09:00
+published_at: 2026-07-19T02:56:01Z
+date_precision: timestamp
+category: enhancement
+---
+
+# 2026-07-19 Claude Code v2.1.215
+
+## 公式内容の日本語要約
+
+v2.1.215は、権限チェック（Permission Check）の抜け穴を大量に修正した回で、セキュリティ色の強いリリース。主な変更は次の通り。
+
+- 悪質・脱獄行為を行うユーザーとの会話を打ち切る `EndConversation` ツールを新規追加（claude.aiでは2025年から提供済みの挙動をClaude Codeにも導入）。
+- `/verify`・`/code-review` スキルを自動実行しないよう変更。明示的に `/verify` `/code-review` を呼んだときのみ実行される。
+- `dir/**` のような単一セグメント許可ルールが、ツリー内のどこにある `dir/` にも誤って書き込み許可を与えてしまう不具合を修正（本来は `<cwd>/dir` のみに限定されるべき）。
+- Windows PowerShell 5.1、非常に長いコマンド（1万文字超）、zsh の変数添字・修飾子、`help`/`man` コマンドなど、複数の権限チェックのすり抜けパターンを修正。
+- リモートセッションでローカル確認ダイアログより先に権限プロンプトが通ってしまう不具合を修正。
+- 長時間実行ツールコールの進捗を定期的にハートビート表示するように改善。
+- OpenTelemetryにメッセージ相関・ツール来歴用の属性（`message.uuid`、`client_request_id`、`tool_source`）を追加。
+- バックグラウンドセッション（`claude agents`）まわりの複数バグ修正（削除できない、再開時に会話が復元されない等）。
+
+## できるようになったこと
+
+- 悪質ユーザー・脱獄試行に対してセッションを安全に終了できる（`EndConversation`）。
+- `/verify`・`/code-review` の意図しない自動実行がなくなり、明示的に呼び出したときだけ動く。
+- 権限ルールの誤許可（`dir/**` の範囲逸脱など）が修正され、想定外ディレクトリへの書き込みリスクが下がる。
+- 長時間ツールコール中も進捗が見えるようになる。
+
+## 影響範囲
+
+- 対象ユーザー: Claude Code全ユーザー
+- 対象プラン: 全プラン
+- API / UI / 管理者機能: CLI本体の権限チェック・エージェントビュー・OpenTelemetry連携
+
+## 教材化メモ
+
+権限バイパス系のバグ修正が多く、単体記事よりは「Claude Codeの権限システムを安全に運用するポイント」まとめ記事の一部として扱うのが適切。`EndConversation`は「AIエージェントの安全装置」という切り口で教材価値がある。
+
+## 原文確認
+
+- 公式見出し: CHANGELOG.md「## 2.1.215」
+- 公式URL: https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md 、https://github.com/anthropics/claude-code/releases/tag/v2.1.215
+- 原文全文は公式ページで確認してください。


### PR DESCRIPTION
## Summary

- 窓: 2026-07-18T10:58 → 2026-07-20T14:23 (JST、約51.5時間)
- 更新あり: 4件（Claude Code v2.1.215 / OpenAI Codex rust-v0.144.6 / OpenAI Status短時間障害3件 / ByteDance Seed Audio 1.0）
- 公開記事化: 0件
- 見送り: 4件（権限修正の羅列で単独記事化には弱い、メタデータのみのパッチ、短時間障害、公式個別記事URL未確定）
- 取得失敗: 0件（ByteDance Seed Audio 1.0の公式個別記事URLスラッグのみ暫定、次回再確認予定）

## Test plan

- [x] `npm run check` — 0 errors
- [x] 日次サマリーに全ソースの確認結果を記録
- [x] `daily-ai-update-monitor` SKILL 規約に準拠

🤖 Generated with [Claude Code](https://claude.com/claude-code)