### PR TITLE
feat: 2026-08-03 AIニュース日次チェック（直近24h・更新なし）

### DIFF
--- a/.claude/skills/daily-ai-update-monitor/references/research-learnings.md
+++ b/.claude/skills/daily-ai-update-monitor/references/research-learnings.md
@@ -139,3 +139,10 @@
 - **原因**: `openai.com/news/` と `help.openai.com` が直接フェッチ403のため、代替として `learn.chatgpt.com/docs/changelog` と OpenAI Status のみを見ていた。`learn.chatgpt.com` は ChatGPT / Codex のプロダクト更新は載るが、API の価格改定は載らない。403 のときに代替ソースが1系統に絞られ、`openai.com/index/<slug>` 側の発表が丸ごと死角になった。
 - **対処**: `openai.com` が403の窓では、`learn.chatgpt.com` の確認に加えて価格・モデル系のWeb検索（例: `OpenAI price OR pricing OR deprecation <YYYY-MM> site:openai.com`）を最低1本走らせる。二次ソース（Axios / CNBC / VentureBeat 等）で発表を見つけたら一次 URL を逆引きして記録する。
 - **カタログ取り込み**: 未（次月レビューで source-catalog.md の「ソース別の注意」へ昇格を検討）。
+
+### 学び6: Runway の公式ドメインが `runwayml.com` → `runway.com` へ移行
+
+- **検知**: 2026-08-03 の巡回で `https://runwayml.com/changelog` が `https://runway.com/changelog` へ 308 Permanent Redirect。
+- **原因**: source-catalog に旧ドメイン（`runwayml.com`）が主ソースとして記載されたまま。リダイレクトが追従されない取得方法だと、1回のフェッチが空振りして「取得失敗」に計上されうる。
+- **対処**: Runway の主ソースは `https://runway.com/changelog`、News は `https://runway.com/news` を先に踏む。`docs.dev.runwayml.com/api-details/api_changelog/`（Runway Dev API changelog）は 2026-08-03 時点で旧ドメインのままのため、両ドメインが並存している前提で扱う。
+- **カタログ取り込み**: 未（次月レビューで source-catalog.md の Runway 行を新ドメインへ差し替え）。

--- a/docs/research/daily-ai-updates/2026-08-03.md
+++ b/docs/research/daily-ai-updates/2026-08-03.md
@@ -1,0 +1,72 @@
+---
+date: 2026-08-03
+title: "AI公式アップデート日次チェック 2026-08-03"
+fetched_at: 2026-08-03T14:35:00+09:00
+window_start: 2026-08-02T18:10:00+09:00
+window_end: 2026-08-03T14:35:00+09:00
+---
+
+# AI公式アップデート日次チェック 2026-08-03
+
+## サマリー
+
+- 対象期間: 2026-08-02 18:10 JST 〜 2026-08-03 14:35 JST（約20.4時間）
+- 更新あり: 0件
+- 更新なし: 16サービス（全対象）
+- 保留（公式未確認）: 0件
+- 取得失敗: 0件（`openai.com/news/` は直接フェッチ403だが、`developers.openai.com/api/docs/changelog`、`learn.chatgpt.com/docs/changelog`、価格・モデル系のWeb検索で代替確認できたため計上しない）
+- OpenAI Codex: 窓内に stable / alpha とも新規タグなし。最新は `rust-v0.147.0-alpha.4`（2026-07-31T17:54:49Z）で窓開始前。最新 stable は `rust-v0.146.0`（2026-07-29T01:42:51Z）。
+- OpenAI Status: 窓内 incident なし（"We're fully operational"）。
+
+窓は前日サマリー（2026-08-02）の `window_end` を起点にした約20.4時間。**窓が 2026-08-02（日）夕方〜08-03（月）昼過ぎ JST に収まっており、米国側では日曜日中に相当するため、全ベンダーが窓内に公式発表を出していない**。2026-08-02 に続き2日連続の無更新だが、`ほぼ毎日` カテゴリ（Claude Code、GitHub Copilot、n8n、OpenAI Codex）はいずれも一次ソースの取得自体に成功しており、直近タグ・直近エントリの日付が窓開始前であることを確認済みのため、ソース取得失敗ではなく実際の無更新と判断する。月曜日の JST 夕方以降に米国側の発表が出る可能性が高いため、翌日（2026-08-04）の窓で拾う。
+
+## 更新あり
+
+なし。
+
+## 更新なし
+
+- ChatGPT / OpenAI: `developers.openai.com/api/docs/changelog` の最新は 2026-07-30（GPT-5.6 の値下げと Fast mode）で窓外。`learn.chatgpt.com/docs/changelog` の最新も 2026-07-31（Codex からの GPT-5.4 / 5.4 mini 退役告知、2026-08-31 予定）で処理済み。`openai.com/index/<slug>` 側も窓内の新規発表を確認できず。
+- OpenAI Codex: GitHub Releases を pagination 込みで確認。窓内タグなし。alpha を含めた最新は 2026-07-31T17:54:49Z。
+- Gemini: `blog.google` の Gemini 面は最新が「Gemini Spark: new Chrome browsing integration」（2026-07-31、Google AI Pro の160カ国以上への拡大を含む）で窓外。Workspace Updates Blog も最新は 2026-07-31 の週次Recap で、個別ポストは 2026-07-30 の Gmail Reply All BCC 警告 / Google Forms のクイズ生成が最後。窓内の新規なし。
+- Claude: 公式Release Notes（`support.claude.com`）の最新日付見出しは 2026-07-24（Claude Opus 5）。`anthropic.com/news` の最新は 2026-07-30、`claude.com/blog` は 2026-07-28（MCP 2026-07-28 対応）。AWS 側（`aws.amazon.com` 逆引き）も窓内の Claude Platform / Bedrock 関連の新規発表なし。
+- Claude Code: GitHub Releases・raw CHANGELOG とも窓内タグなし。最新は `v2.1.220`（2026-07-25T01:35:55Z）。
+- Cursor: `cursor.com/changelog` の最新は「Cursor, now on iPad」（2026-07-29）で窓外。
+- GitHub Copilot: `github.blog/changelog/label/copilot/` の最新エントリは 2026-07-31（Gemini 2.5 Pro / Gemini 3 Flash の廃止、Enterprise 向けモデルポリシー指定の public preview）で処理済み。窓内の新規エントリなし。
+- Genspark: Blog最新は「How This Educator Built 13 Apps, Websites, and Simulations Without Writing a Single Line of Code」（2026-07-30）で窓外。
+- Manus: Blog最新は「Build, Migrate, and Operate Your Supabase Database with Manus」（2026-07-24）で窓外。
+- Dify: GitHub Releases 最新 `1.16.1`（2026-07-28T03:43:51Z）は窓外。公式Blogも窓内新規なし。
+- n8n: GitHub Releases を pagination 込みで確認。最新は `n8n@2.32.7`（stable、2026-07-31T07:56:03Z）と `n8n@2.33.3`（beta、2026-07-31T07:57:44Z）で、いずれも処理済み。窓内の新規リリースなし。
+- Meta AI: Blog最新は「Reimagining Independence」（2026-07-27）で窓外。
+- Runway: changelog の最新は「Runway Agent Skills」（2026-07-02）で窓外。News 面にも窓内投稿なし。
+- xAI / Grok: `docs.x.ai/docs/release-notes` の最新は `grok-imagine-video-1.5` および `grok-voice-think-fast-2.0`（いずれも2026年7月）で窓外。なお `grok-voice-latest` のルーティング切り替えは 2026-08-05 予定と告知されており、当日の窓で拾う。
+- ByteDance Seed: Blog最新は「One-take Creation, Flexible Referencing: Introducing Seedance 2.5」（2026-07-31）で窓外。
+- Pika: 公式Blogに日付付きの新規投稿なし（表示される最新は 2024-06-05）。トップページ観測でも窓内の更新を確認できず。
+
+## 取得失敗・保留
+
+なし。
+
+## 補足メモ
+
+- Runway の公式ドメインが `runwayml.com` → `runway.com` へ移行していることを確認（`runwayml.com/changelog` が 308 Permanent Redirect）。`docs.dev.runwayml.com` 側は旧ドメインのまま並存。詳細は `.claude/skills/daily-ai-update-monitor/references/research-learnings.md` の「学び6」を参照。
+- ユーザー認識ギャップの新規該当なし。
+
+## チェック対象
+
+- ChatGPT / OpenAI: https://learn.chatgpt.com/docs/changelog 、https://developers.openai.com/api/docs/changelog 、https://openai.com/news/ 、https://status.openai.com/
+- OpenAI Codex: https://github.com/openai/codex/releases
+- Gemini: https://blog.google/products-and-platforms/products/gemini/ 、https://workspaceupdates.googleblog.com/
+- Claude: https://support.claude.com/en/articles/12138966-release-notes 、https://www.anthropic.com/news 、https://claude.com/blog 、https://aws.amazon.com/about-aws/whats-new/
+- Claude Code: https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md 、https://github.com/anthropics/claude-code/releases
+- Cursor: https://cursor.com/changelog
+- GitHub Copilot: https://github.blog/changelog/label/copilot/
+- Genspark: https://www.genspark.ai/blog
+- Manus: https://manus.im/blog
+- Dify: https://github.com/langgenius/dify/releases
+- n8n: https://github.com/n8n-io/n8n/releases
+- Meta AI: https://ai.meta.com/blog/
+- Runway: https://runway.com/changelog
+- xAI / Grok: https://docs.x.ai/docs/release-notes
+- ByteDance Seed: https://seed.bytedance.com/en/blog/
+- Pika: https://pika.art/blog


### PR DESCRIPTION
## Summary

- 窓: 2026-08-02T18:10 → 2026-08-03T14:35 (JST、約20.4時間)
- 更新あり: 0件
- 公開記事化: 0件（更新ゼロのため速報記事・教材化メモとも作成なし）
- 見送り: 0件
- 取得失敗: 0件（`openai.com/news/` は直接フェッチ403だが、`developers.openai.com/api/docs/changelog`、`learn.chatgpt.com/docs/changelog`、価格・モデル系Web検索で代替確認）

窓が 2026-08-02（日）夕方〜08-03（月）昼過ぎ JST に収まり、米国側では日曜日中に相当するため全16サービスで窓内の公式発表なし。`ほぼ毎日` カテゴリ（Claude Code / GitHub Copilot / n8n / OpenAI Codex）も一次ソースの取得自体は成功しており、直近タグ・エントリの日付が窓開始前であることを確認済みのため、取得失敗ではなく実際の無更新と判断。

### 補足

- Runway の公式ドメインが `runwayml.com` → `runway.com` へ移行（308 リダイレクト）していることを検知したため、`research-learnings.md` に「学び6」として追記（`source-catalog.md` への反映は次月レビュー対象）。
- xAI の `grok-voice-latest` ルーティング切り替えは 2026-08-05 予定の告知あり。当日の窓で拾う。

## Test plan

- [x] `npm run check` — 0 errors（warnings 0 / hints 40）
- [x] 日次サマリーのリンク・チェック対象URLが解決
- [x] frontmatter が `output-format.md` の日次サマリーテンプレートに合致
- [x] `daily-ai-update-monitor` と `ai-news-publisher` の SKILL 規約に準拠

🤖 Generated with [Claude Code](https://claude.com/claude-code)