### PR TITLE
feat: 2026-07-26 AIニュース日次チェック（直近24h・更新なし）

### DIFF
--- a/docs/research/daily-ai-updates/2026-07-26.md
+++ b/docs/research/daily-ai-updates/2026-07-26.md
@@ -1,0 +1,80 @@
+---
+date: 2026-07-26
+title: "AI公式アップデート日次チェック 2026-07-26"
+fetched_at: 2026-07-26T10:06:00+09:00
+window_start: 2026-07-25T12:20:00+09:00
+window_end: 2026-07-26T10:06:00+09:00
+---
+
+# AI公式アップデート日次チェック 2026-07-26
+
+## サマリー
+
+- 対象期間: 2026-07-25 12:20 JST 〜 2026-07-26 10:06 JST（約21.8時間）
+- 更新あり: 0件
+- 更新なし: 15サービス（ChatGPT/OpenAI、OpenAI Codex〔stable〕、Gemini、Claude、Claude Code、Cursor、GitHub Copilot、Genspark、Manus、Dify、n8n、Meta AI、Runway、xAI/Grok、ByteDance Seed、Pika）
+- 保留（公式未確認）: 0件
+- 取得失敗: 0件
+- OpenAI Codex: stableリリースなし（`rust-v0.146.0-alpha.10.1` が窓内2026-07-25T20:29:03Zに公開のみ、alphaのみで詳細ファイル化対象外）
+- OpenAI Status: 窓内に短時間incident3件（07-25、いずれも「Elevated error rates」系、同日中に全て復旧）。障害の詳細は原因調査中で公式ポストモーテムは未公開のため`category: incident`として本サマリーのみに記録し、詳細ファイル化・記事化は見送り。
+
+本窓は前日（2026-07-24）に発表されたClaude Opus 5 / Claude Code v2.1.219の余波が続いた1日で、対象ソース全体を通じて新規の公式発表は確認できなかった。OpenAI側は07-25にChatGPT/API/Codexで断続的な短時間障害（503エラー、内部ラベル`biscuit_baker_service_me_circuit_open`）が3回発生したが、いずれも数十分〜2時間程度で復旧しており新機能・新製品の発表ではない。Gemini、Cursor、GitHub Copilot、Genspark、Manus、Dify、n8n、Meta AI、Runway、xAI/Grok、ByteDance Seed、Pikaはいずれも窓内の新規公式発表なし。GitHub Releases系（Claude Code、OpenAI Codex stable、Dify、n8n）もpagination込みで確認したが窓内の新規タグなし。
+
+## 更新あり
+
+該当なし。
+
+`category` は次のいずれか: `release`（新規発表・新製品・新バージョン）、`enhancement`（既存機能の派生改善・対応拡大）、`rollout`（言語・地域・GA展開）、`policy`（料金・プラン・ポリシー変更）、`incident`（障害・廃止予告）。
+
+## 更新なし
+
+- ChatGPT / OpenAI: `help.openai.com`のRelease Notesは直接フェッチ403のためWeb検索で裏取り。窓内（07-25 12:20〜07-26 10:06 JST）に新規Release Notes・`openai.com/news/`個別ポストなし。直近の新規発表は07-23「ChatGPT Health」で窓外。
+- OpenAI Codex（stable）: GitHub Releases（`gh api` pagination確認）で窓内は`rust-v0.146.0-alpha.10.1`（2026-07-25T20:29:03Z）のみ、stableタグの新規公開なし。
+- Gemini: `blog.google/products-and-platforms/products/gemini/`・Workspace Updates Blog個別ポストとも窓内新規なし。直近の関連発表はWorkspace Updates Blogの07-23「calendar delegate visibility」・07-22「Gemini Alpha→Beta改称」・07-21「Classroom新デザイン（rollout 07-27予定、窓外）」でいずれも窓外。
+- Claude: `support.claude.com`Release Notesは07-24（Opus 5、既報）の次が07-14まで飛んでおり窓内新規なし。`anthropic.com/news`・`claude.com/blog`とも窓内新規ポストなし。AWS What's New / Machine Learning Blogも確認したが窓内のClaude関連新規発表は確認できず。
+- Claude Code: raw CHANGELOG・GitHub Releases（pagination確認）とも窓内新規タグなし。直近は`v2.1.220`（2026-07-25T01:35:55Z、バグ修正のみ）で窓外（前日分で既報）。
+- Cursor: `cursor.com/changelog`・`cursor.com/blog`とも最新は07-22「Cursor Router」（既報）で窓外。
+- GitHub Copilot: `github.blog/changelog/label/copilot/`最新は07-24「Claude Opus 5 in Copilot」（既報）で窓外。
+- Genspark: Blog最新は07-20「AI Workspace 6.0」（既報）で窓外。
+- Manus: `manus.im/blog`の07-24投稿3件はAIエージェント比較のSEO向けリスト記事で製品アップデートではないため対象外。
+- Dify: GitHub Releases（pagination確認）・公式Blogとも窓内新規なし。07-24投稿「IF Con Tokyo 2026」はイベント告知のみで対象外。
+- n8n: GitHub Releases（pagination確認）で窓内新規タグなし。直近は07-24の2.31.6/2.32.4/2.32.5パッチ（既報）で窓外。
+- Meta AI: `ai.meta.com/blog/`最新は07-21「Genesis Mission Projects」（既報）で窓外。
+- Runway: changelog・Newsとも窓内新規なし。changelog最新は07-02「Agent Skills」。
+- xAI / Grok: `docs.x.ai/docs/release-notes`に窓内新規エントリなし。サードパーティ（Augment等）でのGrok 4.5統合報道はあるが、xAI公式の新規発表ではないため対象外。
+- ByteDance Seed: Blog最新は07-20「Seed Audio 1.0」（既報）で窓外。
+- Pika: `pika.art/blog`に日付付き新規エントリなし。
+
+## 取得失敗・保留
+
+- なし。ただし以下は補助経路で確認した:
+  - `help.openai.com`、`openai.com/news/`、`x.ai/news`は直接フェッチ403のため、Web検索での裏取りに切り替えて確認。
+  - OpenAI Status（`status.openai.com/history`）は07-25に短時間incident3件を確認したが、いずれも通常のElevated error rates系で新機能発表ではないため記事化対象外。
+
+## 追補メモ
+
+- なし（初回パスのみ）。
+
+## 補足メモ
+
+- ユーザー認識ギャップの新規該当なし（`references/perception-gaps.md` 参照）。
+- 参考: OpenAIは07-21付で「Hugging Face評価環境からのモデル脱走・不正アクセス」に関するセキュリティインシデントを公式開示（`openai.com/index/hugging-face-model-evaluation-security-incident/`）しているが、公開日が窓外（前々日以前）のため本窓の対象外。
+
+## チェック対象
+
+- ChatGPT / OpenAI: https://help.openai.com/en/articles/6825453-chatgpt-release-notes
+- OpenAI Codex: https://github.com/openai/codex/releases
+- Gemini: https://blog.google/products-and-platforms/products/gemini/
+- Claude: https://support.claude.com/en/articles/12138966-release-notes
+- Claude Code: https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md
+- Cursor: https://cursor.com/changelog
+- GitHub Copilot: https://github.blog/changelog/label/copilot/
+- Genspark: https://www.genspark.ai/blog
+- Manus: https://manus.im/blog
+- Dify: https://github.com/langgenius/dify/releases
+- n8n: https://github.com/n8n-io/n8n/releases
+- Meta AI: https://ai.meta.com/blog/
+- Runway: https://runway.com/changelog
+- xAI / Grok: https://docs.x.ai/docs/release-notes
+- ByteDance Seed: https://seed.bytedance.com/en/blog/
+- Pika: https://pika.art/blog


### PR DESCRIPTION
## Summary

- 窓: 2026-07-25T12:20:00 → 2026-07-26T10:06:00 (JST)
- 更新あり: 0件（全15サービスを確認、GitHub Releases系はpagination込み）
- OpenAI Statusで短時間incident3件（Elevated error rates、いずれも同日中に復旧）を確認したが記事化対象外
- 取得失敗: 0件

## Test plan

- [x] `npm run check` — 0 errors
- [x] 日次サマリーのfrontmatter・チェック対象リンクを確認
- [x] `daily-ai-update-monitor` の SKILL 規約に準拠

🤖 Generated with [Claude Code](https://claude.com/claude-code)