### PR TITLE
feat: 2026-07-22 AIニュース日次チェック（速報2件）

### DIFF
--- a/docs/research/daily-ai-updates/2026-07-22.md
+++ b/docs/research/daily-ai-updates/2026-07-22.md
@@ -1,0 +1,84 @@
+---
+date: 2026-07-22
+title: "AI公式アップデート日次チェック 2026-07-22"
+fetched_at: 2026-07-22T08:58:54+09:00
+window_start: 2026-07-21T15:55:42+09:00
+window_end: 2026-07-22T08:58:54+09:00
+---
+
+# AI公式アップデート日次チェック 2026-07-22
+
+## サマリー
+
+- 対象期間: 2026-07-21 15:55 JST 〜 2026-07-22 08:58 JST（約17時間）
+- 更新あり: 5件（Claude Code 1件 / OpenAI Codex 1件 / n8n 1件 / GitHub Copilot 1件 / OpenAI Status 1件）
+- 更新なし: 10サービス（ChatGPT release notes、Gemini、Claude Release Notes、Cursor、Dify、Manus、Meta AI、Runway、xAI/Grok、ByteDance Seed、Pika、Genspark ※計12件確認）
+- 保留（公式未確認）: 0件
+- 取得失敗: 0件
+- Codex alpha: 1件（`rust-v0.145.0-alpha.29`、窓内。stableは同日`rust-v0.145.0`が出たため詳細ファイル化）
+
+前回チェック（2026-07-21、window_end 2026-07-21T15:55:42 JST）から約17時間の本窓は、Claude Code v2.1.217（絵文字ショートコード補完・トランスクリプト保存失敗の警告・多数バグ修正）、OpenAI Codex rust-v0.145.0（stable。スレッド履歴ページネーション・`/import`でのCursor/Claude Code設定移行・Amazon Bedrock連携・音声入出力・マルチエージェントV2安定化という大型アップデート）、n8n 2.32.0（beta。AI Builderのバグ修正）、GitHub Copilot（モデルピッカーにGemini 3.6 Flash追加）、OpenAI Status（ログイン/サインアップ障害・API画像生成エラーの2件、いずれも同日中に解消）が中心。ChatGPT/OpenAI Release Notes本体、Gemini、Claude Release Notes、Cursor、Dify、Manus、Meta AI、Runway、xAI/Grok、ByteDance Seed、Pika、Genspark は窓内の新規公式発表なし。
+
+## 更新あり
+
+| service | published_at | title | category | detail |
+| --- | --- | --- | --- | --- |
+| Claude Code | 2026-07-21T21:35:10Z | v2.1.217 — 絵文字ショートコード補完・トランスクリプト保存失敗の警告・バグ修正多数 | enhancement | ../zenn-claude-code-release-basic/official-updates/2026-07-21T213510-claude-code-v2-1-217.md |
+| OpenAI Codex | 2026-07-21T18:21:04Z | rust-v0.145.0 — スレッド履歴ページネーション・Cursor/Claude Code設定インポート・Bedrock連携・音声入出力・マルチエージェントV2安定化 | release | ../openai-codex/official-updates/2026-07-21T182104-codex-rust-v0-145-0.md |
+| n8n | 2026-07-21T07:54:32Z | 2.32.0（beta）— AI Builder関連バグ修正・snapshotヘルスゲート追加 | enhancement | ../zenn-n8n-basic/official-updates/2026-07-21T075432-n8n-2-32-0-beta.md |
+| GitHub Copilot | 2026-07-21 (date-only) | Gemini 3.6 Flashがモデルピッカーに追加 | enhancement | ../zenn-github-copilot-basic/official-updates/2026-07-21T000000-gemini-3-6-flash-in-copilot.md |
+| ChatGPT / OpenAI (Status) | 2026-07-21T18:36:57Z | ログイン/サインアップ障害・API画像生成エラーの2件（同日解消） | incident | ../zenn-chatgpt-openai-basic/official-updates/2026-07-21T183657-status-incidents-2x.md |
+
+`category` は次のいずれか: `release`（新規発表・新製品・新バージョン）、`enhancement`（既存機能の派生改善・対応拡大）、`rollout`（言語・地域・GA展開）、`policy`（料金・プラン・ポリシー変更）、`incident`（障害・廃止予告）。
+
+## 更新なし
+
+- ChatGPT Release Notes: 対象期間内の新規エントリなし（最新は2026-07-16のデスクトップアプリ更新、検索でも再確認済み）。
+- Gemini: `blog.google` Gemini面に窓内新規エントリなし。Workspace Updates個別ポストは2026-07-21付で2件確認（Google Classroomホームページ刷新、Google Meetホームページ刷新）したが、Classroom刷新はGemini/Gemini Notebook機能の条件付き表示に触れるのみでGemini自体の新機能ではなく、ロールアウト開始も2026-07-27で窓外。Meet刷新はGemini/AI機能への言及なし。いずれもGemini製品アップデートとしては対象外と判断。
+- Claude Release Notes: 最新は2026-07-14「HIPAA configuration」で窓外。Claude Platform Docs release notesも最新2026-07-17で窓外。claude.com/blogは2026-07-21付で2件（「How Anthropic secures its AI-native software development lifecycle」「How Datadog built a 'universal machine tool' for Claude Code」）確認したが、いずれも新機能発表を伴わないopinion piece / 顧客事例で、Claude Code自体の新機能・設定変更なしのため対象外。AWS What's New、AWS Machine Learning Blogも窓内新規なし。
+- Cursor: changelog最新は2026-07-17「Improvements to Cursor in Slack」、blog最新は2026-07-20「Agent swarms and the new model economics」でいずれも窓外。
+- Dify: GitHub Releases最新は`1.16.0`（2026-07-17T11:14:06Z）で窓外。
+- Manus: Blog最新は2026-07-17で窓外。
+- Meta AI: Blogに2026-07-21付「How Meta's AI Models Are Powering the First Wave of Genesis Mission Projects」（SAM 3・DINOv3をDOE国立研究所の科学画像解析に応用した事例）を確認したが、新モデル・新機能の発表ではなく既存オープンソースモデルの活用事例のため対象外。
+- Runway: changelog最新2026-07-02、Runway Dev API changelog最新2026-07-10でいずれも窓外。News面も新規なし。
+- xAI / Grok: release-notesページに窓内の新規エントリなし。
+- ByteDance Seed: 最新は2026-07-20のSeed Audio 1.0のみで新規Blogなし。
+- Pika: `pika.art/blog`に窓内の日付付き新規エントリなし。
+- Genspark: Blog最新は2026-07-20「Introducing Genspark AI Workspace 6.0」（前回窓ですでに記録済み）で窓内新規なし。
+
+## 取得失敗・保留
+
+- なし（ChatGPT release notesページとopenai.com/newsは直接フェッチが403だったため、Web検索での逆引きで最新エントリを確認し窓内新規なしと判断）。
+
+## 公開記事化結果
+
+| service | title | 判定 | 理由 | 記事 |
+| --- | --- | --- | --- | --- |
+| OpenAI Codex | rust-v0.145.0 | AIニュース化 | `/import`によるClaude Code設定移行の公式導線明確化、Bedrock連携・音声入出力・マルチエージェントV2安定化を含む大型リリース | `src/content/ai-news/codex/codex-rust-v0-145-0.mdx` + note |
+| GitHub Copilot | Gemini 3.6 Flash対応 | AIニュース化 | モデルピッカーへの主要モデル追加で利用者の操作フローに影響 | `src/content/ai-news/github-copilot/gemini-3-6-flash-in-copilot.mdx` + note |
+| Claude Code | v2.1.217 | 見送り | 絵文字補完・地道なバグ修正が中心でパッチリリースの範囲、教材読者への学習価値が薄い | - |
+| n8n | 2.32.0（beta） | 見送り | AI Builder関連のバグ修正のみで新機能なし | - |
+| ChatGPT / OpenAI (Status) | ログイン/API画像生成障害2件 | 見送り | いずれも同日中に解消した短時間incidentのためSKILLルールにより記事化見送り | - |
+
+## 補足メモ
+
+- ユーザー認識ギャップの新規該当なし（`references/perception-gaps.md` 参照）。ただし、OpenAI Codex rust-v0.145.0の`/import`拡張でClaude Code設定の取り込みが可能になった件は、2026-05-09エントリ「Claude Code → Codex簡単移行」ギャップの前提を一部更新する（片方向インポート機能が公式化された）ため、詳細は`../openai-codex/official-updates/2026-07-21T182104-codex-rust-v0-145-0.md`の教材化メモを参照。ギャップの本体記述（双方向の「簡単移行」ではない点）は引き続き有効。
+
+## チェック対象
+
+- ChatGPT / OpenAI: https://help.openai.com/en/articles/6825453-chatgpt-release-notes
+- OpenAI Codex: https://github.com/openai/codex/releases
+- Gemini: https://blog.google/products-and-platforms/products/gemini/
+- Claude: https://support.claude.com/en/articles/12138966-release-notes
+- Claude Code: https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md
+- Cursor: https://cursor.com/changelog
+- GitHub Copilot: https://github.blog/changelog/label/copilot/
+- Genspark: https://www.genspark.ai/blog
+- Manus: https://manus.im/blog
+- Dify: https://github.com/langgenius/dify/releases
+- n8n: https://github.com/n8n-io/n8n/releases
+- Meta AI: https://ai.meta.com/blog/
+- Runway: https://runwayml.com/changelog
+- xAI / Grok: https://docs.x.ai/docs/release-notes
+- ByteDance Seed: https://seed.bytedance.com/en/blog/
+- Pika: https://pika.art/blog

--- a/docs/research/openai-codex/official-updates/2026-07-21T182104-codex-rust-v0-145-0.md
+++ b/docs/research/openai-codex/official-updates/2026-07-21T182104-codex-rust-v0-145-0.md
@@ -1,0 +1,51 @@
+---
+date: 2026-07-21
+title: "OpenAI Codex rust-v0.145.0 — スレッド履歴のページネーション・Cursor/Claude Code設定インポート・Bedrock連携・音声入出力・マルチエージェントV2安定化"
+service: "OpenAI Codex"
+source: https://github.com/openai/codex/releases/tag/rust-v0.145.0
+fetched_at: 2026-07-22T08:58:54+09:00
+published_at: 2026-07-21T18:21:04Z
+date_precision: timestamp
+category: release
+---
+
+# 2026-07-21 OpenAI Codex rust-v0.145.0（stable）
+
+## 公式内容の日本語要約
+
+Codex CLIのstableリリース。前回stable（rust-v0.144.6、2026-07-18）以降のalpha群を集約した大型アップデート。
+
+- **スレッド履歴のページネーション**（experimental）: 効率的な再開・検索・永続化された名前・サブエージェント対応・memories機能を追加。
+- **`/import`の対象拡大**: Cursor・Claude Codeの設定、MCPサーバー、プラグイン、セッション、コマンド、プロジェクトスコープのmemoriesを移行可能に（Claude Code → Codexへの設定インポート機能）。
+- **Amazon Bedrock連携**（experimental）: Bedrockログイン、カスタムエンドポイント・認証対応を追加。BedrockのデフォルトモデルはGPT-5.6 Sol（既存モデル、2026-07-09に既報のSol/Terra/Luna系列）。
+- **音声入出力**: 一般的なローカル音声フォーマットでの音声入力・ツール出力、ストリーミングrealtime V3会話を追加。
+- **マルチエージェントV2の安定化**: サブエージェントのモデル・reasoning水準・並行数を設定可能にし、ロール復元・エージェントナビゲーション改善（opt-in experimentalから安定化）。
+- **ターミナルUIの可視化リンク**: セキュアでクリック可能なインラインビジュアライゼーションリンクを追加。
+
+バグ修正は、ターミナルの応答性改善（インクリメンタルMarkdownレンダリング等）、MCP起動・認証フローの競合防止、Windowsでのexec-serverサンドボックス・ネットワークプロキシ強制、compactリリースメタデータ解析・macOSコードモードインストールの修正など。
+
+## できるようになったこと
+
+- Codexスレッド履歴のページネーション・検索・memories（experimental）
+- `/import`でCursor・Claude Codeの設定・MCPサーバー・プラグイン・セッション・コマンドを移行
+- Amazon Bedrockログイン・カスタムエンドポイント対応（experimental、デフォルトはGPT-5.6 Sol）
+- 音声入力・音声ツール出力・realtime V3ストリーミング会話
+- マルチエージェントV2（サブエージェントのモデル/reasoning/並行数設定）が安定版に
+- ターミナル上でクリック可能なインライン可視化リンク
+
+## 影響範囲
+
+- 対象ユーザー: Codex CLI利用者、Cursor/Claude Codeからの移行検討者、Amazon Bedrock経由でCodexを使う企業ユーザー、音声インターフェースを使うユーザー
+- 対象プラン: Codex CLI全体（一部experimental機能はopt-in）
+- API / UI / 管理者機能: CLI（`/import`、スレッド履歴、マルチエージェント設定）、Bedrock認証設定、音声入出力API
+
+## 教材化メモ
+
+`/import`でClaude Code設定を取り込める点は「Claude Code → Codex移行」の公式導線として明確化された初のケース。従来は逆方向（`openai/codex-plugin-cc`）のみが公式で、Claude Code→Codexはサードパーティ製ツールに頼っていた（`references/perception-gaps.md` 2026-05-09エントリ参照）。今回の`/import`拡張は片方向インポート機能であり、双方向の「簡単移行」を意味するものではない点に注意して記事化する。マルチエージェントV2の安定化、Bedrock連携、音声対応は独立した記事化候補。
+
+## 原文確認
+
+- 公式見出し: New Features / Bug Fixes / Documentation / Chores
+- 公式URL: https://github.com/openai/codex/releases/tag/rust-v0.145.0
+- Full Changelog: https://github.com/openai/codex/compare/rust-v0.144.0...rust-v0.145.0
+- 原文全文は公式ページで確認してください。

--- a/docs/research/zenn-chatgpt-openai-basic/official-updates/2026-07-21T183657-status-incidents-2x.md
+++ b/docs/research/zenn-chatgpt-openai-basic/official-updates/2026-07-21T183657-status-incidents-2x.md
@@ -1,0 +1,39 @@
+---
+date: 2026-07-21
+title: "OpenAI Status — ログイン/サインアップ障害・API画像生成エラーの2件（いずれも同日解消）"
+service: "ChatGPT / OpenAI"
+source: https://status.openai.com/history
+fetched_at: 2026-07-22T08:58:54+09:00
+published_at: 2026-07-21T18:36:57Z
+date_precision: timestamp
+category: incident
+---
+
+# 2026-07-21 OpenAI Status incident 2件
+
+## 公式内容の日本語要約
+
+対象期間（2026-07-21 15:55 JST 〜 2026-07-22 08:58 JST）に、OpenAI Statusで新規発生・解消したincidentが2件あった。いずれも同日中に解消済み。
+
+1. **Issues with logins and signups**（2026-07-21T18:36:57Z作成〜2026-07-21T19:00:27Z解消、約23分）: ログイン・サインアップに影響。API Platform機能は完全復旧を確認。
+2. **Elevated errors for API image generation**（2026-07-21T19:33:27Z作成〜2026-07-21T22:19:31Z解消、約2時間46分）: API経由の画像生成でエラー率上昇。緩和策適用後、エラー率は正常水準に復旧。
+
+## できるようになったこと
+
+（機能追加ではなく障害情報のため該当なし）
+
+## 影響範囲
+
+- 対象ユーザー: ログイン・サインアップ利用者、API画像生成利用者
+- 対象プラン: 各incidentのステータスページ記載に準拠
+- API / UI / 管理者機能: プロダクト障害情報
+
+## 教材化メモ
+
+いずれも数十分〜数時間で解消済みの短時間incidentのため、単体記事化は見送り。研究ログのみで十分。
+
+## 原文確認
+
+- 公式見出し: OpenAI Status History
+- 公式URL: https://status.openai.com/history 、https://status.openai.com/api/v2/incidents.json
+- 原文全文は公式ページで確認してください。

--- a/docs/research/zenn-claude-code-release-basic/official-updates/2026-07-21T213510-claude-code-v2-1-217.md
+++ b/docs/research/zenn-claude-code-release-basic/official-updates/2026-07-21T213510-claude-code-v2-1-217.md
@@ -1,0 +1,39 @@
+---
+date: 2026-07-21
+title: "Claude Code v2.1.217 — 絵文字ショートコード補完・トランスクリプト保存失敗の警告・バグ修正多数"
+service: "Claude Code"
+source: https://github.com/anthropics/claude-code/releases/tag/v2.1.217
+fetched_at: 2026-07-22T08:58:54+09:00
+published_at: 2026-07-21T21:35:10Z
+date_precision: timestamp
+category: enhancement
+---
+
+# 2026-07-21 Claude Code v2.1.217
+
+## 公式内容の日本語要約
+
+Claude Code v2.1.217は機能追加2件とバグ修正多数のパッチリリース。プロンプト入力欄に絵文字ショートコード補完を追加（`:heart:` で❤️を挿入、`:hea` で候補表示。`emojiCompletionEnabled` 設定で無効化可能）。ディスク容量不足などでトランスクリプト書き込みに失敗した場合や、継承環境変数でセッション保存がオフになっている場合に、無言で消失させず警告を表示するようになった。
+
+バグ修正は、MCPツール出力の切り詰め時に元の全文がメモリに残り続けるメモリリーク、Windowsの自動更新失敗時に`claude.exe`が消失する問題、シンボリックリンクされた作業ディレクトリでバックグラウンドセッションの隔離が機能しない問題、Bedrock上のClaude Opus 4.8でauto-compactが発火しない問題、Claude Desktopで企業向けmTLS/TLS-verify/OAuthスコープ/プロキシ設定が無視される問題など多数。
+
+## できるようになったこと
+
+- プロンプト入力での絵文字ショートコード補完（`emojiCompletionEnabled`設定あり）
+- トランスクリプト書き込み失敗・セッション保存オフ時の警告表示
+
+## 影響範囲
+
+- 対象ユーザー: Claude Code全ユーザー（絵文字補完・警告表示）、Windows利用者（自動更新修正）、Bedrock利用者（auto-compact修正）、企業プロキシ/mTLS環境利用者
+- 対象プラン: 全プラン
+- API / UI / 管理者機能: プロンプト入力UI、CLI設定、Claude Desktop企業向けネットワーク設定
+
+## 教材化メモ
+
+セキュリティ・信頼性まわりの地道な修正が中心（memory leak、worktree隔離のsymlink脱出防止、OTLPエンドポイント上書き防止など）。単体記事化の優先度は低いが、v2.1.216の`sandbox.filesystem.disabled`と合わせて「直近1週間のClaude Codeバグ修正まとめ」的な記事があれば言及候補。
+
+## 原文確認
+
+- 公式見出し: What's changed
+- 公式URL: https://github.com/anthropics/claude-code/releases/tag/v2.1.217
+- 原文全文は公式ページで確認してください。

--- a/docs/research/zenn-github-copilot-basic/official-updates/2026-07-21T000000-gemini-3-6-flash-in-copilot.md
+++ b/docs/research/zenn-github-copilot-basic/official-updates/2026-07-21T000000-gemini-3-6-flash-in-copilot.md
@@ -1,0 +1,39 @@
+---
+date: 2026-07-21
+title: "GitHub CopilotでGemini 3.6 Flashが利用可能に"
+service: "GitHub Copilot"
+source: https://github.blog/changelog/2026-07-21-gemini-3-6-flash-is-now-available-in-github-copilot
+fetched_at: 2026-07-22T08:58:54+09:00
+published_at: 2026-07-21T00:00:00Z
+date_precision: date-only
+category: enhancement
+---
+
+# 2026-07-21 GitHub Copilot — Gemini 3.6 Flash対応
+
+## 公式内容の日本語要約
+
+GitHub Copilotのモデルピッカーに、Googleの最新モデル「Gemini 3.6 Flash」が追加された。Web/アプリ開発、コーディング、長時間の自律的エージェントタスク向けに設計され、reasoning強度の設定・並列ツール呼び出しに対応。早期テストでは前バージョン（3.5）比でタスク完了率とトークン効率が向上したとされる。対応IDE・プラットフォームのモデルピッカーから選択可能。課金はプロバイダーのリスト価格に基づく従量制。
+
+Enterprise/Business管理者は、チームが利用できるようにする前に「Gemini 3.6 Flash Preview」ポリシーを有効化する必要がある。段階的ロールアウト。
+
+## できるようになったこと
+
+- Copilotのモデルピッカーで Gemini 3.6 Flash を選択可能
+- reasoning強度の設定・並列ツール呼び出しに対応
+
+## 影響範囲
+
+- 対象ユーザー: GitHub Copilot利用者（IDE・対応プラットフォーム）
+- 対象プラン: Copilot Pro / Pro+ / Max / Business / Enterprise
+- API / UI / 管理者機能: モデルピッカーUI、Enterprise/Business管理者向けポリシー設定（Gemini 3.6 Flash Previewポリシー）
+
+## 教材化メモ
+
+Copilotのマルチモデル対応強化の一例。管理者ポリシー有効化が前提となる点は、企業導入まわりの教材で注意点として言及できる。
+
+## 原文確認
+
+- 公式見出し: Gemini 3.6 Flash is now available in GitHub Copilot
+- 公式URL: https://github.blog/changelog/2026-07-21-gemini-3-6-flash-is-now-available-in-github-copilot
+- 原文全文は公式ページで確認してください。

--- a/docs/research/zenn-n8n-basic/official-updates/2026-07-21T075432-n8n-2-32-0-beta.md
+++ b/docs/research/zenn-n8n-basic/official-updates/2026-07-21T075432-n8n-2-32-0-beta.md
@@ -1,0 +1,44 @@
+---
+date: 2026-07-21
+title: "n8n 2.32.0（beta） — AI Builder関連のバグ修正・snapshotヘルスゲート追加"
+service: "n8n"
+source: https://github.com/n8n-io/n8n/releases/tag/n8n%402.32.0
+fetched_at: 2026-07-22T08:58:54+09:00
+published_at: 2026-07-21T07:54:32Z
+date_precision: timestamp
+release_date: 2026-07-21
+version: "2.32.0"
+channel: beta
+official_url: https://github.com/n8n-io/n8n/releases/tag/n8n%402.32.0
+category: enhancement
+---
+
+# 2026-07-21 n8n 2.32.0（beta）
+
+## 公式内容の日本語要約
+
+n8nのbetaリリース（`n8n@2.31.0`からの差分）。AI Builder（AIA agent builder）関連のバグ修正が中心。生成されたノード型定義で`@version`のeq条件を正しく反映するよう修正、instance AI上のエージェントチャットプレビューを同一タブで開くよう修正、AIA agent builderのartifactモードでチャンネル編集モーダルが再表示されない問題を修正、ToolIoViewの合成実行をsyntheticドキュメントストア配下にスコープする修正、Slackチャンネル付きエージェントのスレッド会話履歴をcaps付きで連携する修正など。加えて、Instance AIのsandboxスナップショットが利用不能な場合にアラートを出し、スナップショットのヘルス状態でリリースをゲートする仕組みをcoreに追加。AWS Bedrock Chat Modelノードのguardrailバージョンデフォルト修正なども含む。
+
+同一コミットに`beta`タグが付与されている（内容は`n8n@2.32.0`と同一）。
+
+## できるようになったこと
+
+- AI Builder（AIA agent builder）のチャンネル編集・チャットプレビュー・スレッド履歴連携の不具合修正
+- 生成ノード型定義の`@version`条件反映修正
+- Instance AI sandboxスナップショットのヘルスチェック・リリースゲート追加
+
+## 影響範囲
+
+- 対象ユーザー: n8n AI Builder（AIA agent builder）利用者、Instance AI利用者、AWS Bedrock Chat Modelノード利用者
+- 対象プラン: Cloud（AI Builder機能はCloud中心）
+- API / UI / 管理者機能: AI Builder UI、Instance AI sandbox基盤
+
+## 教材化メモ
+
+AI Builderのバグ修正のみで新機能はなし。教材記事としての優先度は低い。次回大型リリースでAI Builder関連機能がまとまって出た際に、今回の修正内容も含めて言及する形が妥当。
+
+## 原文確認
+
+- 公式見出し: Bug Fixes
+- 公式URL: https://github.com/n8n-io/n8n/releases/tag/n8n%402.32.0
+- 原文全文は公式ページで確認してください。

--- a/src/content/ai-news-notes/codex/codex-rust-v0-145-0.mdx
+++ b/src/content/ai-news-notes/codex/codex-rust-v0-145-0.mdx
@@ -1,0 +1,9 @@
+---
+title: "教材化メモ：Codex rust-v0.145.0 の /import 拡張とユーザー認識ギャップ"
+noteFor: "codex/codex-rust-v0-145-0"
+date: 2026-07-21
+tags: ["codex", "import", "perception-gap"]
+---
+
+- `/import`でClaude Code設定を取り込める点は「Claude Code → Codex移行」の公式導線として明確化された初のケース。`references/perception-gaps.md`の2026-05-09エントリ（Claude Code → Codex簡単移行の誤認）の前提を一部更新するが、双方向の「簡単移行」ではない点（片方向インポートのみ）は引き続き有効なので、`vs-claude-code.mdx`へ反映する場合はこの区別を明示する。
+- マルチエージェントV2の安定化、Bedrock連携、音声対応は、それぞれ独立した記事化候補として今後の窓で深掘りできる（今回は本体アップデートの一部としてまとめて記事化）。

--- a/src/content/ai-news-notes/github-copilot/gemini-3-6-flash-in-copilot.mdx
+++ b/src/content/ai-news-notes/github-copilot/gemini-3-6-flash-in-copilot.mdx
@@ -1,0 +1,9 @@
+---
+title: "教材化メモ：GitHub Copilot Gemini 3.6 Flash対応"
+noteFor: "github-copilot/gemini-3-6-flash-in-copilot"
+date: 2026-07-21
+tags: ["github-copilot", "gemini", "model-picker"]
+---
+
+- 管理者ポリシー有効化が前提となる点は、企業導入まわりの教材で注意点として言及できる。現時点でCopilot向けの管理者向けKnowledge記事が存在しないため、relatedKnowledgeは空配列。
+- Copilotのマルチモデル対応強化の一例として、他モデル追加ニュースと合わせて「Copilotで使えるモデル一覧」的な教材を作る際の素材になる。

--- a/src/content/ai-news/codex/codex-rust-v0-145-0.mdx
+++ b/src/content/ai-news/codex/codex-rust-v0-145-0.mdx
@@ -1,0 +1,42 @@
+---
+title: "OpenAI Codex rust-v0.145.0：`/import`でClaude Code設定を移行可能に、Bedrock連携・音声入出力・マルチエージェントV2が安定化"
+tool: "codex"
+toolLabel: "OpenAI Codex"
+date: 2026-07-21
+sourceUrl: "https://github.com/openai/codex/releases/tag/rust-v0.145.0"
+summary: "Codex CLIのstableリリース。/importでCursor・Claude Codeの設定・MCPサーバー・プラグイン・セッション・コマンドを移行できるようになり、Claude CodeからCodexへの公式な移行導線が明確化された。ほかAmazon Bedrock連携（experimental）、音声入出力・realtime V3ストリーミング会話、マルチエージェントV2の安定化、スレッド履歴のページネーションを追加。"
+description: "/importでCursor・Claude Code設定の移行に対応、Amazon Bedrockログイン・カスタムエンドポイント対応、音声入出力・realtime V3ストリーミング会話、マルチエージェントV2（サブエージェントのモデル/reasoning/並行数設定）の安定化、スレッド履歴ページネーション。"
+impact: "Claude CodeやCursorからCodexへの移行を検討しているチーム、Amazon Bedrock経由でCodexを使う企業ユーザー、音声インターフェースやマルチエージェント運用を行う開発者に直接影響。"
+tags: ["codex", "import", "bedrock", "voice", "multi-agent", "release"]
+status: "candidate"
+relatedKnowledge:
+  - "/knowledge/ai-tools/codex/vs-claude-code"
+draft: false
+---
+
+## 要約
+
+OpenAI Codex CLIのrust-v0.145.0がstableリリースされました（2026-07-21公開）。前回stable（rust-v0.144.6、2026-07-18）以降のalpha群を集約した大型アップデートです。
+
+最も注目すべき変更は`/import`コマンドの対象拡大です。従来からCursorの設定は移行対象でしたが、今回**Claude Codeの設定・MCPサーバー・プラグイン・セッション・コマンド・プロジェクトスコープのmemoriesも移行できる**ようになりました。これはClaude CodeからCodexへの乗り換えを検討するユーザー向けの公式移行導線が明確化された初めてのケースです。これまで公式に用意されていたのは逆方向（`openai/codex-plugin-cc`によるCodex→Claude Code方向の連携）のみで、Claude Code→Codexはサードパーティ製ツールに頼らざるを得ませんでした。ただし今回追加されたのは片方向のインポート機能であり、双方向にシームレスに行き来できる「簡単移行」を意味するものではない点には注意が必要です。
+
+このほか、Amazon Bedrockへのログインとカスタムエンドポイント・認証対応（experimental、デフォルトモデルはGPT-5.6 Sol）、一般的なローカル音声フォーマットでの音声入力・ツール出力とストリーミングrealtime V3会話、マルチエージェントV2の安定化（サブエージェントのモデル・reasoning水準・並行数を設定可能にし、ロール復元やエージェントナビゲーションも改善、opt-in experimentalから安定版へ移行）、スレッド履歴のページネーション（experimental、検索・永続化された名前・サブエージェント対応・memories機能）、ターミナル上でクリック可能なインライン可視化リンクが追加されています。
+
+## 何が変わったか
+
+- `/import`でCursor・Claude Codeの設定、MCPサーバー、プラグイン、セッション、コマンド、プロジェクトスコープのmemoriesを移行可能に
+- Amazon Bedrockログイン・カスタムエンドポイント対応（experimental、デフォルトはGPT-5.6 Sol）
+- 音声入力・音声ツール出力・realtime V3ストリーミング会話に対応
+- マルチエージェントV2（サブエージェントのモデル/reasoning水準/並行数の設定）が安定版に
+- スレッド履歴のページネーション・検索・memories機能（experimental）
+- ターミナル上でのクリック可能なインライン可視化リンク
+
+## 業務インパクト（一般企業向け）
+
+`/import`によるClaude Code設定の移行は、複数のコーディングエージェントを併用している組織や、ツール標準化を検討している組織にとって乗り換えコストを下げる変更です。ただし片方向インポートである以上、両ツールを併用する運用では設定の同期漏れに注意が必要で、移行手順やチェックリストの整備が引き続き求められます。
+
+Amazon Bedrock連携は、Bedrockを経由したAIツール利用をガバナンスの前提にしている企業にとって、Codexを選択肢に加えやすくする変更です。マルチエージェントV2の安定化は、サブエージェントを使った並行タスク処理をCI/CDや大規模リファクタリングに本格導入する際の信頼性向上につながります。
+
+## 副業・個人活用視点
+
+Claude CodeとCodexを両方試したいが移行コストで踏み切れなかった個人開発者にとって、`/import`は乗り換えのハードルを下げる材料になります。音声入出力対応は、移動中や作業スペースが限られる環境でCodexを使いたい個人ユーザーにとって新しい使いどころです。マルチエージェントV2の安定化により、個人でも複数サブエージェントへの並行委譲を安心して運用に組み込みやすくなります。

--- a/src/content/ai-news/github-copilot/gemini-3-6-flash-in-copilot.mdx
+++ b/src/content/ai-news/github-copilot/gemini-3-6-flash-in-copilot.mdx
@@ -1,0 +1,38 @@
+---
+title: "GitHub CopilotでGemini 3.6 Flashが利用可能に：長時間の自律タスク向けモデルがモデルピッカーに追加"
+tool: "github-copilot"
+toolLabel: "GitHub Copilot"
+date: 2026-07-21
+sourceUrl: "https://github.blog/changelog/2026-07-21-gemini-3-6-flash-is-now-available-in-github-copilot"
+summary: "GitHub CopilotのモデルピッカーにGoogleの最新モデル「Gemini 3.6 Flash」が追加された。Web/アプリ開発、コーディング、長時間の自律的エージェントタスク向けに設計され、reasoning強度の設定・並列ツール呼び出しに対応。早期テストでは前バージョン（3.5）比でタスク完了率とトークン効率が向上したという。Enterprise/Business管理者はチーム利用を許可する前に専用ポリシーを有効化する必要がある。"
+description: "モデルピッカーにGemini 3.6 Flashを追加。reasoning強度設定・並列ツール呼び出しに対応し、3.5比でタスク完了率とトークン効率が向上。Enterprise/Business管理者向けポリシー設定が必要な段階的ロールアウト。"
+impact: "Copilot Pro/Pro+/Max/Business/Enterpriseで利用可能。企業導入では管理者によるポリシー有効化が前提となる。"
+tags: ["github-copilot", "gemini", "model-picker", "enhancement"]
+status: "candidate"
+relatedKnowledge: []
+draft: false
+---
+
+## 要約
+
+GitHub Copilotのモデルピッカーに、Googleの最新モデル「**Gemini 3.6 Flash**」が追加されました（2026-07-21公開）。Web/アプリ開発、コーディング、長時間の自律的エージェントタスク向けに設計されたモデルで、reasoning強度の設定と並列ツール呼び出しに対応しています。GitHubの早期テストでは、前バージョンのGemini 3.5比でタスク完了率とトークン効率が向上したと報告されています。
+
+対応IDE・プラットフォームのモデルピッカーから選択可能で、課金は各プロバイダーのリスト価格に基づく従量制です。Enterprise/Business管理者は、チームメンバーが利用できるようにする前に「Gemini 3.6 Flash Preview」ポリシーを有効化する必要があり、提供は段階的ロールアウトとなっています。
+
+## 何が変わったか
+
+- Copilotのモデルピッカーで Gemini 3.6 Flash を選択可能に
+- reasoning強度の設定・並列ツール呼び出しに対応
+- 早期テストでGemini 3.5比のタスク完了率・トークン効率向上を確認（GitHub報告）
+- 対象プランはCopilot Pro / Pro+ / Max / Business / Enterprise
+- Enterprise/Business管理者は「Gemini 3.6 Flash Preview」ポリシーの有効化が必要
+
+## 業務インパクト（一般企業向け）
+
+Copilotのマルチモデル対応がさらに強化され、コーディングタスクの性質に応じてモデルを使い分ける選択肢が広がります。特に長時間の自律的エージェントタスクに強いモデルという位置づけのため、リファクタリングやテスト生成など時間のかかるタスクをCopilot Agentに任せている組織にとって選択肢が増える形です。
+
+Enterprise/Business環境では管理者によるポリシー有効化が前提となるため、新モデルをチームに展開する際は情シス側での事前設定が必要になります。段階的ロールアウトのため、自社アカウントで実際に選択できるタイミングを確認しておくとよいでしょう。
+
+## 副業・個人活用視点
+
+個人でCopilot Pro/Pro+を利用している開発者は、モデルピッカーからGemini 3.6 Flashを選ぶだけで長時間タスクの効率改善を試せます。特に自律的なエージェントタスク（一括リファクタリングやテストコード生成など）を任せる場面で、既存モデルとの完了率・トークン効率の違いを比較してみる価値があります。


### PR DESCRIPTION
## Summary

- 窓: 2026-07-21T15:55:42 → 2026-07-22T08:58:54 (JST)
- 更新あり: 5件（Claude Code / OpenAI Codex / n8n / GitHub Copilot / OpenAI Status）
- 公開記事化: 2件（OpenAI Codex rust-v0.145.0 / GitHub Copilot Gemini 3.6 Flash対応）
- 見送り: 3件（Claude Codeはパッチリリース範囲 / n8nはバグ修正のみ / OpenAI Statusは同日解消の短時間incident）
- 取得失敗: 0件

## Test plan

- [x] `npm run check` — 0 errors
- [x] 日次サマリーから詳細メモ・公開記事・教材化メモへのリンクが解決
- [x] frontmatter（aiNews / aiNewsNotes スキーマ）に合致
- [x] `daily-ai-update-monitor` と `ai-news-publisher` の SKILL 規約に準拠

🤖 Generated with [Claude Code](https://claude.com/claude-code)