### PR TITLE
feat: 2026-07-27 AIニュース日次チェック（直近24h・更新なし）

### DIFF
--- a/docs/research/daily-ai-updates/2026-07-27.md
+++ b/docs/research/daily-ai-updates/2026-07-27.md
@@ -1,0 +1,80 @@
+---
+date: 2026-07-27
+title: "AI公式アップデート日次チェック 2026-07-27"
+fetched_at: 2026-07-27T10:43:14+09:00
+window_start: 2026-07-26T10:06:00+09:00
+window_end: 2026-07-27T10:43:14+09:00
+---
+
+# AI公式アップデート日次チェック 2026-07-27
+
+## サマリー
+
+- 対象期間: 2026-07-26 10:06 JST 〜 2026-07-27 10:43 JST（約24.6時間）
+- 更新あり: 0件
+- 更新なし: 15サービス（ChatGPT/OpenAI、OpenAI Codex〔stable〕、Gemini、Claude、Claude Code、Cursor、GitHub Copilot、Genspark、Manus、Dify、n8n、Meta AI、Runway、xAI/Grok、ByteDance Seed、Pika）
+- 保留（公式未確認）: 0件
+- 取得失敗: 0件
+- OpenAI Codex: stableリリースなし（`rust-v0.146.0-alpha.10.1` が2026-07-25T20:29:03Z公開が最新で窓外、alphaのみで詳細ファイル化対象外）
+- OpenAI Status: 窓内に新規incidentなし。07-25 23:57時点開始の「Elevated errors affecting ChatGPT conversations」は監視継続中の記載があったが、開始時刻が窓外（前日分）で新規発生ではないため対象外。
+
+本窓は対象ソース全体を通じて新規の公式発表を確認できなかった。GitHub Releases系（Claude Code、OpenAI Codex stable、Dify、n8n）はいずれもpagination込みで確認したが、窓内の新規タグはなし。Claude Code最新`v2.1.220`（2026-07-25T01:35:55Z）、n8n最新`n8n@2.32.5`/`beta`（2026-07-24T18:03:53Z）、Dify最新`1.16.0`（2026-07-17）はいずれも窓外。ChatGPT/OpenAIはhelp.openai.comとopenai.com/news系が直接フェッチ403のためWeb検索で裏取りしたが、窓内新規なし（直近の関連発表はGPT-5.6系が07-09、OpenAI Presenceが07-22でいずれも窓外）。Gemini、Claude、Cursor、GitHub Copilot、Genspark、Manus、Dify、n8n、Meta AI、Runway、xAI/Grok、ByteDance Seed、Pikaはいずれも窓内の新規公式発表なし。
+
+## 更新あり
+
+該当なし。
+
+`category` は次のいずれか: `release`（新規発表・新製品・新バージョン）、`enhancement`（既存機能の派生改善・対応拡大）、`rollout`（言語・地域・GA展開）、`policy`（料金・プラン・ポリシー変更）、`incident`（障害・廃止予告）。
+
+## 更新なし
+
+- ChatGPT / OpenAI: `help.openai.com`・`openai.com/news/`とも直接フェッチ403のためWeb検索で裏取り。窓内（07-26 10:06〜07-27 10:43 JST）に新規Release Notes・個別ポストなし。直近の関連発表はGPT-5.6 Sol/Terra/Luna（07-09）、OpenAI Presence（07-22）、ChatGPT for small businesses（日付未特定だが少なくとも07-22以前）でいずれも窓外。
+- OpenAI Codex（stable）: GitHub Releases（`gh api` pagination確認）で窓内は新規タグなし。最新は`rust-v0.146.0-alpha.10.1`（2026-07-25T20:29:03Z、alphaのみ）で窓外。
+- Gemini: `blog.google/products-and-platforms/products/gemini/`確認したが窓内該当日付の投稿なし。Workspace Updates Blogは最新個別ポストが07-23「calendar delegate visibility」、07-22「Meet notes/transcripts自動整理」「Gemini Alpha→Beta改称」、07-21「Classroom新デザイン（rollout 07-27予定）」でいずれも公開日は窓外（Classroomのrollout開始日07-27は窓内該当の可能性があるが、rollout実施の一次確認ソースが個別ポスト上の予告のみで新規発表ではないため見送り）。
+- Claude: `support.claude.com`Release Notesの最新見出しは07-24（Opus 5、既報）で窓内新規日付なし。`claude.com/blog`・`anthropic.com/news`もWeb検索で確認したが窓内新規ポストなし。AWS What's New / Machine Learning Blogも確認したが、直近のClaude関連発表は07-24「Claude Opus 5 on AWS Bedrock/Claude Platform」で窓外。
+- Claude Code: raw CHANGELOG・GitHub Releases（pagination確認）とも窓内新規タグなし。最新`v2.1.220`（2026-07-25T01:35:55Z、バグ修正のみ）で窓外。
+- Cursor: `cursor.com/changelog`最新は07-22「Cursor Router」（既報）で窓外。
+- GitHub Copilot: `github.blog/changelog/label/copilot/`最新は07-24「Claude Opus 5 in Copilot」（既報）で窓外。
+- Genspark: Blog最新は07-20「AI Workspace 6.0」（既報）で窓外。
+- Manus: Blog最新は07-24のAIエージェント比較系SEO記事3本（製品アップデートではないため対象外）。直近の製品発表は07-22「Plan Mode」で窓外。
+- Dify: GitHub Releases（pagination確認）・公式Blogとも窓内新規なし。最新リリースは`1.16.0`（2026-07-17）で窓外。
+- n8n: GitHub Releases（pagination確認、50件取得しソート確認）で窓内新規タグなし。最新は`n8n@2.32.5`/`beta`（2026-07-24T18:03:53Z）で窓外。
+- Meta AI: `ai.meta.com/blog/`最新は07-21「Genesis Mission Projects」（既報）で窓外。
+- Runway: `runway.com/changelog`最新は07-02「Agent Skills」で窓外。News個別ポスト日付は取得できなかったが、changelog側に窓内更新の兆候なし。
+- xAI / Grok: `docs.x.ai/docs/release-notes`直接フェッチで窓内新規エントリなし（`x.ai/news`は403のためWeb検索で裏取り、Outlook/Google Workspace連携等の言及があるが窓内の新規公式日付は特定できず）。
+- ByteDance Seed: Blog最新は07-20「Seed Audio 1.0」（既報）で窓外。
+- Pika: `pika.art/blog`が実質更新なし（旧コンテンツのみ表示）。日付付き新規エントリなし。
+
+## 取得失敗・保留
+
+- なし。ただし以下は補助経路で確認した:
+  - `help.openai.com`、`openai.com/news/`、`openai.com/news/company-announcements/`、`openai.com/news/product-releases/`、`x.ai/news`は直接フェッチ403のため、Web検索での裏取りに切り替えて確認。
+  - `runway.com/news`は本文取得できずナビゲーションのみ返却。changelog側で窓内更新なしを確認済みのため保留扱いとせず対象外とした。
+
+## 追補メモ
+
+- なし（初回パスのみ）。
+
+## 補足メモ
+
+- ユーザー認識ギャップの新規該当なし（`references/perception-gaps.md` 参照）。
+- Web検索結果に「GPT-5.6 SolがHugging Face評価環境をサンドボックス脱走して侵害した」という趣旨の記述が混在していたが、これは07-09のGPT-5.6発表と07-21付の別件セキュリティインシデント公式開示（`openai.com/index/hugging-face-model-evaluation-security-incident/`、前日分で既報）が検索要約上で混同された可能性が高い。いずれにせよ両事象とも公開日が窓外のため本日は記録対象外。次回以降の巡回でGPT-5.6と紐づけた誤情報が独立して言及される場合は`references/perception-gaps.md`へのエントリ化を検討する。
+
+## チェック対象
+
+- ChatGPT / OpenAI: https://help.openai.com/en/articles/6825453-chatgpt-release-notes
+- OpenAI Codex: https://github.com/openai/codex/releases
+- Gemini: https://blog.google/products-and-platforms/products/gemini/
+- Claude: https://support.claude.com/en/articles/12138966-release-notes
+- Claude Code: https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md
+- Cursor: https://cursor.com/changelog
+- GitHub Copilot: https://github.blog/changelog/label/copilot/
+- Genspark: https://www.genspark.ai/blog
+- Manus: https://manus.im/blog
+- Dify: https://github.com/langgenius/dify/releases
+- n8n: https://github.com/n8n-io/n8n/releases
+- Meta AI: https://ai.meta.com/blog/
+- Runway: https://runway.com/changelog
+- xAI / Grok: https://docs.x.ai/docs/release-notes
+- ByteDance Seed: https://seed.bytedance.com/en/blog/
+- Pika: https://pika.art/blog


### PR DESCRIPTION
## Summary

- 窓: 2026-07-26T10:06:00 → 2026-07-27T10:43:14 (JST)
- 更新あり: 0件（全15サービスを確認、GitHub Releases系はpagination込み）
- 取得失敗: 0件

## Test plan

- [x] `npm run check` — 0 errors
- [x] 日次サマリーのfrontmatter・チェック対象リンクを確認
- [x] `daily-ai-update-monitor` の SKILL 規約に準拠

🤖 Generated with [Claude Code](https://claude.com/claude-code)