### PR TITLE
refactor: デザイントークンとプリミティブを刷新し、全ページから装飾を除去

### DIFF
--- a/src/components/ai-news/ArchiveSelect.astro
+++ b/src/components/ai-news/ArchiveSelect.astro
@@ -21,7 +21,7 @@ const { months, currentMonth } = Astro.props;
   <select
     id="ai-news-archive-select"
     data-archive-select
-    class="w-full rounded-lg border border-border bg-white px-3 py-2 text-sm text-foreground"
+    class="w-full rounded-[4px] border border-border bg-white px-3 py-2 text-sm text-foreground"
   >
     <option value="/ai-news" selected={currentMonth === undefined}>
       最新のニュース

--- a/src/components/ai-news/NewsCard.astro
+++ b/src/components/ai-news/NewsCard.astro
@@ -34,7 +34,7 @@ const formattedDate = date.toLocaleDateString("ja-JP", {
 const displayTags = tags.slice(0, 3);
 ---
 
-<Card hover class="h-full rounded-2xl">
+<Card hover class="h-full">
   <article class="flex h-full flex-col gap-4">
     <div class="flex items-center gap-2 flex-wrap">
       <Badge variant="teal">{toolLabel}</Badge>

--- a/src/components/islands/ContactForm.tsx
+++ b/src/components/islands/ContactForm.tsx
@@ -72,12 +72,12 @@ export default function ContactForm() {
   };
 
   const inputClasses =
-    "w-full px-4 py-2.5 rounded-lg border border-gray-200 bg-white text-foreground text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-teal-500/20 focus:border-teal-500/50 transition-colors";
+    "w-full px-4 py-2.5 rounded-[4px] border border-gray-200 bg-white text-foreground text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:border-primary/30 focus:border-teal-500/50 transition-colors";
   const errorInputClasses =
-    "w-full px-4 py-2.5 rounded-lg border border-red-300 bg-white text-foreground text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-red-500/20 focus:border-red-500/50 transition-colors";
+    "w-full px-4 py-2.5 rounded-[4px] border border-red-300 bg-white text-foreground text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-red-500/20 focus:border-red-500/50 transition-colors";
 
   return (
-    <div className="glass rounded-2xl p-6">
+    <div className="border border-border p-6">
       <form onSubmit={handleSubmit} className="space-y-4" noValidate>
         <div>
           <label
@@ -147,7 +147,7 @@ export default function ContactForm() {
         <button
           type="submit"
           disabled={status === "sending"}
-          className="w-full bg-gradient-to-r from-teal-500 to-emerald-500 hover:from-teal-600 hover:to-emerald-600 text-white border-0 shadow-lg shadow-teal-500/25 py-3 rounded-lg text-sm font-medium transition-all disabled:opacity-60 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+          className="w-full bg-primary hover:bg-accent text-white border-0 py-3 rounded-[4px] text-sm font-medium transition-all disabled:opacity-60 disabled:cursor-not-allowed flex items-center justify-center gap-2"
         >
           {status === "sending" ? (
             "送信中..."

--- a/src/components/islands/MobileMenu.tsx
+++ b/src/components/islands/MobileMenu.tsx
@@ -35,7 +35,7 @@ export default function MobileMenu({ navItems, currentPath }: Props) {
   };
 
   const linkClass = (href: string) =>
-    `px-4 py-3 text-sm rounded-lg transition-colors ${
+    `px-4 py-3 text-sm rounded-[4px] transition-colors ${
       currentPath === href
         ? "text-foreground font-medium bg-gray-50"
         : "text-muted-foreground hover:text-foreground hover:bg-gray-100"
@@ -122,9 +122,7 @@ export default function MobileMenu({ navItems, currentPath }: Props) {
                       >
                         {item.label}
                         <svg
-                          className={`w-4 h-4 transition-transform ${
-                            expandedKey === item.label ? "rotate-180" : ""
-                          }`}
+                          className={`w-4 h-4 transition-transform ${ expandedKey === item.label ? "rotate-180" : "" }`}
                           fill="none"
                           stroke="currentColor"
                           viewBox="0 0 24 24"
@@ -168,7 +166,7 @@ export default function MobileMenu({ navItems, currentPath }: Props) {
                   <a
                     href="/contact"
                     onClick={closeMenu}
-                    className="block w-full text-center bg-gradient-to-r from-teal-500 to-emerald-500 hover:from-teal-600 hover:to-emerald-600 text-white rounded-lg px-4 py-2.5 text-sm font-medium transition-all"
+                    className="block w-full text-center bg-primary hover:bg-accent text-white rounded-[4px] px-4 py-2.5 text-sm font-medium transition-all"
                   >
                     お問い合わせ
                   </a>

--- a/src/components/knowledge/CategoryCard.astro
+++ b/src/components/knowledge/CategoryCard.astro
@@ -26,7 +26,7 @@ const iconMap: Record<string, string> = {
   <Card hover class="h-full">
     <div class="flex items-start gap-4">
       <div
-        class="w-12 h-12 rounded-2xl bg-gradient-to-br from-teal-500 to-emerald-500 flex items-center justify-center text-2xl shrink-0"
+        class="w-12 h-12 bg-secondary flex items-center justify-center text-2xl shrink-0"
       >
         {iconMap[category.icon] ?? "📄"}
       </div>

--- a/src/components/sections/About.astro
+++ b/src/components/sections/About.astro
@@ -8,7 +8,7 @@
     </div>
 
     <div class="max-w-3xl mx-auto">
-      <div class="glass rounded-2xl p-8">
+      <div class="border border-border p-8">
         <p class="text-muted-foreground leading-relaxed mb-4">
           中小企業向けのAI活用伴走支援を専門としています。AIツールの使い方指導ではなく、「何から始めるべきか」「どこにAIを適用すべきか」といった意思決定の整理から入り、PoC・導入・運用までを一貫してサポートします。
         </p>

--- a/src/components/sections/Career.astro
+++ b/src/components/sections/Career.astro
@@ -10,7 +10,7 @@ import Badge from "@/components/ui/Badge.astro";
 
     <div class="relative">
       <div
-        class="absolute left-4 top-0 bottom-0 w-px bg-gradient-to-b from-teal-500/50 via-emerald-500/50 to-transparent hidden sm:block"
+        class="absolute left-4 top-0 bottom-0 w-px bg-border hidden sm:block"
       >
       </div>
 
@@ -18,11 +18,11 @@ import Badge from "@/components/ui/Badge.astro";
         {
           careerExperiences.map((exp, index) => (
             <div
-              class={`relative sm:pl-12 `}
+              class={`relative sm:pl-12`}
             >
               <div class="absolute left-4 top-6 w-3 h-3 rounded-full bg-teal-500 -translate-x-1.5 hidden sm:block ring-4 ring-background z-10" />
 
-              <div class="glass rounded-2xl p-5 sm:p-6 transition-all duration-300 hover:border-teal-500/20">
+              <div class="border border-border p-5 sm:p-6 transition-all duration-300 hover:border-teal-500/20">
                 <div class="flex flex-wrap items-start justify-between gap-3 mb-3">
                   <div class="flex-1 min-w-0">
                     <div class="flex items-center gap-2 text-xs text-muted-foreground mb-1">

--- a/src/components/sections/Cases.astro
+++ b/src/components/sections/Cases.astro
@@ -19,7 +19,7 @@ const featuredCases = caseStudies.slice(0, 3);
         featuredCases.map((caseStudy, i) => (
           <a
             href={`/cases/${caseStudy.slug}`}
-            class={`block bg-card/95 ring-1 ring-gray-950/5 shadow-sm rounded-3xl p-6 transition-all duration-300 group hover:ring-teal-500/20 hover:shadow-md `}
+            class={`block border border-border p-6 transition-all duration-300 group hover:border-primary/40`}
           >
             <div class="flex items-center gap-2 mb-3 flex-wrap">
               <Badge variant="teal">{caseStudy.category}</Badge>

--- a/src/components/sections/Contact.astro
+++ b/src/components/sections/Contact.astro
@@ -34,7 +34,7 @@ const activeSocialLinks = socialLinks.filter((l) => !l.comingSoon);
 
         <div class="space-y-3">
           <div class="flex items-center gap-3 text-sm text-muted-foreground">
-            <div class="w-9 h-9 rounded-lg bg-teal-500/10 flex items-center justify-center flex-shrink-0">
+            <div class="w-9 h-9 rounded-[4px] bg-teal-500/10 flex items-center justify-center flex-shrink-0">
               <svg class="w-4 h-4 text-teal-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <rect width="20" height="16" x="2" y="4" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/>
               </svg>
@@ -52,7 +52,7 @@ const activeSocialLinks = socialLinks.filter((l) => !l.comingSoon);
                 href={link.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                class="w-10 h-10 rounded-lg bg-gray-100 hover:bg-teal-500/10 flex items-center justify-center text-muted-foreground hover:text-teal-600 transition-colors"
+                class="w-10 h-10 rounded-[4px] bg-gray-100 hover:bg-teal-500/10 flex items-center justify-center text-muted-foreground hover:text-teal-600 transition-colors"
                 aria-label={link.name}
               >
                 <Fragment set:html={iconMap[link.icon] || ""} />

--- a/src/components/sections/Cta.astro
+++ b/src/components/sections/Cta.astro
@@ -4,19 +4,13 @@ import Button from "@/components/ui/Button.astro";
 
 <section class="py-20">
   <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-    <div class="relative overflow-hidden rounded-3xl p-8 sm:p-12 text-center">
-      <!-- Gradient background -->
-      <div class="absolute inset-0 bg-gradient-to-br from-yellow-50 via-pink-50 to-purple-50"></div>
-      <div class="absolute top-0 left-1/4 w-64 h-64 bg-gradient-to-br from-yellow-200/40 via-pink-200/30 to-transparent rounded-full blur-3xl"></div>
-      <div class="absolute bottom-0 right-1/4 w-64 h-64 bg-gradient-to-br from-purple-200/30 via-teal-200/20 to-transparent rounded-full blur-3xl"></div>
-
-      <div class="relative z-10">
-        <h2 class="text-2xl sm:text-3xl lg:text-4xl font-bold text-foreground mb-4">
+    <div class="border-t border-border pt-12">
+      <div>
+        <h2 class="text-2xl sm:text-3xl font-bold text-foreground mb-4">
           プロジェクトについて
-          <br class="sm:hidden" />
-          <span class="gradient-text">ご相談ください</span>
+              ご相談ください
         </h2>
-        <p class="text-muted-foreground mb-8 max-w-xl mx-auto">
+        <p class="text-muted-foreground mb-8 max-w-xl">
           Web開発・AI導入・セミナーなど、お気軽にお問い合わせください。
           初回のご相談は無料です。
         </p>

--- a/src/components/sections/Difference.astro
+++ b/src/components/sections/Difference.astro
@@ -23,14 +23,14 @@ import SectionHeader from "@/components/ui/SectionHeader.astro";
               {item.aspect}
             </div>
 
-            <div class="rounded-2xl bg-gray-50 ring-1 ring-gray-950/5 p-5">
+            <div class="bg-gray-50 border border-border p-5">
               <div class="text-xs text-muted-foreground mb-2">一般的な外注</div>
               <p class="text-sm text-muted-foreground leading-relaxed">
                 {item.others}
               </p>
             </div>
 
-            <div class="rounded-2xl bg-teal-50 ring-1 ring-teal-500/20 p-5">
+            <div class="bg-teal-50 ring-1 border-primary/30 p-5">
               <div class="flex items-center gap-1.5 mb-2">
                 <svg
                   class="w-4 h-4 text-teal-600"

--- a/src/components/sections/Education.astro
+++ b/src/components/sections/Education.astro
@@ -11,7 +11,7 @@ import SectionHeader from "@/components/ui/SectionHeader.astro";
     />
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-      <div class="glass rounded-2xl p-6">
+      <div class="border border-border p-6">
         <h3 class="font-semibold text-foreground mb-4 flex items-center gap-2">
           <svg
             class="w-4 h-4 text-teal-500"
@@ -43,7 +43,7 @@ import SectionHeader from "@/components/ui/SectionHeader.astro";
         </ul>
       </div>
 
-      <div class="glass rounded-2xl p-6">
+      <div class="border border-border p-6">
         <h3 class="font-semibold text-foreground mb-4 flex items-center gap-2">
           <svg
             class="w-4 h-4 text-teal-500"

--- a/src/components/sections/FeaturedKnowledge.astro
+++ b/src/components/sections/FeaturedKnowledge.astro
@@ -16,7 +16,7 @@ import Badge from "@/components/ui/Badge.astro";
         featuredKnowledge.map((item, i) => (
           <a
             href={item.href}
-            class={`group block bg-card/95 ring-1 ring-gray-950/5 shadow-sm rounded-3xl p-6 transition-all duration-300 hover:ring-teal-500/20 hover:shadow-md `}
+            class={`group block border border-border p-6 transition-all duration-300 hover:border-primary/40`}
           >
             <div class="flex items-center gap-2 flex-wrap mb-3">
               {item.categoryLabel && (

--- a/src/components/sections/Footer.astro
+++ b/src/components/sections/Footer.astro
@@ -58,7 +58,7 @@ const year = new Date().getFullYear();
             if (link.comingSoon) {
               return (
                 <div
-                  class="w-9 h-9 rounded-lg bg-gray-100 flex items-center justify-center text-muted-foreground/40 cursor-default relative group"
+                  class="w-9 h-9 rounded-[4px] bg-gray-100 flex items-center justify-center text-muted-foreground/40 cursor-default relative group"
                   aria-label={`${link.name} (Coming Soon)`}
                 >
                   {link.icon === "note" && <NoteIcon class="w-4 h-4" />}
@@ -73,7 +73,7 @@ const year = new Date().getFullYear();
                 href={link.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                class="w-9 h-9 rounded-lg bg-gray-100 hover:bg-gray-200 flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors"
+                class="w-9 h-9 rounded-[4px] bg-gray-100 hover:bg-gray-200 flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors"
                 aria-label={link.name}
               >
                 <Fragment set:html={iconMap[link.icon] || ""} />

--- a/src/components/sections/Hero.astro
+++ b/src/components/sections/Hero.astro
@@ -2,18 +2,13 @@
 import Button from "@/components/ui/Button.astro";
 ---
 
-<section class="relative min-h-[90vh] flex items-center justify-center overflow-hidden pt-16">
-  <!-- Background decorations -->
-  <div class="absolute top-1/4 -left-32 w-96 h-96 bg-gradient-to-br from-yellow-200/30 via-pink-200/20 to-purple-200/30 rounded-full blur-3xl"></div>
-  <div class="absolute bottom-1/4 -right-32 w-96 h-96 bg-gradient-to-br from-purple-200/20 via-teal-200/20 to-blue-200/30 rounded-full blur-3xl"></div>
-
-  <div class="relative mx-auto max-w-5xl px-4 sm:px-6 lg:px-8 py-20">
+<section class="min-h-[80vh] flex items-center pt-16">
+  <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8 py-20">
     <div class="flex flex-col md:flex-row items-center gap-12 md:gap-16">
       <!-- Profile Image -->
       <div class="flex-shrink-0">
-        <div class="relative w-40 h-40 md:w-52 md:h-52 rounded-2xl overflow-hidden shadow-lg ring-1 ring-gray-950/5">
-          <div class="absolute inset-0 rounded-2xl gradient-border z-10"></div>
-          <img
+        <div class="relative w-40 h-40 md:w-52 md:h-52 overflow-hidden border border-border">
+                <img
             src="/assets/images/profile.jpg"
             alt="田中 省伍"
             class="w-full h-full object-cover"
@@ -34,7 +29,7 @@ import Button from "@/components/ui/Button.astro";
         </h1>
 
         <p class="text-xl sm:text-2xl font-medium mb-6">
-          <span class="gradient-text">AI活用と開発</span>
+          <span class="text-primary">AI活用と開発</span>
           <span class="text-muted-foreground"> を、</span>
           <br class="sm:hidden" />
           <span class="text-foreground">現場で手を動かしながら伴走する</span>

--- a/src/components/sections/Media.astro
+++ b/src/components/sections/Media.astro
@@ -48,14 +48,14 @@ function iconUrl(slug: string, color?: string): string {
             </div>
           );
 
-          const wrapperClass = `block bg-card/95 ring-1 ring-gray-950/5 shadow-sm rounded-2xl p-5 transition-all duration-300 `;
+          const wrapperClass = `block border border-border  p-5 transition-all duration-300 `;
 
           return (
             <a
               href={outlet.url}
               target="_blank"
               rel="noopener noreferrer"
-              class={`${wrapperClass} group hover:ring-teal-500/30 hover:shadow-md`}
+              class={`${wrapperClass} group hover:ring-teal-500/30`}
             >
               {inner}
             </a>

--- a/src/components/sections/Navbar.astro
+++ b/src/components/sections/Navbar.astro
@@ -55,12 +55,12 @@ const isActive = (href: string, children?: { href: string }[]) =>
                   data-dropdown-panel
                   class="invisible opacity-0 translate-y-1 transition-all duration-200 absolute left-0 top-full pt-2 w-72"
                 >
-                  <div class="bg-white rounded-xl border border-gray-100 shadow-lg p-2">
+                  <div class="bg-white rounded-[4px] border border-gray-100 shadow-lg p-2">
                     {item.children.map((child) => (
                       <a
                         href={child.href}
                         class:list={[
-                          "block px-3 py-2.5 rounded-lg transition-colors hover:bg-gray-50",
+                          "block px-3 py-2.5 rounded-[4px] transition-colors hover:bg-gray-50",
                           currentPath === child.href ? "bg-gray-50" : "",
                         ]}
                       >

--- a/src/components/sections/NoteArticles.astro
+++ b/src/components/sections/NoteArticles.astro
@@ -32,7 +32,7 @@ function formatDate(date: Date): string {
               href={article.link}
               target="_blank"
               rel="noopener noreferrer"
-              class={`group block bg-card/95 ring-1 ring-gray-950/5 shadow-sm rounded-3xl overflow-hidden transition-all duration-300 hover:ring-teal-500/20 hover:shadow-md `}
+              class={`group block border border-border overflow-hidden transition-all duration-300 hover:border-primary/40`}
             >
               {article.thumbnail && (
                 <div class="aspect-video bg-secondary/40 overflow-hidden">

--- a/src/components/sections/Portfolio.astro
+++ b/src/components/sections/Portfolio.astro
@@ -18,7 +18,7 @@ import SectionHeader from "@/components/ui/SectionHeader.astro";
             href={isClickable ? app.url : undefined}
             target={isClickable ? "_blank" : undefined}
             rel={isClickable ? "noopener noreferrer" : undefined}
-            class={`glass rounded-2xl overflow-hidden group transition-all duration-300 hover:border-teal-500/20 block  ${isClickable ? "cursor-pointer" : "cursor-default"}`}
+            class={`border border-border overflow-hidden group transition-all duration-300 hover:border-teal-500/20 block ${isClickable ? "cursor-pointer" : "cursor-default"}`}
           >
             <!-- Image -->
             <div class="relative w-full h-48 overflow-hidden bg-gray-100">
@@ -29,7 +29,7 @@ import SectionHeader from "@/components/ui/SectionHeader.astro";
                 loading="lazy"
               />
               {isClickable && (
-                <div class="absolute top-3 right-3 w-8 h-8 rounded-lg bg-black/50 backdrop-blur-sm flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+                <div class="absolute top-3 right-3 w-8 h-8 rounded-[4px] bg-black/50 backdrop-blur-sm flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
                   <svg class="w-4 h-4 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
                   </svg>

--- a/src/components/sections/Seminars.astro
+++ b/src/components/sections/Seminars.astro
@@ -22,24 +22,18 @@ import Button from "@/components/ui/Button.astro";
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         {upcomingSeminars.map((seminar, index) => (
           <div
-            class={`relative glass rounded-2xl p-6 hover:border-teal-500/20 transition-colors overflow-hidden `}
+            class="border border-border p-6 transition-colors"
           >
-            <div class="absolute top-0 right-0 w-32 h-32 bg-gradient-to-bl from-teal-500/10 to-transparent rounded-bl-full"></div>
-
-            <div class="flex items-start justify-between mb-4 relative z-10">
+            <div class="flex items-start justify-between mb-4">
               <h3 class="font-semibold text-foreground pr-4">{seminar.title}</h3>
               <span
-                class={`flex-shrink-0 px-3 py-1 text-xs rounded-full font-medium ${
-                  seminar.status === "残り5席"
-                    ? "bg-red-500/10 text-red-400 border border-red-500/20"
-                    : "bg-emerald-500/10 text-emerald-400 border border-emerald-500/20"
-                }`}
+                class={`flex-shrink-0 px-3 py-1 text-xs rounded-full font-medium ${ seminar.status === "残り5席" ? "bg-red-500/10 text-red-400 border border-red-500/20" : "bg-emerald-500/10 text-emerald-400 border border-emerald-500/20" }`}
               >
                 {seminar.status}
               </span>
             </div>
 
-            <div class="space-y-2 mb-5 relative z-10">
+            <div class="space-y-2 mb-5">
               <div class="flex items-center gap-2 text-sm text-muted-foreground">
                 <svg class="w-4 h-4 text-teal-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2v4"/><path d="M16 2v4"/><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M3 10h18"/></svg>
                 <span>{seminar.date}</span>
@@ -58,8 +52,8 @@ import Button from "@/components/ui/Button.astro";
               </div>
             </div>
 
-            <div class="flex items-center justify-between relative z-10">
-              <span class="text-lg font-bold gradient-text">{seminar.price}</span>
+            <div class="flex items-center justify-between">
+              <span class="text-lg font-bold text-primary">{seminar.price}</span>
               <Button size="sm">詳細・申込み</Button>
             </div>
           </div>

--- a/src/components/sections/ServiceDetail.astro
+++ b/src/components/sections/ServiceDetail.astro
@@ -32,7 +32,7 @@ const iconSvgs: Record<string, string> = {
     <div class:list={[index === 0 ? "" : ""]}>
       <!-- ヘッダー -->
       <div class="flex items-center gap-4 mb-6">
-        <div class="w-14 h-14 rounded-2xl bg-teal-50 flex items-center justify-center shrink-0">
+        <div class="w-14 h-14 bg-teal-50 flex items-center justify-center shrink-0">
           <Fragment set:html={iconSvgs[service.icon] || ""} />
         </div>
         <div>
@@ -69,7 +69,7 @@ const iconSvgs: Record<string, string> = {
             <h3 class="text-lg font-semibold text-foreground mb-4">サービス内容</h3>
             <div class="space-y-4">
               {service.details.map((detail) => (
-                <div class="bg-white/80 ring-1 ring-gray-950/5 shadow-sm rounded-2xl p-5">
+                <div class="border border-border p-5">
                   <h4 class="font-medium text-foreground mb-2">{detail.heading}</h4>
                   <p class="text-sm text-muted-foreground leading-relaxed">{detail.body}</p>
                 </div>
@@ -104,7 +104,7 @@ const iconSvgs: Record<string, string> = {
 
         <!-- 右カラム: 料金プラン -->
         <div>
-          <div class="bg-white/80 ring-1 ring-gray-950/5 shadow-sm rounded-2xl p-6 sticky top-24">
+          <div class="border border-border p-6 sticky top-24">
             <h3 class="text-lg font-semibold text-foreground mb-1">料金プラン</h3>
             <p class="text-xs text-teal-600 font-medium mb-5">モニター価格適用中</p>
             <div class="space-y-4">
@@ -127,13 +127,13 @@ const iconSvgs: Record<string, string> = {
             <div class="mt-6 space-y-3">
               <a
                 href={service.href}
-                class="block w-full text-center px-4 py-2.5 bg-teal-500 text-white text-sm font-medium rounded-xl hover:bg-teal-600 transition-colors"
+                class="block w-full text-center px-4 py-2.5 bg-teal-500 text-white text-sm font-medium rounded-[4px] hover:bg-teal-600 transition-colors"
               >
                 詳しいサービスページを見る
               </a>
               <a
                 href="/contact"
-                class="block w-full text-center px-4 py-2.5 bg-white text-teal-700 text-sm font-medium rounded-xl ring-1 ring-teal-500/20 hover:bg-teal-50 transition-colors"
+                class="block w-full text-center px-4 py-2.5 bg-white text-teal-700 text-sm font-medium rounded-[4px] ring-1 border-primary/30 hover:bg-teal-50 transition-colors"
               >
                 お問い合わせ
               </a>

--- a/src/components/sections/ServiceLandingPage.astro
+++ b/src/components/sections/ServiceLandingPage.astro
@@ -54,20 +54,20 @@ const hasFaq = (service.faq?.length ?? 0) > 0;
         <div class="mt-8 flex flex-col gap-3 sm:flex-row">
           <a
             href="/contact"
-            class="inline-flex items-center justify-center rounded-xl bg-teal-500 px-6 py-3 font-medium text-white transition-colors hover:bg-teal-600"
+            class="inline-flex items-center justify-center rounded-[4px] bg-teal-500 px-6 py-3 font-medium text-white transition-colors hover:bg-teal-600"
           >
             {service.title}について問い合わせる
           </a>
           <a
             href="#details"
-            class="inline-flex items-center justify-center rounded-xl bg-white px-6 py-3 font-medium text-foreground ring-1 ring-gray-950/10 transition-colors hover:bg-gray-50"
+            class="inline-flex items-center justify-center rounded-[4px] bg-white px-6 py-3 font-medium text-foreground border border-border transition-colors hover:bg-gray-50"
           >
             提供内容を見る
           </a>
         </div>
       </div>
 
-      <aside class="rounded-3xl bg-white/80 p-6 shadow-sm ring-1 ring-gray-950/5">
+      <aside class="bg-white/80 p-6 border border-border">
         <h2 class="text-base font-semibold text-foreground">料金の目安</h2>
         <p class="mt-1 text-xs font-medium text-teal-600">モニター価格適用中</p>
         <div class="mt-5 space-y-4">
@@ -97,7 +97,7 @@ const hasFaq = (service.faq?.length ?? 0) > 0;
     <h2 class="text-2xl font-bold text-foreground">こんな課題を解決します</h2>
     <div class="mt-8 grid gap-4 md:grid-cols-2">
       {service.painPoints.map((point) => (
-        <div class="flex items-start gap-3 rounded-2xl bg-white p-5 shadow-sm ring-1 ring-gray-950/5">
+        <div class="flex items-start gap-3 bg-white p-5 border border-border">
           <svg class="mt-0.5 h-5 w-5 shrink-0 text-teal-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <path d="M20 6 9 17l-5-5" />
           </svg>
@@ -113,7 +113,7 @@ const hasFaq = (service.faq?.length ?? 0) > 0;
     <h2 class="text-2xl font-bold text-foreground">提供内容</h2>
     <div class="mt-8 grid gap-5 md:grid-cols-2">
       {service.details.map((detail) => (
-        <article class="rounded-2xl bg-white/80 p-6 shadow-sm ring-1 ring-gray-950/5">
+        <article class="bg-white/80 p-6 border border-border">
           <h3 class="font-semibold text-foreground">{detail.heading}</h3>
           <p class="mt-3 text-sm leading-relaxed text-muted-foreground">{detail.body}</p>
         </article>
@@ -175,7 +175,7 @@ const hasFaq = (service.faq?.length ?? 0) > 0;
       <h2 class="text-2xl font-bold text-foreground">よくあるご質問</h2>
       <dl class="mt-8 space-y-4">
         {service.faq!.map((item) => (
-          <div class="rounded-2xl bg-white/80 p-6 shadow-sm ring-1 ring-gray-950/5">
+          <div class="bg-white/80 p-6 border border-border">
             <dt class="font-semibold text-foreground">{item.question}</dt>
             <dd class="mt-3 text-sm leading-relaxed text-muted-foreground">{item.answer}</dd>
           </div>
@@ -187,7 +187,7 @@ const hasFaq = (service.faq?.length ?? 0) > 0;
 
 <section class="pb-20 pt-4">
   <div class="mx-auto max-w-3xl px-4 text-center sm:px-6 lg:px-8">
-    <div class="rounded-3xl bg-gradient-to-br from-teal-50 via-white to-yellow-50 p-8 ring-1 ring-teal-500/10 sm:p-12">
+    <div class="border border-border p-8 sm:p-12">
       <h2 class="text-2xl font-bold text-foreground">
         {service.title}についてご相談ください
       </h2>
@@ -196,7 +196,7 @@ const hasFaq = (service.faq?.length ?? 0) > 0;
       </p>
       <a
         href="/contact"
-        class="mt-8 inline-flex items-center justify-center rounded-xl bg-teal-500 px-6 py-3 font-medium text-white transition-colors hover:bg-teal-600"
+        class="mt-8 inline-flex items-center justify-center rounded-[4px] bg-teal-500 px-6 py-3 font-medium text-white transition-colors hover:bg-teal-600"
       >
         お問い合わせへ進む
       </a>

--- a/src/components/sections/Services.astro
+++ b/src/components/sections/Services.astro
@@ -37,9 +37,9 @@ const iconSvgs: Record<string, string> = {
         {services.map((service, index) => (
           <a
             href={service.href}
-            class={`group flex items-start gap-4 py-5 first:pt-0 last:pb-0 `}
+            class={`group flex items-start gap-4 py-5 first:pt-0 last:pb-0`}
           >
-            <div class="w-12 h-12 shrink-0 rounded-xl bg-teal-50 flex items-center justify-center group-hover:bg-teal-100 transition-colors">
+            <div class="w-12 h-12 shrink-0 rounded-[4px] bg-teal-50 flex items-center justify-center group-hover:bg-teal-100 transition-colors">
               <Fragment set:html={iconSvgs[service.icon] || ""} />
             </div>
             <div class="min-w-0">

--- a/src/components/sections/Skills.astro
+++ b/src/components/sections/Skills.astro
@@ -9,7 +9,6 @@ const categoryConfig: {
   key: SkillCategoryKey;
   title: string;
   iconSvg: string;
-  gradient: string;
   starColor: string;
 }[] = [
   {
@@ -17,7 +16,6 @@ const categoryConfig: {
     title: "Languages & Frameworks",
     iconSvg:
       '<svg class="w-5 h-5 text-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 16 4-4-4-4"/><path d="m6 8-4 4 4 4"/><path d="m14.5 4-5 16"/></svg>',
-    gradient: "from-teal-500/20 to-blue-500/20",
     starColor: "text-teal-400",
   },
   {
@@ -25,7 +23,6 @@ const categoryConfig: {
     title: "Backend & Infrastructure",
     iconSvg:
       '<svg class="w-5 h-5 text-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5V19A9 3 0 0 0 21 19V5"/><path d="M3 12A9 3 0 0 0 21 12"/></svg>',
-    gradient: "from-emerald-500/20 to-green-500/20",
     starColor: "text-emerald-400",
   },
   {
@@ -33,7 +30,6 @@ const categoryConfig: {
     title: "AI & Automation",
     iconSvg:
       '<svg class="w-5 h-5 text-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/><path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/></svg>',
-    gradient: "from-violet-500/20 to-purple-500/20",
     starColor: "text-violet-400",
   },
   {
@@ -41,7 +37,6 @@ const categoryConfig: {
     title: "Development Tools",
     iconSvg:
       '<svg class="w-5 h-5 text-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>',
-    gradient: "from-blue-500/20 to-cyan-500/20",
     starColor: "text-blue-400",
   },
 ];
@@ -63,11 +58,11 @@ function renderStars(level: SkillLevel, colorClass: string): string {
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
       {categoryConfig.map((cat, index) => (
         <div
-          class={`glass rounded-2xl p-6 hover:border-teal-500/20 transition-colors `}
+          class={`border border-border p-6 hover:border-teal-500/20 transition-colors`}
         >
           <div class="flex items-center gap-3 mb-5">
             <div
-              class={`w-10 h-10 rounded-xl bg-gradient-to-br ${cat.gradient} flex items-center justify-center`}
+              class="w-10 h-10 rounded-[4px] bg-secondary flex items-center justify-center"
             >
               <Fragment set:html={cat.iconSvg} />
             </div>

--- a/src/components/sections/SocialLinks.astro
+++ b/src/components/sections/SocialLinks.astro
@@ -22,7 +22,7 @@ const iconMap: Record<string, string> = {
     if (link.comingSoon) {
       return (
         <div
-          class="w-9 h-9 rounded-lg bg-gray-100 flex items-center justify-center text-muted-foreground/40 cursor-default relative group"
+          class="w-9 h-9 rounded-[4px] bg-gray-100 flex items-center justify-center text-muted-foreground/40 cursor-default relative group"
           aria-label={`${link.name} (Coming Soon)`}
         >
           {link.icon === "note" && <NoteIcon class="w-4 h-4" />}
@@ -37,7 +37,7 @@ const iconMap: Record<string, string> = {
         href={link.url}
         target="_blank"
         rel="noopener noreferrer"
-        class="w-9 h-9 rounded-lg bg-gray-100 hover:bg-gray-200 flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors"
+        class="w-9 h-9 rounded-[4px] bg-gray-100 hover:bg-gray-200 flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors"
         aria-label={link.name}
       >
         <Fragment set:html={iconMap[link.icon] || ""} />

--- a/src/components/sections/Stats.astro
+++ b/src/components/sections/Stats.astro
@@ -7,9 +7,9 @@ import { stats } from "@/data";
     <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
       {stats.map((stat, index) => (
         <div
-          class={`bg-white/80 ring-1 ring-gray-950/5 shadow-sm rounded-3xl p-6 text-center transition-colors group `}
+          class={`border border-border p-6 text-center transition-colors group`}
         >
-          <p class="text-3xl sm:text-4xl font-bold gradient-text mb-1">
+          <p class="text-3xl sm:text-4xl font-bold text-primary mb-1">
             {stat.value}
           </p>
           <p class="text-sm font-medium text-foreground mb-1">{stat.label}</p>

--- a/src/components/sections/Teaching.astro
+++ b/src/components/sections/Teaching.astro
@@ -14,7 +14,7 @@ import Badge from "@/components/ui/Badge.astro";
     <!-- Timeline -->
     <div class="relative">
       <!-- Timeline line -->
-      <div class="absolute left-4 md:left-1/2 top-0 bottom-0 w-px bg-gradient-to-b from-teal-500/50 via-emerald-500/50 to-transparent hidden sm:block"></div>
+      <div class="absolute left-4 md:left-1/2 top-0 bottom-0 w-px bg-border hidden sm:block"></div>
 
       <div class="space-y-6">
         {teachingExperience.map((exp, index) => {
@@ -23,9 +23,7 @@ import Badge from "@/components/ui/Badge.astro";
 
           return (
             <div
-              class={`relative flex flex-col sm:flex-row ${
-                isEven ? "sm:flex-row" : "sm:flex-row-reverse"
-              } gap-4 sm:gap-8 `}
+              class={`relative flex flex-col sm:flex-row ${ isEven ? "sm:flex-row" : "sm:flex-row-reverse" } gap-4 sm:gap-8`}
             >
               <!-- Timeline dot -->
               <div class="absolute left-4 md:left-1/2 top-6 w-3 h-3 rounded-full bg-teal-500 -translate-x-1.5 hidden sm:block ring-4 ring-background z-10"></div>
@@ -34,7 +32,7 @@ import Badge from "@/components/ui/Badge.astro";
               <div class="hidden sm:block sm:w-1/2"></div>
 
               <!-- Card -->
-              <div class={`sm:w-1/2 glass rounded-2xl p-5 transition-all duration-300 hover:border-teal-500/20`}>
+              <div class={`sm:w-1/2 border border-border p-5 transition-all duration-300 hover:border-teal-500/20`}>
                 {isClickable ? (
                   <a href={exp.url} target="_blank" rel="noopener noreferrer" class="block">
                     <div class="flex items-start justify-between mb-2">

--- a/src/components/sections/TechStack.astro
+++ b/src/components/sections/TechStack.astro
@@ -14,7 +14,7 @@ import SectionHeader from "@/components/ui/SectionHeader.astro";
       {
         techStack.map((category, i) => (
           <div
-            class={`bg-card/95 ring-1 ring-gray-950/5 shadow-sm rounded-3xl p-6 md:p-7 `}
+            class={`border border-border p-6 md:p-7`}
           >
             <h3 class="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-4">
               {category.label}

--- a/src/components/sections/Testimonials.astro
+++ b/src/components/sections/Testimonials.astro
@@ -29,7 +29,7 @@ const ordered = audienceOrder
 
     <div class="grid grid-cols-1 gap-6 md:grid-cols-3">
       {ordered.map((group, index) => (
-        <div class={`flex flex-col gap-3 `}>
+        <div class={`flex flex-col gap-3`}>
           <p class="text-sm font-semibold text-teal-600">{group.label}</p>
           {group.items.map((testimonial) => (
             <TestimonialCard testimonial={testimonial} class="grow" />

--- a/src/components/ui/Button.astro
+++ b/src/components/ui/Button.astro
@@ -19,15 +19,14 @@ const {
   ...rest
 } = Astro.props;
 
+// 操作要素なので小さい角丸だけ持つ。グラデーションと影は使わない（docs/DESIGN.md）
 const baseClasses =
-  "inline-flex items-center justify-center rounded-lg font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+  "inline-flex items-center justify-center rounded-[4px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
 
 const variants = {
-  primary:
-    "bg-gradient-to-r from-teal-500 to-emerald-500 hover:from-teal-600 hover:to-emerald-600 text-white border-0 shadow-lg shadow-teal-500/25",
-  outline:
-    "border border-gray-200 hover:bg-gray-50 text-foreground bg-transparent",
-  ghost: "hover:bg-gray-100 text-foreground bg-transparent",
+  primary: "bg-primary hover:bg-accent text-primary-foreground border-0",
+  outline: "border border-border hover:bg-secondary text-foreground bg-transparent",
+  ghost: "hover:bg-secondary text-foreground bg-transparent",
 };
 
 const sizes = {

--- a/src/components/ui/Card.astro
+++ b/src/components/ui/Card.astro
@@ -2,18 +2,31 @@
 import { cn } from "@/utils/cn";
 
 interface Props {
-  class?: string;
+  /**
+   * plain: 枠なし・余白のみ（既定）。ページを一枚のキャンバスとして扱う
+   * outlined: 1px 枠。数値サマリなど、比較のために囲む必要がある場合だけ使う
+   */
+  variant?: "plain" | "outlined";
+  /** リンクカードでホバーの手応えを出す */
   hover?: boolean;
+  class?: string;
 }
 
-const { class: className, hover = false } = Astro.props;
+const { variant = "plain", hover = false, class: className } = Astro.props;
+
+const variants = {
+  plain: "",
+  outlined: "border border-border",
+};
 ---
 
+{/* 影と大きな角丸は使わない。階層は余白と区切り線で作る（docs/DESIGN.md） */}
 <div
   class={cn(
-    "bg-card/95 ring-1 ring-gray-950/5 shadow-sm rounded-3xl p-6 transition-all duration-300",
-    hover && "hover:border-teal-500/20",
-    className
+    "p-5 transition-colors",
+    variants[variant],
+    hover && "hover:border-primary/40",
+    className,
   )}
 >
   <slot />

--- a/src/components/ui/Container.astro
+++ b/src/components/ui/Container.astro
@@ -1,0 +1,21 @@
+---
+import { cn } from "@/utils/cn";
+
+interface Props {
+  /** 記事本文など、読み幅を狭めたい場合に narrow を指定する */
+  width?: "default" | "narrow" | "wide";
+  class?: string;
+}
+
+const { width = "default", class: className } = Astro.props;
+
+const widths = {
+  narrow: "max-w-3xl",
+  default: "max-w-5xl",
+  wide: "max-w-6xl",
+};
+---
+
+<div class={cn("mx-auto px-4 sm:px-6 lg:px-8", widths[width], className)}>
+  <slot />
+</div>

--- a/src/components/ui/Section.astro
+++ b/src/components/ui/Section.astro
@@ -1,0 +1,30 @@
+---
+import { cn } from "@/utils/cn";
+import Container from "@/components/ui/Container.astro";
+
+interface Props {
+  id?: string;
+  /** セクション間の縦余白。階層はこの差でつける（docs/DESIGN.md） */
+  spacing?: "default" | "compact";
+  width?: "default" | "narrow" | "wide";
+  class?: string;
+}
+
+const {
+  id,
+  spacing = "default",
+  width = "default",
+  class: className,
+} = Astro.props;
+
+const spacings = {
+  default: "py-20",
+  compact: "py-14",
+};
+---
+
+<section id={id} class={cn(spacings[spacing], className)}>
+  <Container width={width}>
+    <slot />
+  </Container>
+</section>

--- a/src/components/ui/SectionHeader.astro
+++ b/src/components/ui/SectionHeader.astro
@@ -1,13 +1,32 @@
 ---
+import { cn } from "@/utils/cn";
+
 interface Props {
   title: string;
   subtitle?: string;
+  /** 見出しの上に置く小さい英字ラベル。装飾として乱用しない（docs/DESIGN.md） */
+  eyebrow?: string;
+  class?: string;
 }
 
-const { title, subtitle } = Astro.props;
+const { title, subtitle, eyebrow, class: className } = Astro.props;
 ---
 
-<div class="text-center mb-12">
-  <h2 class="text-3xl font-bold text-foreground mb-3">{title}</h2>
-  {subtitle && <p class="text-muted-foreground max-w-2xl mx-auto">{subtitle}</p>}
+{/* 中央寄せをやめ、左寄せに統一する。階層は余白と文字サイズで作る */}
+<div class={cn("mb-10", className)}>
+  {
+    eyebrow && (
+      <p class="text-xs font-medium uppercase tracking-wider text-primary mb-2">
+        {eyebrow}
+      </p>
+    )
+  }
+  <h2 class="text-2xl sm:text-3xl font-bold text-foreground">{title}</h2>
+  {
+    subtitle && (
+      <p class="mt-3 max-w-2xl text-muted-foreground leading-relaxed">
+        {subtitle}
+      </p>
+    )
+  }
 </div>

--- a/src/components/ui/TestimonialCard.astro
+++ b/src/components/ui/TestimonialCard.astro
@@ -15,7 +15,7 @@ const stars = Array.from({ length: MAX_STARS }, (_, i) => i < testimonial.rating
 
 <figure
   class:list={[
-    "flex h-full flex-col rounded-3xl bg-white/80 p-6 shadow-sm ring-1 ring-gray-950/5",
+    "flex h-full flex-col border border-border p-6",
     className,
   ]}
 >
@@ -41,7 +41,7 @@ const stars = Array.from({ length: MAX_STARS }, (_, i) => i < testimonial.rating
       src={testimonial.screenshot}
       alt={`${testimonial.authorAttribute} のレビュー`}
       loading="lazy"
-      class="mt-4 w-full rounded-xl ring-1 ring-gray-950/5"
+      class="mt-4 w-full border border-border"
     />
   )}
 

--- a/src/layouts/KnowledgeLayout.astro
+++ b/src/layouts/KnowledgeLayout.astro
@@ -122,7 +122,7 @@ const jsonLd = JSON.stringify({
 
       <div class="lg:grid lg:grid-cols-[17rem_minmax(0,1fr)_15rem] lg:gap-10 lg:items-start">
         <aside
-          class="hidden lg:block lg:sticky lg:top-24 lg:max-h-[calc(100vh-7rem)] lg:overflow-y-auto lg:bg-secondary/40 lg:rounded-2xl lg:p-4"
+          class="hidden lg:block lg:sticky lg:top-24 lg:max-h-[calc(100vh-7rem)] lg:overflow-y-auto lg:bg-secondary/40 lg: lg:p-4"
           aria-label="記事一覧"
         >
           <ArticleSidebar
@@ -184,7 +184,7 @@ const jsonLd = JSON.stringify({
               previous ? (
                 <a
                   href={`${articleBasePath}/${previous.slug}`}
-                  class="group block p-4 rounded-2xl border border-border hover:border-teal-500/60 hover:bg-teal-50/30 transition-colors"
+                  class="group block p-4 border border-border hover:border-teal-500/60 hover:bg-teal-50/30 transition-colors"
                 >
                   <span class="block text-xs text-muted-foreground mb-1">
                     ← 前の記事
@@ -201,7 +201,7 @@ const jsonLd = JSON.stringify({
               next ? (
                 <a
                   href={`${articleBasePath}/${next.slug}`}
-                  class="group block p-4 rounded-2xl border border-border hover:border-teal-500/60 hover:bg-teal-50/30 transition-colors text-right sm:text-right"
+                  class="group block p-4 border border-border hover:border-teal-500/60 hover:bg-teal-50/30 transition-colors text-right sm:text-right"
                 >
                   <span class="block text-xs text-muted-foreground mb-1">
                     次の記事 →
@@ -227,7 +227,7 @@ const jsonLd = JSON.stringify({
         </div>
 
         <aside
-          class="hidden lg:block lg:sticky lg:top-24 lg:max-h-[calc(100vh-7rem)] lg:overflow-y-auto lg:bg-secondary/40 lg:rounded-2xl lg:p-4"
+          class="hidden lg:block lg:sticky lg:top-24 lg:max-h-[calc(100vh-7rem)] lg:overflow-y-auto lg:bg-secondary/40 lg: lg:p-4"
         >
           <ArticleToc headings={headings} />
         </aside>

--- a/src/pages/cases/[slug].astro
+++ b/src/pages/cases/[slug].astro
@@ -41,7 +41,7 @@ const { caseStudy } = Astro.props;
         {caseStudy.title}
       </h1>
 
-      <dl class="grid grid-cols-1 sm:grid-cols-2 gap-4 bg-secondary/50 rounded-2xl p-6 mb-10 text-sm">
+      <dl class="grid grid-cols-1 sm:grid-cols-2 gap-4 bg-secondary/50 p-6 mb-10 text-sm">
         <div>
           <dt class="text-muted-foreground mb-1">クライアント</dt>
           <dd class="font-medium text-foreground">{caseStudy.clientType}</dd>
@@ -131,18 +131,18 @@ const { caseStudy } = Astro.props;
         )
       }
 
-      <div class="bg-gradient-to-r from-teal-500 to-emerald-500 rounded-3xl p-8 sm:p-10 text-center">
-        <p class="text-white font-semibold text-lg mb-2">
+      <div class="border-t border-border pt-10">
+        <p class="text-foreground font-semibold text-lg mb-2">
           同じような課題をお持ちですか？
         </p>
-        <p class="text-white/90 text-sm mb-6">
+        <p class="text-muted-foreground text-sm mb-6">
           現状を伺ったうえで、最適な進め方をご提案します。
         </p>
         <div class="flex flex-col sm:flex-row gap-3 justify-center">
-          <Button href="/contact" size="md" class="bg-white text-teal-700 hover:bg-white/90">
+          <Button href="/contact" size="md" >
             無料で相談する
           </Button>
-          <Button href="/services" variant="ghost" size="md" class="text-white border border-white/50 hover:bg-white/10">
+          <Button href="/services" variant="ghost" size="md" >
             サービスを見る
           </Button>
         </div>

--- a/src/pages/cases/index.astro
+++ b/src/pages/cases/index.astro
@@ -21,7 +21,7 @@ import { caseStudies } from "@/data";
           caseStudies.map((caseStudy) => (
             <a
               href={`/cases/${caseStudy.slug}`}
-              class="block bg-card/95 ring-1 ring-gray-950/5 shadow-sm rounded-3xl p-6 transition-all duration-300 group hover:ring-teal-500/20 hover:shadow-md"
+              class="block border border-border p-6 transition-all duration-300 group hover:border-primary/40"
             >
               <div class="flex items-center gap-2 mb-3 flex-wrap">
                 <Badge variant="teal">{caseStudy.category}</Badge>
@@ -57,7 +57,7 @@ import { caseStudies } from "@/data";
         }
       </div>
 
-      <div class="mt-14 bg-secondary/50 rounded-3xl p-8 text-center">
+      <div class="mt-14 bg-secondary/50 p-8 text-center">
         <p class="text-foreground font-medium mb-2">
           同じような課題をお持ちですか？
         </p>
@@ -66,7 +66,7 @@ import { caseStudies } from "@/data";
         </p>
         <a
           href="/contact"
-          class="inline-block bg-gradient-to-r from-teal-500 to-emerald-500 hover:from-teal-600 hover:to-emerald-600 text-white rounded-lg px-6 py-3 text-sm font-medium transition-all"
+          class="inline-block bg-primary hover:bg-accent text-white rounded-[4px] px-6 py-3 text-sm font-medium transition-all"
         >
           無料で相談する
         </a>

--- a/src/pages/knowledge/[category]/index.astro
+++ b/src/pages/knowledge/[category]/index.astro
@@ -74,7 +74,7 @@ const dateFormatter = new Intl.DateTimeFormat("ja-JP", {
               {subcategoryMetrics.map(({ meta, metrics }) => (
                 <a
                   href={`/knowledge/${category.slug}/${meta.slug}`}
-                  class="flex flex-col p-5 rounded-2xl border border-border hover:border-teal-500/60 hover:bg-teal-50/30 transition-colors"
+                  class="flex flex-col p-5 border border-border hover:border-teal-500/60 hover:bg-teal-50/30 transition-colors"
                 >
                   <h3 class="font-semibold text-foreground mb-1">
                     {meta.label}

--- a/src/pages/knowledge/index.astro
+++ b/src/pages/knowledge/index.astro
@@ -42,11 +42,11 @@ function getCategoryLabel(slug: string): string {
         class="group block mb-10"
       >
         <div
-          class="rounded-3xl p-6 md:p-7 bg-gradient-to-r from-teal-50 to-emerald-50 ring-1 ring-teal-500/20 hover:ring-teal-500/40 transition-all"
+          class="p-6 md:p-7 border border-border hover:border-primary/40 transition-colors"
         >
           <div class="flex items-start gap-4">
             <div
-              class="w-12 h-12 rounded-2xl bg-gradient-to-br from-teal-500 to-emerald-500 flex items-center justify-center text-2xl shrink-0"
+              class="w-12 h-12 bg-secondary flex items-center justify-center text-2xl shrink-0"
               aria-hidden="true"
             >
               🧭

--- a/src/pages/knowledge/roadmap.astro
+++ b/src/pages/knowledge/roadmap.astro
@@ -43,7 +43,7 @@ const resolvedPaths = resolveAllRoadmaps(roadmapPaths, allEntries);
           resolvedPaths.map((path, pathIdx) => (
             <section
               id={path.id}
-              class={` scroll-mt-24`}
+              class={`scroll-mt-24`}
             >
               <header class="mb-6">
                 <h2 class="text-2xl font-bold text-foreground mb-2">

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -18,7 +18,7 @@ import { services } from "@/data";
         {services.map((service) => (
           <a
             href={service.href}
-            class="px-4 py-2 text-sm font-medium text-muted-foreground bg-white/80 ring-1 ring-gray-950/5 rounded-full hover:text-teal-600 hover:ring-teal-500/20 transition-all"
+            class="px-4 py-2 text-sm font-medium text-muted-foreground bg-white/80 border border-border rounded-full hover:text-teal-600 hover:border-primary/40 transition-all"
           >
             {service.title} の詳細
           </a>
@@ -40,7 +40,7 @@ import { services } from "@/data";
       </p>
       <a
         href="/contact"
-        class="inline-flex items-center gap-2 px-6 py-3 bg-teal-500 text-white font-medium rounded-xl hover:bg-teal-600 transition-colors"
+        class="inline-flex items-center gap-2 px-6 py-3 bg-teal-500 text-white font-medium rounded-[4px] hover:bg-teal-600 transition-colors"
       >
         お問い合わせ
         <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">

--- a/src/pages/tech/[slug].astro
+++ b/src/pages/tech/[slug].astro
@@ -33,7 +33,7 @@ const { tool } = Astro.props;
       </nav>
 
       <div class="flex items-center gap-4 mb-4">
-        <div class="w-14 h-14 rounded-2xl bg-secondary flex items-center justify-center">
+        <div class="w-14 h-14 bg-secondary flex items-center justify-center">
           <img
             src={`https://cdn.simpleicons.org/${tool.iconSlug}`}
             alt=""
@@ -54,7 +54,7 @@ const { tool } = Astro.props;
         <p class="text-muted-foreground leading-relaxed">{tool.overview}</p>
       </div>
 
-      <div class="bg-secondary/50 rounded-2xl p-6 sm:p-8 mb-10">
+      <div class="bg-secondary/50 p-6 sm:p-8 mb-10">
         <h2 class="text-xl font-bold text-foreground mb-4">
           私が提供できる価値
         </h2>
@@ -88,7 +88,7 @@ const { tool } = Astro.props;
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
           {
             tool.useCases.map((useCase) => (
-              <div class="bg-card/95 ring-1 ring-gray-950/5 shadow-sm rounded-2xl p-5">
+              <div class="border border-border p-5">
                 <h3 class="text-base font-semibold text-foreground mb-2">
                   {useCase.title}
                 </h3>
@@ -127,18 +127,18 @@ const { tool } = Astro.props;
         )
       }
 
-      <div class="bg-gradient-to-r from-teal-500 to-emerald-500 rounded-3xl p-8 sm:p-10 text-center">
-        <p class="text-white font-semibold text-lg mb-2">
+      <div class="border-t border-border pt-10">
+        <p class="text-foreground font-semibold text-lg mb-2">
           {tool.name} を活用した業務改善のご相談はお気軽に
         </p>
-        <p class="text-white/90 text-sm mb-6">
+        <p class="text-muted-foreground text-sm mb-6">
           現状の課題をお聞きして、最適な活用方法をご提案します。
         </p>
         <div class="flex flex-col sm:flex-row gap-3 justify-center">
-          <Button href="/contact" size="md" class="bg-white text-teal-700 hover:bg-white/90">
+          <Button href="/contact" size="md" >
             お問い合わせ
           </Button>
-          <Button href="/services" variant="ghost" size="md" class="text-white border border-white/50 hover:bg-white/10">
+          <Button href="/services" variant="ghost" size="md" >
             サービスを見る
           </Button>
         </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -20,6 +20,14 @@
   --color-border: hsl(214 32% 91%);
   --color-input: hsl(214 32% 91%);
   --color-ring: hsl(168 76% 42%);
+
+  /* 操作要素だけが角丸を持つ。通常領域は 0（docs/DESIGN.md） */
+  --radius-control: 4px;
+  --radius-pill: 9999px;
+
+  /* セクションの縦リズム。この2値だけで階層を作る */
+  --space-section: 5rem;
+  --space-section-sm: 3.5rem;
 }
 
 /* Base styles */
@@ -33,39 +41,6 @@ body {
   font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-}
-
-/* Gradient utilities */
-.gradient-text {
-  background-clip: text;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-image: linear-gradient(135deg, #14b8a6 0%, #10b981 50%, #34d399 100%);
-}
-
-.gradient-border {
-  position: relative;
-}
-.gradient-border::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  padding: 1px;
-  background: linear-gradient(135deg, #14b8a6, #10b981);
-  -webkit-mask:
-    linear-gradient(#fff 0 0) content-box,
-    linear-gradient(#fff 0 0);
-  -webkit-mask-composite: xor;
-  mask-composite: exclude;
-  pointer-events: none;
-}
-
-/* Glass morphism */
-.glass {
-  background: rgba(255, 255, 255, 0.8);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
-  border: 1px solid rgba(3, 7, 18, 0.05);
 }
 
 /* Knowledge base prose */

--- a/tests/styles/designRules.test.ts
+++ b/tests/styles/designRules.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, globSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * docs/DESIGN.md の方針を機械的に守らせるためのテスト。
+ * 装飾を戻す変更が入ったら、レビューを待たずにここで落ちる。
+ */
+
+const SRC_ROOT = join(process.cwd(), "src");
+
+interface SourceFile {
+  path: string;
+  content: string;
+}
+
+function loadSourceFiles(): SourceFile[] {
+  return globSync("**/*.{astro,tsx,ts,css}", { cwd: SRC_ROOT })
+    // 記事本文のスタイルは docs/DESIGN.md が例外として許可している
+    .filter((relativePath) => relativePath !== "styles/global.css")
+    .map((relativePath) => ({
+      path: `src/${relativePath}`,
+      content: readFileSync(join(SRC_ROOT, relativePath), "utf-8"),
+    }));
+}
+
+const files = loadSourceFiles();
+
+/** 前面へ浮くため影を許可する要素を持つファイル */
+const SHADOW_ALLOWED = new Set([
+  "src/components/sections/Navbar.astro", // ドロップダウンパネル
+  "src/components/islands/MobileMenu.tsx", // ドロワーとバックドロップ
+]);
+
+function findViolations(pattern: RegExp, allowed = new Set<string>()): string[] {
+  const violations: string[] = [];
+
+  for (const file of files) {
+    if (allowed.has(file.path)) continue;
+
+    for (const [index, line] of file.content.split("\n").entries()) {
+      if (pattern.test(line)) {
+        violations.push(`${file.path}:${index + 1}: ${line.trim()}`);
+      }
+      pattern.lastIndex = 0;
+    }
+  }
+
+  return violations;
+}
+
+describe("角丸", () => {
+  it("通常領域に大きな角丸（rounded-2xl / rounded-3xl）を使わないこと", () => {
+    const violations = findViolations(/\brounded-(2xl|3xl|full-\w+)\b/);
+    expect(violations, violations.join("\n")).toEqual([]);
+  });
+});
+
+describe("影", () => {
+  it("前面へ浮く要素以外に影を使わないこと", () => {
+    // shadow-none は打ち消し用途なので許可する
+    const violations = findViolations(
+      /\bshadow-(sm|md|lg|xl|2xl|inner|teal|black|gray)\b/,
+      SHADOW_ALLOWED,
+    );
+    expect(violations, violations.join("\n")).toEqual([]);
+  });
+});
+
+describe("グラデーションと質感表現", () => {
+  it("グラデーション背景を使わないこと", () => {
+    const violations = findViolations(/\bbg-gradient-to-\w+\b/);
+    expect(violations, violations.join("\n")).toEqual([]);
+  });
+
+  it("gradient-text / gradient-border / glass を使わないこと", () => {
+    const violations = findViolations(/\b(gradient-text|gradient-border|glass(-strong)?)\b/);
+    expect(violations, violations.join("\n")).toEqual([]);
+  });
+
+  it("teal から emerald への2色グラデーションを使わないこと", () => {
+    const violations = findViolations(/\b(from|via|to)-(teal|emerald)-\d{2,3}\b/);
+    expect(violations, violations.join("\n")).toEqual([]);
+  });
+});
+
+describe("無効化済みアニメーション", () => {
+  it("CSS 定義のないアニメーションクラスを残さないこと", () => {
+    const violations = findViolations(
+      /\b(animate-on-scroll|stagger-|animate-fade-in-up|animate-scale-in)\b/,
+    );
+    expect(violations, violations.join("\n")).toEqual([]);
+  });
+});
+
+describe("走査対象", () => {
+  it("src 配下のファイルを読み込めていること", () => {
+    // グロブが壊れて0件になると全テストが素通りするため保険を置く
+    expect(files.length).toBeGreaterThan(40);
+  });
+});


### PR DESCRIPTION
## 背景

サイトの見た目が「AIが生成したテンプレート」に見える原因のうち、**装飾レイヤー**を潰す。`docs/DESIGN.md` の方針を実装へ適用する第1弾。

レイアウト構造（トップの6連続カードグリッドなど）の作り直しは後続PRで行う。本PRは「トークン・プリミティブ・装飾の除去」まで。

## 変更内容

### 1. デザイントークンとプリミティブ

利用側へ自動的に波及するため、ここが最も効果が大きい。

- `global.css` に角丸・セクション余白のトークンを追加。`.gradient-text` / `.gradient-border` / `.glass` を削除
- **`Container.astro` / `Section.astro` を新設**。20ファイルで重複していた `mx-auto max-w-5xl px-4 …` と `py-20` を集約する受け皿
- **`SectionHeader`**: 中央寄せをやめ、eyebrow 付きの左寄せへ。**21ファイルが同じ「中央寄せ見出し」を共有していた**のがテンプレ感の最大要因だった
- **`Card`**: 影と `rounded-3xl` を廃止。既定を枠なしにし、囲む必要がある箇所だけ `outlined` を選べるように
- **`Button`**: teal→emerald グラデーションと `shadow-lg shadow-teal-500/25` をやめ、単色 primary・角丸4px へ
- **`TestimonialCard`**: 影と大きな角丸をやめ枠線のみへ

### 2. 全ページの装飾除去

| 対象 | Before | After |
|---|---|---|
| 角丸 | `rounded-2xl` 32箇所 / `rounded-3xl` 15箇所 | 0。操作要素のみ 4px |
| 影 | `shadow-*` 28箇所 | オーバーレイ（Navbarドロップダウン / MobileMenuドロワー）のみ |
| カード外観 | `ring-1 ring-gray-950/5` 手書き18箇所 ＋ `.glass` 8箇所 | `border border-border` に統一 |
| グラデーション | `bg-gradient-to-*` 19箇所 | 0 |
| 装飾ブロブ | Hero 2つ / Cta 3つ / Seminars 1つ（`blur-3xl`） | 削除 |
| グラデ文字 | `gradient-text` 5箇所 | 単色 `text-primary` |

タイムラインの縦線・アイコンチップ・CTAバナー・野良ボタンのグラデーションも単色化した。

### 3. 回帰防止

`tests/styles/designRules.test.ts` を新設。`src/**/*.{astro,tsx,ts,css}` を走査し、禁止パターンが0件であることを検証する（影はオーバーレイのみ許可リストで除外、`global.css` の `.knowledge-prose` は対象外）。

装飾が戻る変更が入ったら、レビューを待たずにここで落ちる。

## 検証

- `npm run check` — 0 errors
- `npm test` — 192 tests / 21 files すべてパス（規約テスト7件を含む）
- `npm run build` — エラー0件
- ブラウザ目視: `/`、`/ai-news`、`/knowledge`、`/services/personal-support`
- **1440 / 1024 / 768 / 390px × 5ページ = 20通りで横スクロールなしを確認**

## 残作業（後続PR）

- トップページの6連続カードグリッドを `Services.astro` 方式の行リストへ（PR 3）
- Navbar のスクロール時 `backdrop-blur`、`ServiceLandingPage` のグリッド整理、`KnowledgeLayout` の aside 背景（PR 4）
- アイコンSVGの一元化（`Services` / `ServiceDetail` / `Footer` / `SocialLinks` / `Contact` / `Skills` に最大3重複）

🤖 Generated with [Claude Code](https://claude.com/claude-code)