### PR TITLE
refactor: トップページのカードグリッド反復を解体し、色をトークンへ統一

### DIFF
--- a/src/components/ai-news/ArchiveSidebar.astro
+++ b/src/components/ai-news/ArchiveSidebar.astro
@@ -26,7 +26,7 @@ const total = months.reduce((sum, month) => sum + month.count, 0);
         class:list={[
           "flex items-center justify-between gap-2 rounded-md px-2.5 py-1.5 text-sm transition-colors",
           currentMonth === undefined
-            ? "bg-teal-50 text-teal-700 font-medium"
+            ? "bg-secondary text-primary font-medium"
             : "text-muted-foreground hover:bg-gray-50 hover:text-foreground",
         ]}
       >
@@ -42,7 +42,7 @@ const total = months.reduce((sum, month) => sum + month.count, 0);
             class:list={[
               "flex items-center justify-between gap-2 rounded-md px-2.5 py-1.5 text-sm transition-colors",
               currentMonth === month.key
-                ? "bg-teal-50 text-teal-700 font-medium"
+                ? "bg-secondary text-primary font-medium"
                 : "text-muted-foreground hover:bg-gray-50 hover:text-foreground",
             ]}
           >

--- a/src/components/ai-news/NewsCard.astro
+++ b/src/components/ai-news/NewsCard.astro
@@ -46,7 +46,7 @@ const displayTags = tags.slice(0, 3);
 
     <div class="flex-1">
       <h3 class="text-lg font-semibold text-foreground line-clamp-2">
-        <a href={href} class="hover:text-teal-600 transition-colors">{title}</a>
+        <a href={href} class="hover:text-primary transition-colors">{title}</a>
       </h3>
       <p class="mt-2 text-sm text-muted-foreground line-clamp-3">{summary}</p>
     </div>
@@ -62,7 +62,7 @@ const displayTags = tags.slice(0, 3);
     }
 
     <div class="flex items-center gap-4 text-sm">
-      <a href={href} class="text-teal-600 hover:text-teal-700 transition-colors">
+      <a href={href} class="text-primary hover:text-primary transition-colors">
         概要を見る →
       </a>
       <a

--- a/src/components/ai-news/ToolFilter.astro
+++ b/src/components/ai-news/ToolFilter.astro
@@ -18,8 +18,8 @@ const total = Object.values(counts).reduce((sum, count) => sum + count, 0);
     class:list={[
       "inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm transition-colors",
       currentTool === undefined
-        ? "border-teal-500/30 bg-teal-50 text-teal-700"
-        : "border-border text-muted-foreground hover:border-teal-500/40 hover:text-foreground",
+        ? "border-primary/30 bg-secondary text-primary"
+        : "border-border text-muted-foreground hover:border-primary/40 hover:text-foreground",
     ]}
   >
     All
@@ -32,8 +32,8 @@ const total = Object.values(counts).reduce((sum, count) => sum + count, 0);
         class:list={[
           "inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm transition-colors",
           currentTool === tool.slug
-            ? "border-teal-500/30 bg-teal-50 text-teal-700"
-            : "border-border text-muted-foreground hover:border-teal-500/40 hover:text-foreground",
+            ? "border-primary/30 bg-secondary text-primary"
+            : "border-border text-muted-foreground hover:border-primary/40 hover:text-foreground",
         ]}
       >
         {tool.label}

--- a/src/components/islands/ContactForm.tsx
+++ b/src/components/islands/ContactForm.tsx
@@ -72,7 +72,7 @@ export default function ContactForm() {
   };
 
   const inputClasses =
-    "w-full px-4 py-2.5 rounded-[4px] border border-gray-200 bg-white text-foreground text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:border-primary/30 focus:border-teal-500/50 transition-colors";
+    "w-full px-4 py-2.5 rounded-[4px] border border-gray-200 bg-white text-foreground text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary transition-colors";
   const errorInputClasses =
     "w-full px-4 py-2.5 rounded-[4px] border border-red-300 bg-white text-foreground text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-red-500/20 focus:border-red-500/50 transition-colors";
 

--- a/src/components/knowledge/ArticleCard.astro
+++ b/src/components/knowledge/ArticleCard.astro
@@ -37,7 +37,7 @@ const displayTags = tags.slice(0, 3);
         <span class="text-xs text-muted-foreground">{formattedDate}</span>
       </div>
       <h3
-        class="text-lg font-semibold text-foreground group-hover:text-teal-600 transition-colors line-clamp-2"
+        class="text-lg font-semibold text-foreground group-hover:text-primary transition-colors line-clamp-2"
       >
         {title}
       </h3>

--- a/src/components/knowledge/ArticleSidebar.astro
+++ b/src/components/knowledge/ArticleSidebar.astro
@@ -72,7 +72,7 @@ const currentHref = headingHref;
           サブカテゴリ
         </label>
         <select
-          class="w-full text-sm rounded-md border border-border bg-background px-2.5 py-1.5 text-foreground focus:outline-none focus:ring-2 focus:ring-teal-500/40 focus:border-teal-500/60"
+          class="w-full text-sm rounded-md border border-border bg-background px-2.5 py-1.5 text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary"
           aria-label="サブカテゴリを切り替える"
           onchange="if(this.value)window.location.href=this.value"
         >
@@ -95,7 +95,7 @@ const currentHref = headingHref;
 
   <a
     href={headingHref}
-    class="block text-xs font-semibold uppercase tracking-wider text-muted-foreground hover:text-teal-600 transition-colors mb-3"
+    class="block text-xs font-semibold uppercase tracking-wider text-muted-foreground hover:text-primary transition-colors mb-3"
   >
     {headingLabel}
   </a>
@@ -111,7 +111,7 @@ const currentHref = headingHref;
                 group.articles.some((a) => a.slug === currentSlug)
               }
             >
-              <summary class="flex items-start gap-2 cursor-pointer select-none py-1.5 text-[11px] font-bold uppercase tracking-wide text-foreground/80 hover:text-teal-600 transition-colors list-none">
+              <summary class="flex items-start gap-2 cursor-pointer select-none py-1.5 text-[11px] font-bold uppercase tracking-wide text-foreground/80 hover:text-primary transition-colors list-none">
                 <svg
                   class="w-3 h-3 mt-1 transition-transform duration-200 group-open/tier:rotate-90 flex-shrink-0"
                   viewBox="0 0 12 12"
@@ -127,7 +127,7 @@ const currentHref = headingHref;
                   />
                 </svg>
                 {group.tier && (
-                  <span class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-teal-500/10 text-teal-600 text-[10px] font-semibold flex-shrink-0 mt-0.5">
+                  <span class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-primary/10 text-primary text-[10px] font-semibold flex-shrink-0 mt-0.5">
                     {group.tier.order}
                   </span>
                 )}
@@ -157,7 +157,7 @@ const currentHref = headingHref;
                         class:list={[
                           "block px-3 py-1.5 -ml-px border-l transition-colors leading-snug",
                           isCurrent
-                            ? "border-teal-500 text-teal-600 font-semibold bg-teal-50/50"
+                            ? "border-primary text-primary font-semibold bg-secondary/50"
                             : "border-transparent text-muted-foreground hover:text-foreground hover:border-muted-foreground/40",
                         ]}
                         aria-current={isCurrent ? "page" : undefined}
@@ -185,7 +185,7 @@ const currentHref = headingHref;
                   class:list={[
                     "block px-3 py-1.5 -ml-px border-l transition-colors leading-snug",
                     isCurrent
-                      ? "border-teal-500 text-teal-600 font-semibold bg-teal-50/50"
+                      ? "border-primary text-primary font-semibold bg-secondary/50"
                       : "border-transparent text-muted-foreground hover:text-foreground hover:border-muted-foreground/40",
                   ]}
                   aria-current={isCurrent ? "page" : undefined}

--- a/src/components/knowledge/Breadcrumb.astro
+++ b/src/components/knowledge/Breadcrumb.astro
@@ -20,7 +20,7 @@ const { items } = Astro.props;
           {item.href ? (
             <a
               href={item.href}
-              class="hover:text-teal-600 transition-colors"
+              class="hover:text-primary transition-colors"
             >
               {item.label}
             </a>

--- a/src/components/knowledge/CategoryCard.astro
+++ b/src/components/knowledge/CategoryCard.astro
@@ -33,7 +33,7 @@ const iconMap: Record<string, string> = {
       <div class="flex-1 min-w-0">
         <div class="flex items-center gap-2 mb-1">
           <h3
-            class="text-lg font-semibold text-foreground group-hover:text-teal-600 transition-colors"
+            class="text-lg font-semibold text-foreground group-hover:text-primary transition-colors"
           >
             {category.label}
           </h3>

--- a/src/components/sections/Career.astro
+++ b/src/components/sections/Career.astro
@@ -20,9 +20,9 @@ import Badge from "@/components/ui/Badge.astro";
             <div
               class={`relative sm:pl-12`}
             >
-              <div class="absolute left-4 top-6 w-3 h-3 rounded-full bg-teal-500 -translate-x-1.5 hidden sm:block ring-4 ring-background z-10" />
+              <div class="absolute left-4 top-6 w-3 h-3 rounded-full bg-primary -translate-x-1.5 hidden sm:block ring-4 ring-background z-10" />
 
-              <div class="border border-border p-5 sm:p-6 transition-all duration-300 hover:border-teal-500/20">
+              <div class="border border-border p-5 sm:p-6 transition-all duration-300 hover:border-primary/20">
                 <div class="flex flex-wrap items-start justify-between gap-3 mb-3">
                   <div class="flex-1 min-w-0">
                     <div class="flex items-center gap-2 text-xs text-muted-foreground mb-1">
@@ -43,7 +43,7 @@ import Badge from "@/components/ui/Badge.astro";
                     <h3 class="font-semibold text-foreground leading-snug">
                       {exp.company}
                     </h3>
-                    <p class="text-sm text-teal-600 mt-0.5">{exp.role}</p>
+                    <p class="text-sm text-primary mt-0.5">{exp.role}</p>
                   </div>
                   <div class="flex flex-wrap items-center gap-2 shrink-0">
                     {exp.current && <Badge variant="emerald">現職</Badge>}
@@ -61,7 +61,7 @@ import Badge from "@/components/ui/Badge.astro";
                 <ul class="space-y-1.5 mb-4">
                   {exp.highlights.map((item) => (
                     <li class="flex gap-2 text-sm text-muted-foreground leading-relaxed">
-                      <span class="text-teal-500 mt-1.5 shrink-0 w-1 h-1 rounded-full bg-teal-500" />
+                      <span class="text-primary mt-1.5 shrink-0 w-1 h-1 rounded-full bg-primary" />
                       <span>{item}</span>
                     </li>
                   ))}

--- a/src/components/sections/Cases.astro
+++ b/src/components/sections/Cases.astro
@@ -1,53 +1,50 @@
 ---
 import { caseStudies } from "@/data";
+import Section from "@/components/ui/Section.astro";
 import SectionHeader from "@/components/ui/SectionHeader.astro";
-import Badge from "@/components/ui/Badge.astro";
 
 // トップページには代表3件のみ表示する
 const featuredCases = caseStudies.slice(0, 3);
 ---
 
-<section id="cases" class="py-20">
-  <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-    <SectionHeader
-      title="導入事例・指導実績"
-      subtitle="さまざまな規模・目的のお客様を支援してきました。代表的な事例をご紹介します。"
-    />
+<Section id="cases">
+  <SectionHeader
+    eyebrow="Cases"
+    title="導入事例・指導実績"
+    subtitle="さまざまな規模・目的のお客様を支援してきました。代表的な事例をご紹介します。"
+  />
 
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-      {
-        featuredCases.map((caseStudy, i) => (
-          <a
-            href={`/cases/${caseStudy.slug}`}
-            class={`block border border-border p-6 transition-all duration-300 group hover:border-primary/40`}
-          >
-            <div class="flex items-center gap-2 mb-3 flex-wrap">
-              <Badge variant="teal">{caseStudy.category}</Badge>
-              <span class="text-xs text-muted-foreground">
-                {caseStudy.clientType}
-              </span>
-            </div>
-            <h3 class="text-lg font-semibold text-foreground mb-2 leading-snug">
+  {/* カードではなく行として並べ、区切り線で階層を作る */}
+  <div class="flex flex-col divide-y divide-border border-y border-border">
+    {
+      featuredCases.map((caseStudy) => (
+        <a
+          href={`/cases/${caseStudy.slug}`}
+          class="group grid grid-cols-1 gap-2 py-6 sm:grid-cols-[10rem_minmax(0,1fr)] sm:gap-8"
+        >
+          <div class="text-sm">
+            <p class="font-medium text-primary">{caseStudy.category}</p>
+            <p class="mt-1 text-muted-foreground">{caseStudy.clientType}</p>
+          </div>
+          <div class="min-w-0">
+            <h3 class="text-lg font-semibold text-foreground leading-snug group-hover:text-primary transition-colors">
               {caseStudy.title}
             </h3>
-            <p class="text-sm text-muted-foreground leading-relaxed mb-4">
+            <p class="mt-2 text-sm text-muted-foreground leading-relaxed">
               {caseStudy.summary}
             </p>
-            <span class="inline-flex items-center gap-1 text-sm font-medium text-teal-600 group-hover:text-teal-700 transition-colors">
-              詳しく見る →
-            </span>
-          </a>
-        ))
-      }
-    </div>
-
-    <div class="mt-10 text-center">
-      <a
-        href="/cases"
-        class="inline-flex items-center gap-1 text-sm font-medium text-teal-600 hover:text-teal-700 transition-colors"
-      >
-        すべての事例を見る →
-      </a>
-    </div>
+          </div>
+        </a>
+      ))
+    }
   </div>
-</section>
+
+  <div class="mt-8">
+    <a
+      href="/cases"
+      class="inline-flex items-center gap-1 text-sm font-medium text-primary hover:text-accent transition-colors"
+    >
+      すべての事例を見る →
+    </a>
+  </div>
+</Section>

--- a/src/components/sections/Contact.astro
+++ b/src/components/sections/Contact.astro
@@ -34,8 +34,8 @@ const activeSocialLinks = socialLinks.filter((l) => !l.comingSoon);
 
         <div class="space-y-3">
           <div class="flex items-center gap-3 text-sm text-muted-foreground">
-            <div class="w-9 h-9 rounded-[4px] bg-teal-500/10 flex items-center justify-center flex-shrink-0">
-              <svg class="w-4 h-4 text-teal-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <div class="w-9 h-9 rounded-[4px] bg-primary/10 flex items-center justify-center flex-shrink-0">
+              <svg class="w-4 h-4 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <rect width="20" height="16" x="2" y="4" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/>
               </svg>
             </div>
@@ -52,7 +52,7 @@ const activeSocialLinks = socialLinks.filter((l) => !l.comingSoon);
                 href={link.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                class="w-10 h-10 rounded-[4px] bg-gray-100 hover:bg-teal-500/10 flex items-center justify-center text-muted-foreground hover:text-teal-600 transition-colors"
+                class="w-10 h-10 rounded-[4px] bg-gray-100 hover:bg-primary/10 flex items-center justify-center text-muted-foreground hover:text-primary transition-colors"
                 aria-label={link.name}
               >
                 <Fragment set:html={iconMap[link.icon] || ""} />

--- a/src/components/sections/Cta.astro
+++ b/src/components/sections/Cta.astro
@@ -1,26 +1,30 @@
 ---
 import Button from "@/components/ui/Button.astro";
+import Section from "@/components/ui/Section.astro";
 ---
 
-<section class="py-20">
-  <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-    <div class="border-t border-border pt-12">
-      <div>
-        <h2 class="text-2xl sm:text-3xl font-bold text-foreground mb-4">
-          プロジェクトについて
-              ご相談ください
-        </h2>
-        <p class="text-muted-foreground mb-8 max-w-xl">
-          Web開発・AI導入・セミナーなど、お気軽にお問い合わせください。
-          初回のご相談は無料です。
-        </p>
-        <Button href="/contact" size="lg">
-          お問い合わせはこちら
-          <svg class="ml-2 h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M5 12h14"/><path d="m12 5 7 7-7 7"/>
-          </svg>
-        </Button>
-      </div>
-    </div>
+{/* 塗りのバナーをやめ、罫線で区切っただけの締めにする */}
+<Section>
+  <div class="border-t border-border pt-12">
+    <h2 class="text-2xl sm:text-3xl font-bold text-foreground">
+      プロジェクトについてご相談ください
+    </h2>
+    <p class="mt-4 mb-8 max-w-xl text-muted-foreground leading-relaxed">
+      Web開発・AI導入・セミナーなど、お気軽にお問い合わせください。初回のご相談は無料です。
+    </p>
+    <Button href="/contact" size="lg">
+      お問い合わせはこちら
+      <svg
+        class="ml-2 h-4 w-4"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path d="M5 12h14"></path><path d="m12 5 7 7-7 7"></path>
+      </svg>
+    </Button>
   </div>
-</section>
+</Section>

--- a/src/components/sections/Difference.astro
+++ b/src/components/sections/Difference.astro
@@ -1,12 +1,13 @@
 ---
 import { differences } from "@/data";
+import Section from "@/components/ui/Section.astro";
 import SectionHeader from "@/components/ui/SectionHeader.astro";
 ---
 
-<section id="difference" class="py-20">
-  <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+<Section id="difference">
     <SectionHeader
-      title="他社との違い"
+    eyebrow="Why me"
+    title="他社との違い"
       subtitle="個人だからこそ、課題から逆算して速く・継続的に伴走できます。"
     />
 
@@ -30,10 +31,10 @@ import SectionHeader from "@/components/ui/SectionHeader.astro";
               </p>
             </div>
 
-            <div class="bg-teal-50 ring-1 border-primary/30 p-5">
+            <div class="bg-secondary border-primary/30 p-5">
               <div class="flex items-center gap-1.5 mb-2">
                 <svg
-                  class="w-4 h-4 text-teal-600"
+                  class="w-4 h-4 text-primary"
                   viewBox="0 0 24 24"
                   fill="none"
                   stroke="currentColor"
@@ -43,7 +44,7 @@ import SectionHeader from "@/components/ui/SectionHeader.astro";
                 >
                   <path d="M20 6 9 17l-5-5" />
                 </svg>
-                <span class="text-xs font-medium text-teal-700">田中省伍</span>
+                <span class="text-xs font-medium text-primary">田中省伍</span>
               </div>
               <p class="text-sm text-foreground leading-relaxed">{item.mine}</p>
             </div>
@@ -52,4 +53,4 @@ import SectionHeader from "@/components/ui/SectionHeader.astro";
       }
     </div>
   </div>
-</section>
+</Section>

--- a/src/components/sections/Education.astro
+++ b/src/components/sections/Education.astro
@@ -14,7 +14,7 @@ import SectionHeader from "@/components/ui/SectionHeader.astro";
       <div class="border border-border p-6">
         <h3 class="font-semibold text-foreground mb-4 flex items-center gap-2">
           <svg
-            class="w-4 h-4 text-teal-500"
+            class="w-4 h-4 text-primary"
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
@@ -36,7 +36,7 @@ import SectionHeader from "@/components/ui/SectionHeader.astro";
                 {edu.department && (
                   <p class="text-sm text-muted-foreground">{edu.department}</p>
                 )}
-                <p class="text-xs text-teal-600 mt-0.5">{edu.status}</p>
+                <p class="text-xs text-primary mt-0.5">{edu.status}</p>
               </li>
             ))
           }
@@ -46,7 +46,7 @@ import SectionHeader from "@/components/ui/SectionHeader.astro";
       <div class="border border-border p-6">
         <h3 class="font-semibold text-foreground mb-4 flex items-center gap-2">
           <svg
-            class="w-4 h-4 text-teal-500"
+            class="w-4 h-4 text-primary"
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"

--- a/src/components/sections/FeaturedKnowledge.astro
+++ b/src/components/sections/FeaturedKnowledge.astro
@@ -1,46 +1,43 @@
 ---
 import { featuredKnowledge } from "@/data";
+import Section from "@/components/ui/Section.astro";
 import SectionHeader from "@/components/ui/SectionHeader.astro";
-import Badge from "@/components/ui/Badge.astro";
 ---
 
-<section id="featured-knowledge" class="py-20">
-  <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-    <SectionHeader
-      title="注目のナレッジ"
-      subtitle="読まれている解説記事をピックアップ。Claude Code・プロンプト工学・現場運用のハーネス設計まで。"
-    />
+<Section id="featured-knowledge">
+  <SectionHeader
+    eyebrow="Knowledge"
+    title="注目のナレッジ"
+    subtitle="読まれている解説記事をピックアップ。Claude Code・プロンプト工学・現場運用のハーネス設計まで。"
+  />
 
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-      {
-        featuredKnowledge.map((item, i) => (
-          <a
-            href={item.href}
-            class={`group block border border-border p-6 transition-all duration-300 hover:border-primary/40`}
-          >
-            <div class="flex items-center gap-2 flex-wrap mb-3">
-              {item.categoryLabel && (
-                <Badge variant="teal">{item.categoryLabel}</Badge>
-              )}
-            </div>
-            <h3 class="text-lg font-semibold text-foreground group-hover:text-teal-700 transition-colors mb-2 line-clamp-2">
+  <div class="flex flex-col divide-y divide-border border-y border-border">
+    {
+      featuredKnowledge.map((item) => (
+        <a
+          href={item.href}
+          class="group grid grid-cols-1 gap-1 py-5 sm:grid-cols-[10rem_minmax(0,1fr)] sm:gap-8"
+        >
+          <p class="text-sm font-medium text-primary">{item.categoryLabel}</p>
+          <div class="min-w-0">
+            <h3 class="text-base font-semibold text-foreground group-hover:text-primary transition-colors">
               {item.title}
             </h3>
-            <p class="text-sm text-muted-foreground leading-relaxed line-clamp-3">
+            <p class="mt-1 text-sm text-muted-foreground leading-relaxed">
               {item.description}
             </p>
-          </a>
-        ))
-      }
-    </div>
-
-    <div class="mt-10 text-center">
-      <a
-        href="/knowledge"
-        class="inline-flex items-center gap-1 text-sm font-medium text-teal-600 hover:text-teal-700 transition-colors"
-      >
-        Knowledge Base をすべて見る →
-      </a>
-    </div>
+          </div>
+        </a>
+      ))
+    }
   </div>
-</section>
+
+  <div class="mt-8">
+    <a
+      href="/knowledge"
+      class="inline-flex items-center gap-1 text-sm font-medium text-primary hover:text-accent transition-colors"
+    >
+      Knowledge Base をすべて見る →
+    </a>
+  </div>
+</Section>

--- a/src/components/sections/Hero.astro
+++ b/src/components/sections/Hero.astro
@@ -20,7 +20,7 @@ import Button from "@/components/ui/Button.astro";
 
       <!-- Text Content -->
       <div class="flex-1 text-center md:text-left">
-        <p class="text-sm font-medium text-teal-600 mb-3 tracking-wide uppercase font-mono">
+        <p class="text-sm font-medium text-primary mb-3 tracking-wide uppercase font-mono">
           Freelance AI Engineer & Instructor
         </p>
 

--- a/src/components/sections/Media.astro
+++ b/src/components/sections/Media.astro
@@ -1,6 +1,6 @@
 ---
 import { mediaOutlets } from "@/data";
-import SectionHeader from "@/components/ui/SectionHeader.astro";
+import Section from "@/components/ui/Section.astro";
 
 // 準備中の媒体はトップに出さない（URL が決まったら comingSoon を外すだけで再表示される）
 const activeOutlets = mediaOutlets.filter((outlet) => !outlet.comingSoon);
@@ -15,53 +15,40 @@ function iconUrl(slug: string, color?: string): string {
 }
 ---
 
-<section id="media" class="py-20 bg-secondary/30">
-  <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-    <SectionHeader
-      title="メディア発信"
-      subtitle="各プラットフォームで発信中です。気になる媒体からフォローいただけると嬉しいです。"
-    />
+{/* 発信媒体は補足情報。見出しを小さくして横一列に収め、主要セクションと差をつける */}
+<Section id="media" spacing="compact">
+  <div class="border-t border-border pt-8">
+    <h2 class="text-sm font-semibold text-foreground">メディア発信</h2>
+    <p class="mt-1 text-sm text-muted-foreground">
+      各プラットフォームで発信中です。気になる媒体からフォローいただけると嬉しいです。
+    </p>
 
-    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+    <ul class="mt-5 flex flex-wrap gap-x-8 gap-y-4">
       {
-        activeOutlets.map((outlet, i) => {
-          const inner = (
-            <div class="flex items-start gap-3">
-              <img
-                src={iconUrl(outlet.iconSlug, outlet.brandColor)}
-                alt={outlet.name}
-                width="28"
-                height="28"
-                class="shrink-0 mt-0.5"
-                loading="lazy"
-              />
-              <div class="flex-1 min-w-0">
-                <div class="flex items-center gap-2 mb-1 flex-wrap">
-                  <span class="text-base font-semibold text-foreground">
-                    {outlet.name}
-                  </span>
-                </div>
-                <p class="text-xs text-muted-foreground leading-relaxed">
-                  {outlet.description}
-                </p>
-              </div>
-            </div>
-          );
-
-          const wrapperClass = `block border border-border  p-5 transition-all duration-300 `;
-
-          return (
+        activeOutlets.map((outlet) => (
+          <li>
             <a
               href={outlet.url}
               target="_blank"
               rel="noopener noreferrer"
-              class={`${wrapperClass} group hover:ring-teal-500/30`}
+              class="group inline-flex items-center gap-2 text-sm"
             >
-              {inner}
+              <img
+                src={iconUrl(outlet.iconSlug, outlet.brandColor)}
+                alt=""
+                width="20"
+                height="20"
+                class="shrink-0"
+                loading="lazy"
+              />
+              <span class="font-medium text-foreground group-hover:text-primary transition-colors">
+                {outlet.name}
+              </span>
+              <span class="text-muted-foreground">↗</span>
             </a>
-          );
-        })
+          </li>
+        ))
       }
-    </div>
+    </ul>
   </div>
-</section>
+</Section>

--- a/src/components/sections/NoteArticles.astro
+++ b/src/components/sections/NoteArticles.astro
@@ -1,6 +1,6 @@
 ---
 import { mediaOutlets } from "@/data";
-import SectionHeader from "@/components/ui/SectionHeader.astro";
+import Section from "@/components/ui/Section.astro";
 import { fetchNoteFeed } from "@/utils/noteFeed";
 
 const noteOutlet = mediaOutlets.find((o) => o.name === "note");
@@ -19,57 +19,49 @@ function formatDate(date: Date): string {
 
 {
   articles.length > 0 && (
-    <section id="note-articles" class="py-20">
-      <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-        <SectionHeader
-          title="note の最新記事"
-          subtitle="現場視点の AI 活用メモを継続発信中。直近の投稿をピックアップしています。"
-        />
+    <Section id="note-articles" spacing="compact">
+      {/* サムネイルのカードをやめ、日付＋タイトルの行として並べる */}
+      <div class="border-t border-border pt-8">
+        <h2 class="text-sm font-semibold text-foreground">note の最新記事</h2>
+        <p class="mt-1 text-sm text-muted-foreground">
+          現場視点の AI 活用メモを継続発信中です。
+        </p>
 
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-          {articles.map((article, i) => (
-            <a
-              href={article.link}
-              target="_blank"
-              rel="noopener noreferrer"
-              class={`group block border border-border overflow-hidden transition-all duration-300 hover:border-primary/40`}
-            >
-              {article.thumbnail && (
-                <div class="aspect-video bg-secondary/40 overflow-hidden">
-                  <img
-                    src={article.thumbnail}
-                    alt=""
-                    loading="lazy"
-                    class="w-full h-full object-cover group-hover:scale-[1.02] transition-transform duration-300"
-                  />
-                </div>
-              )}
-              <div class="p-5">
-                <p class="text-xs text-muted-foreground mb-2">
+        <ul class="mt-5 flex flex-col divide-y divide-border">
+          {articles.map((article) => (
+            <li>
+              <a
+                href={article.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="group flex flex-col gap-1 py-3 sm:flex-row sm:items-baseline sm:gap-6"
+              >
+                <time
+                  class="shrink-0 text-xs text-muted-foreground tabular-nums"
+                  datetime={article.pubDate.toISOString()}
+                >
                   {formatDate(article.pubDate)}
-                </p>
-                <h3 class="text-base font-semibold text-foreground group-hover:text-teal-700 transition-colors line-clamp-2">
+                </time>
+                <span class="text-sm font-medium text-foreground group-hover:text-primary transition-colors">
                   {article.title}
-                  <span class="text-muted-foreground text-sm ml-1">↗</span>
-                </h3>
-              </div>
-            </a>
+                  <span class="ml-1 text-muted-foreground">↗</span>
+                </span>
+              </a>
+            </li>
           ))}
-        </div>
+        </ul>
 
         {noteUrl && (
-          <div class="mt-10 text-center">
-            <a
-              href={noteUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="inline-flex items-center gap-1 text-sm font-medium text-teal-600 hover:text-teal-700 transition-colors"
-            >
-              note をすべて見る →
-            </a>
-          </div>
+          <a
+            href={noteUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="mt-5 inline-flex items-center gap-1 text-sm font-medium text-primary hover:text-accent transition-colors"
+          >
+            note をすべて見る →
+          </a>
         )}
       </div>
-    </section>
+    </Section>
   )
 }

--- a/src/components/sections/Portfolio.astro
+++ b/src/components/sections/Portfolio.astro
@@ -18,7 +18,7 @@ import SectionHeader from "@/components/ui/SectionHeader.astro";
             href={isClickable ? app.url : undefined}
             target={isClickable ? "_blank" : undefined}
             rel={isClickable ? "noopener noreferrer" : undefined}
-            class={`border border-border overflow-hidden group transition-all duration-300 hover:border-teal-500/20 block ${isClickable ? "cursor-pointer" : "cursor-default"}`}
+            class={`border border-border overflow-hidden group transition-all duration-300 hover:border-primary/20 block ${isClickable ? "cursor-pointer" : "cursor-default"}`}
           >
             <!-- Image -->
             <div class="relative w-full h-48 overflow-hidden bg-gray-100">
@@ -45,7 +45,7 @@ import SectionHeader from "@/components/ui/SectionHeader.astro";
               </p>
               <div class="flex flex-wrap gap-2">
                 {app.technologies.map((tech) => (
-                  <span class="px-3 py-1 text-xs rounded-full bg-teal-500/10 text-teal-700 border border-teal-500/20 font-medium">
+                  <span class="px-3 py-1 text-xs rounded-full bg-primary/10 text-primary border border-primary/20 font-medium">
                     {tech}
                   </span>
                 ))}

--- a/src/components/sections/Seminars.astro
+++ b/src/components/sections/Seminars.astro
@@ -35,19 +35,19 @@ import Button from "@/components/ui/Button.astro";
 
             <div class="space-y-2 mb-5">
               <div class="flex items-center gap-2 text-sm text-muted-foreground">
-                <svg class="w-4 h-4 text-teal-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2v4"/><path d="M16 2v4"/><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M3 10h18"/></svg>
+                <svg class="w-4 h-4 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2v4"/><path d="M16 2v4"/><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M3 10h18"/></svg>
                 <span>{seminar.date}</span>
               </div>
               <div class="flex items-center gap-2 text-sm text-muted-foreground">
-                <svg class="w-4 h-4 text-teal-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+                <svg class="w-4 h-4 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
                 <span>{seminar.time}</span>
               </div>
               <div class="flex items-center gap-2 text-sm text-muted-foreground">
-                <svg class="w-4 h-4 text-teal-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"/><circle cx="12" cy="10" r="3"/></svg>
+                <svg class="w-4 h-4 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"/><circle cx="12" cy="10" r="3"/></svg>
                 <span>{seminar.venue}</span>
               </div>
               <div class="flex items-center gap-2 text-sm text-muted-foreground">
-                <svg class="w-4 h-4 text-teal-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+                <svg class="w-4 h-4 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
                 <span>{seminar.capacity}</span>
               </div>
             </div>

--- a/src/components/sections/ServiceDetail.astro
+++ b/src/components/sections/ServiceDetail.astro
@@ -11,13 +11,13 @@ const { service, index } = Astro.props;
 
 const iconSvgs: Record<string, string> = {
   wrench:
-    '<svg class="w-7 h-7 text-teal-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>',
-  bot: '<svg class="w-7 h-7 text-teal-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/><path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/></svg>',
+    '<svg class="w-7 h-7 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>',
+  bot: '<svg class="w-7 h-7 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/><path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/></svg>',
   "graduation-cap":
-    '<svg class="w-7 h-7 text-teal-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.42 10.922a1 1 0 0 0-.019-1.838L12.83 5.18a2 2 0 0 0-1.66 0L2.6 9.08a1 1 0 0 0 0 1.832l8.57 3.908a2 2 0 0 0 1.66 0z"/><path d="M22 10v6"/><path d="M6 12.5V16a6 3 0 0 0 12 0v-3.5"/></svg>',
-  code: '<svg class="w-7 h-7 text-teal-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>',
+    '<svg class="w-7 h-7 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.42 10.922a1 1 0 0 0-.019-1.838L12.83 5.18a2 2 0 0 0-1.66 0L2.6 9.08a1 1 0 0 0 0 1.832l8.57 3.908a2 2 0 0 0 1.66 0z"/><path d="M22 10v6"/><path d="M6 12.5V16a6 3 0 0 0 12 0v-3.5"/></svg>',
+  code: '<svg class="w-7 h-7 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>',
   server:
-    '<svg class="w-7 h-7 text-teal-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="8" x="2" y="2" rx="2"/><rect width="20" height="8" x="2" y="14" rx="2"/><path d="M6 6h.01"/><path d="M6 18h.01"/><path d="M10 6h8"/><path d="M10 18h8"/></svg>',
+    '<svg class="w-7 h-7 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="8" x="2" y="2" rx="2"/><rect width="20" height="8" x="2" y="14" rx="2"/><path d="M6 6h.01"/><path d="M6 18h.01"/><path d="M10 6h8"/><path d="M10 18h8"/></svg>',
 };
 ---
 
@@ -32,7 +32,7 @@ const iconSvgs: Record<string, string> = {
     <div class:list={[index === 0 ? "" : ""]}>
       <!-- ヘッダー -->
       <div class="flex items-center gap-4 mb-6">
-        <div class="w-14 h-14 bg-teal-50 flex items-center justify-center shrink-0">
+        <div class="w-14 h-14 bg-secondary flex items-center justify-center shrink-0">
           <Fragment set:html={iconSvgs[service.icon] || ""} />
         </div>
         <div>
@@ -55,7 +55,7 @@ const iconSvgs: Record<string, string> = {
             <ul class="space-y-3">
               {service.painPoints.map((point) => (
                 <li class="flex items-start gap-3">
-                  <svg class="w-5 h-5 text-teal-500 mt-0.5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <svg class="w-5 h-5 text-primary mt-0.5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <path d="M20 6 9 17l-5-5" />
                   </svg>
                   <span class="text-sm text-muted-foreground">{point}</span>
@@ -106,7 +106,7 @@ const iconSvgs: Record<string, string> = {
         <div>
           <div class="border border-border p-6 sticky top-24">
             <h3 class="text-lg font-semibold text-foreground mb-1">料金プラン</h3>
-            <p class="text-xs text-teal-600 font-medium mb-5">モニター価格適用中</p>
+            <p class="text-xs text-primary font-medium mb-5">モニター価格適用中</p>
             <div class="space-y-4">
               {service.pricing.map((plan) => (
                 <div class="border-b border-gray-100 pb-4 last:border-0 last:pb-0">
@@ -114,7 +114,7 @@ const iconSvgs: Record<string, string> = {
                   <div class="flex items-baseline gap-2">
                     {plan.monitorPrice ? (
                       <>
-                        <span class="text-lg font-bold text-teal-600">{plan.monitorPrice}</span>
+                        <span class="text-lg font-bold text-primary">{plan.monitorPrice}</span>
                         <span class="text-xs text-muted-foreground line-through">{plan.price}</span>
                       </>
                     ) : (
@@ -127,13 +127,13 @@ const iconSvgs: Record<string, string> = {
             <div class="mt-6 space-y-3">
               <a
                 href={service.href}
-                class="block w-full text-center px-4 py-2.5 bg-teal-500 text-white text-sm font-medium rounded-[4px] hover:bg-teal-600 transition-colors"
+                class="block w-full text-center px-4 py-2.5 bg-primary text-white text-sm font-medium rounded-[4px] hover:bg-primary transition-colors"
               >
                 詳しいサービスページを見る
               </a>
               <a
                 href="/contact"
-                class="block w-full text-center px-4 py-2.5 bg-white text-teal-700 text-sm font-medium rounded-[4px] ring-1 border-primary/30 hover:bg-teal-50 transition-colors"
+                class="block w-full text-center px-4 py-2.5 bg-white text-primary text-sm font-medium rounded-[4px] border-primary/30 hover:bg-secondary transition-colors"
               >
                 お問い合わせ
               </a>

--- a/src/components/sections/ServiceLandingPage.astro
+++ b/src/components/sections/ServiceLandingPage.astro
@@ -23,13 +23,13 @@ const hasFaq = (service.faq?.length ?? 0) > 0;
 
 <section class="pt-28 pb-16">
   <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-    <a href="/services" class="text-sm font-medium text-teal-700 hover:text-teal-800">
+    <a href="/services" class="text-sm font-medium text-primary hover:text-primary">
       Services に戻る
     </a>
 
     <div class="mt-8 grid items-start gap-10 lg:grid-cols-[1fr_20rem]">
       <div>
-        <p class="text-sm font-semibold tracking-wide text-teal-600">SERVICE</p>
+        <p class="text-sm font-semibold tracking-wide text-primary">SERVICE</p>
         <h1 class="mt-4 text-3xl font-bold tracking-tight text-foreground sm:text-5xl">
           {service.title}
         </h1>
@@ -42,7 +42,7 @@ const hasFaq = (service.faq?.length ?? 0) > 0;
         {hasAchievements && (
           <ul class="mt-6 flex flex-wrap gap-2">
             {service.achievements!.map((achievement) => (
-              <li class="inline-flex items-center gap-1.5 rounded-full bg-teal-50 px-3 py-1.5 text-xs font-medium text-teal-700 ring-1 ring-teal-500/15">
+              <li class="inline-flex items-center gap-1.5 rounded-full bg-secondary px-3 py-1.5 text-xs font-medium text-primary border-primary/15">
                 <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                   <path d="M20 6 9 17l-5-5" />
                 </svg>
@@ -54,7 +54,7 @@ const hasFaq = (service.faq?.length ?? 0) > 0;
         <div class="mt-8 flex flex-col gap-3 sm:flex-row">
           <a
             href="/contact"
-            class="inline-flex items-center justify-center rounded-[4px] bg-teal-500 px-6 py-3 font-medium text-white transition-colors hover:bg-teal-600"
+            class="inline-flex items-center justify-center rounded-[4px] bg-primary px-6 py-3 font-medium text-white transition-colors hover:bg-primary"
           >
             {service.title}について問い合わせる
           </a>
@@ -69,7 +69,7 @@ const hasFaq = (service.faq?.length ?? 0) > 0;
 
       <aside class="bg-white/80 p-6 border border-border">
         <h2 class="text-base font-semibold text-foreground">料金の目安</h2>
-        <p class="mt-1 text-xs font-medium text-teal-600">モニター価格適用中</p>
+        <p class="mt-1 text-xs font-medium text-primary">モニター価格適用中</p>
         <div class="mt-5 space-y-4">
           {service.pricing.map((plan) => (
             <div class="border-b border-gray-100 pb-4 last:border-b-0 last:pb-0">
@@ -77,7 +77,7 @@ const hasFaq = (service.faq?.length ?? 0) > 0;
               <div class="mt-2 flex items-baseline gap-2">
                 {plan.monitorPrice ? (
                   <>
-                    <span class="text-xl font-bold text-teal-600">{plan.monitorPrice}</span>
+                    <span class="text-xl font-bold text-primary">{plan.monitorPrice}</span>
                     <span class="text-xs text-muted-foreground line-through">{plan.price}</span>
                   </>
                 ) : (
@@ -98,7 +98,7 @@ const hasFaq = (service.faq?.length ?? 0) > 0;
     <div class="mt-8 grid gap-4 md:grid-cols-2">
       {service.painPoints.map((point) => (
         <div class="flex items-start gap-3 bg-white p-5 border border-border">
-          <svg class="mt-0.5 h-5 w-5 shrink-0 text-teal-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <svg class="mt-0.5 h-5 w-5 shrink-0 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <path d="M20 6 9 17l-5-5" />
           </svg>
           <p class="text-sm leading-relaxed text-muted-foreground">{point}</p>
@@ -196,7 +196,7 @@ const hasFaq = (service.faq?.length ?? 0) > 0;
       </p>
       <a
         href="/contact"
-        class="mt-8 inline-flex items-center justify-center rounded-[4px] bg-teal-500 px-6 py-3 font-medium text-white transition-colors hover:bg-teal-600"
+        class="mt-8 inline-flex items-center justify-center rounded-[4px] bg-primary px-6 py-3 font-medium text-white transition-colors hover:bg-primary"
       >
         お問い合わせへ進む
       </a>

--- a/src/components/sections/Services.astro
+++ b/src/components/sections/Services.astro
@@ -1,67 +1,60 @@
 ---
 import { services } from "@/data";
 import Button from "@/components/ui/Button.astro";
+import SplitSection from "@/components/ui/SplitSection.astro";
 
 const iconSvgs: Record<string, string> = {
   wrench:
-    '<svg class="w-6 h-6 text-teal-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>',
-  code: '<svg class="w-6 h-6 text-teal-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>',
-  bot: '<svg class="w-6 h-6 text-teal-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/><path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/></svg>',
+    '<svg class="w-6 h-6 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>',
+  code: '<svg class="w-6 h-6 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>',
+  bot: '<svg class="w-6 h-6 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/><path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/></svg>',
   "graduation-cap":
-    '<svg class="w-6 h-6 text-teal-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.42 10.922a1 1 0 0 0-.019-1.838L12.83 5.18a2 2 0 0 0-1.66 0L2.6 9.08a1 1 0 0 0 0 1.832l8.57 3.908a2 2 0 0 0 1.66 0z"/><path d="M22 10v6"/><path d="M6 12.5V16a6 3 0 0 0 12 0v-3.5"/></svg>',
+    '<svg class="w-6 h-6 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.42 10.922a1 1 0 0 0-.019-1.838L12.83 5.18a2 2 0 0 0-1.66 0L2.6 9.08a1 1 0 0 0 0 1.832l8.57 3.908a2 2 0 0 0 1.66 0z"/><path d="M22 10v6"/><path d="M6 12.5V16a6 3 0 0 0 12 0v-3.5"/></svg>',
   server:
-    '<svg class="w-6 h-6 text-teal-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="8" x="2" y="2" rx="2"/><rect width="20" height="8" x="2" y="14" rx="2"/><path d="M6 6h.01"/><path d="M6 18h.01"/><path d="M10 6h8"/><path d="M10 18h8"/></svg>',
+    '<svg class="w-6 h-6 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="8" x="2" y="2" rx="2"/><rect width="20" height="8" x="2" y="14" rx="2"/><path d="M6 6h.01"/><path d="M6 18h.01"/><path d="M10 6h8"/><path d="M10 18h8"/></svg>',
 };
 ---
 
-<section id="services" class="py-20">
-  <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-    <div class="grid grid-cols-1 lg:grid-cols-[1fr_1.4fr] gap-10 lg:gap-16">
-      <!-- 左: 訴求コピー -->
-      <div class="lg:sticky lg:top-24 self-start">
-        <p class="text-sm font-medium text-teal-600 mb-3">Services</p>
-        <h2 class="text-3xl font-bold text-foreground mb-4">提供サービス</h2>
-        <p class="text-muted-foreground leading-relaxed mb-8">
-          個人へのマンツーマンAIサポートと、企業向けのアプリ開発・講師登壇。フリーランスとして、現場で手を動かしながら伴走します。
-        </p>
-        <div class="flex flex-wrap gap-3">
-          <Button href="/contact" size="md">無料で相談する</Button>
-          <Button href="/services" variant="outline" size="md">
-            サービス一覧
-          </Button>
-        </div>
-      </div>
-
-      <!-- 右: サービスリスト -->
-      <div class="flex flex-col divide-y divide-gray-100">
-        {services.map((service, index) => (
-          <a
-            href={service.href}
-            class={`group flex items-start gap-4 py-5 first:pt-0 last:pb-0`}
-          >
-            <div class="w-12 h-12 shrink-0 rounded-[4px] bg-teal-50 flex items-center justify-center group-hover:bg-teal-100 transition-colors">
-              <Fragment set:html={iconSvgs[service.icon] || ""} />
-            </div>
-            <div class="min-w-0">
-              <h3 class="text-base font-semibold text-foreground mb-1 group-hover:text-teal-700 transition-colors">
-                {service.title}
-              </h3>
-              <p class="text-sm text-muted-foreground leading-relaxed">
-                {service.description}
-              </p>
-            </div>
-            <svg
-              class="w-5 h-5 shrink-0 mt-1 text-gray-300 group-hover:text-teal-600 group-hover:translate-x-0.5 transition-all"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-            >
-              <path d="M5 12h14M12 5l7 7-7 7" />
-            </svg>
-          </a>
-        ))}
-      </div>
-    </div>
+<SplitSection
+  id="services"
+  eyebrow="Services"
+  title="提供サービス"
+  lead="個人へのマンツーマンAIサポートと、企業向けのアプリ開発・講師登壇。フリーランスとして、現場で手を動かしながら伴走します。"
+>
+  <div slot="actions" class="flex flex-wrap gap-3">
+    <Button href="/contact" size="md">無料で相談する</Button>
+    <Button href="/services" variant="outline" size="md">サービス一覧</Button>
   </div>
-</section>
+
+  <div class="flex flex-col divide-y divide-border">
+    {
+      services.map((service) => (
+        <a
+          href={service.href}
+          class="group flex items-start gap-4 py-5 first:pt-0 last:pb-0"
+        >
+          <div class="w-12 h-12 shrink-0 rounded-[4px] bg-secondary flex items-center justify-center">
+            <Fragment set:html={iconSvgs[service.icon] || ""} />
+          </div>
+          <div class="min-w-0">
+            <h3 class="text-base font-semibold text-foreground mb-1 group-hover:text-primary transition-colors">
+              {service.title}
+            </h3>
+            <p class="text-sm text-muted-foreground leading-relaxed">
+              {service.description}
+            </p>
+          </div>
+          <svg
+            class="w-5 h-5 shrink-0 mt-1 text-muted-foreground/50 group-hover:text-primary group-hover:translate-x-0.5 transition-all"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <path d="M5 12h14M12 5l7 7-7 7" />
+          </svg>
+        </a>
+      ))
+    }
+  </div>
+</SplitSection>

--- a/src/components/sections/Skills.astro
+++ b/src/components/sections/Skills.astro
@@ -16,7 +16,7 @@ const categoryConfig: {
     title: "Languages & Frameworks",
     iconSvg:
       '<svg class="w-5 h-5 text-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 16 4-4-4-4"/><path d="m6 8-4 4 4 4"/><path d="m14.5 4-5 16"/></svg>',
-    starColor: "text-teal-400",
+    starColor: "text-primary",
   },
   {
     key: "backendAndInfra",
@@ -58,7 +58,7 @@ function renderStars(level: SkillLevel, colorClass: string): string {
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
       {categoryConfig.map((cat, index) => (
         <div
-          class={`border border-border p-6 hover:border-teal-500/20 transition-colors`}
+          class={`border border-border p-6 hover:border-primary/20 transition-colors`}
         >
           <div class="flex items-center gap-3 mb-5">
             <div

--- a/src/components/sections/Stats.astro
+++ b/src/components/sections/Stats.astro
@@ -1,25 +1,28 @@
 ---
 import { stats } from "@/data";
+import Section from "@/components/ui/Section.astro";
 ---
 
-<section id="stats" class="py-20">
-  <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-    <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
-      {stats.map((stat, index) => (
-        <div
-          class={`border border-border p-6 text-center transition-colors group`}
-        >
-          <p class="text-3xl sm:text-4xl font-bold text-primary mb-1">
-            {stat.value}
-          </p>
-          <p class="text-sm font-medium text-foreground mb-1">{stat.label}</p>
-          {stat.description && (
-            <p class="text-xs text-muted-foreground hidden sm:block">
-              {stat.description}
-            </p>
-          )}
+{/* 見出しを持たない実績バンド。前後のセクションとリズムを変える役割 */}
+<Section id="stats" spacing="compact">
+  <dl
+    class="grid grid-cols-2 gap-x-8 gap-y-8 border-y border-border py-8 md:grid-cols-3 lg:grid-cols-5"
+  >
+    {
+      stats.map((stat) => (
+        <div>
+          <dt class="sr-only">{stat.label}</dt>
+          <dd>
+            <p class="text-3xl font-bold text-foreground">{stat.value}</p>
+            <p class="mt-1 text-sm font-medium text-foreground">{stat.label}</p>
+            {stat.description && (
+              <p class="mt-0.5 text-xs text-muted-foreground">
+                {stat.description}
+              </p>
+            )}
+          </dd>
         </div>
-      ))}
-    </div>
-  </div>
-</section>
+      ))
+    }
+  </dl>
+</Section>

--- a/src/components/sections/Teaching.astro
+++ b/src/components/sections/Teaching.astro
@@ -26,13 +26,13 @@ import Badge from "@/components/ui/Badge.astro";
               class={`relative flex flex-col sm:flex-row ${ isEven ? "sm:flex-row" : "sm:flex-row-reverse" } gap-4 sm:gap-8`}
             >
               <!-- Timeline dot -->
-              <div class="absolute left-4 md:left-1/2 top-6 w-3 h-3 rounded-full bg-teal-500 -translate-x-1.5 hidden sm:block ring-4 ring-background z-10"></div>
+              <div class="absolute left-4 md:left-1/2 top-6 w-3 h-3 rounded-full bg-primary -translate-x-1.5 hidden sm:block ring-4 ring-background z-10"></div>
 
               <!-- Spacer -->
               <div class="hidden sm:block sm:w-1/2"></div>
 
               <!-- Card -->
-              <div class={`sm:w-1/2 border border-border p-5 transition-all duration-300 hover:border-teal-500/20`}>
+              <div class={`sm:w-1/2 border border-border p-5 transition-all duration-300 hover:border-primary/20`}>
                 {isClickable ? (
                   <a href={exp.url} target="_blank" rel="noopener noreferrer" class="block">
                     <div class="flex items-start justify-between mb-2">
@@ -43,7 +43,7 @@ import Badge from "@/components/ui/Badge.astro";
                             <path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
                           </svg>
                         </h3>
-                        <p class="text-sm text-teal-600">{exp.organization}</p>
+                        <p class="text-sm text-primary">{exp.organization}</p>
                       </div>
                       <Badge variant="teal">{exp.type}</Badge>
                     </div>
@@ -64,7 +64,7 @@ import Badge from "@/components/ui/Badge.astro";
                     <div class="flex items-start justify-between mb-2">
                       <div class="flex-1">
                         <h3 class="font-semibold text-foreground mb-1">{exp.title}</h3>
-                        <p class="text-sm text-teal-600">{exp.organization}</p>
+                        <p class="text-sm text-primary">{exp.organization}</p>
                       </div>
                       <Badge variant="teal">{exp.type}</Badge>
                     </div>

--- a/src/components/sections/TechStack.astro
+++ b/src/components/sections/TechStack.astro
@@ -1,20 +1,21 @@
 ---
 import { techStack } from "@/data";
+import Section from "@/components/ui/Section.astro";
 import SectionHeader from "@/components/ui/SectionHeader.astro";
 ---
 
-<section id="tech-stack" class="py-20 bg-secondary/30">
-  <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+<Section id="tech-stack">
     <SectionHeader
-      title="取り扱い技術"
+    eyebrow="Tech Stack"
+    title="取り扱い技術"
       subtitle="AI / クラウド / Web を中心に、対応可能な主要技術スタックです。"
     />
 
-    <div class="space-y-8">
+    <div class="divide-y divide-border border-y border-border">
       {
         techStack.map((category, i) => (
           <div
-            class={`border border-border p-6 md:p-7`}
+            class="py-6"
           >
             <h3 class="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-4">
               {category.label}
@@ -22,7 +23,7 @@ import SectionHeader from "@/components/ui/SectionHeader.astro";
             <div class="flex flex-wrap gap-2">
               {category.items.map((tech) => {
                 const chipClass =
-                  "inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-border bg-background hover:border-teal-500/40 hover:text-teal-700 transition-colors text-sm text-foreground";
+                  "inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-border bg-background hover:border-primary/40 hover:text-primary transition-colors text-sm text-foreground";
                 const chipInner = (
                   <>
                     <img
@@ -42,7 +43,7 @@ import SectionHeader from "@/components/ui/SectionHeader.astro";
                   return (
                     <a href={`/tech/${tech.detailSlug}`} class={chipClass}>
                       {chipInner}
-                      <span class="text-xs text-teal-600">詳しく見る →</span>
+                      <span class="text-xs text-primary">詳しく見る →</span>
                     </a>
                   );
                 }
@@ -65,13 +66,12 @@ import SectionHeader from "@/components/ui/SectionHeader.astro";
       }
     </div>
 
-    <div class="mt-10 text-center">
+    <div class="mt-8">
       <a
         href="/skills"
-        class="inline-flex items-center gap-1 text-sm font-medium text-teal-600 hover:text-teal-700 transition-colors"
+        class="inline-flex items-center gap-1 text-sm font-medium text-primary hover:text-primary transition-colors"
       >
         スキル一覧（レベル評価付き）を見る →
       </a>
     </div>
-  </div>
-</section>
+</Section>

--- a/src/components/sections/Testimonials.astro
+++ b/src/components/sections/Testimonials.astro
@@ -1,8 +1,7 @@
 ---
 import { testimonials, siteConfig } from "@/data";
 import type { TestimonialAudience } from "@/types";
-import SectionHeader from "@/components/ui/SectionHeader.astro";
-import TestimonialCard from "@/components/ui/TestimonialCard.astro";
+import SplitSection from "@/components/ui/SplitSection.astro";
 import Button from "@/components/ui/Button.astro";
 
 // 顧客属性ごとに並べると「自分ごと」として刺さる。表示順を属性で固定する
@@ -12,43 +11,63 @@ const audienceOrder: { key: TestimonialAudience; label: string }[] = [
   { key: "developer", label: "開発者の方" },
 ];
 
-const ordered = audienceOrder
-  .map(({ key, label }) => ({
-    label,
-    items: testimonials.filter((t) => t.audience === key),
-  }))
-  .filter((group) => group.items.length > 0);
+const ordered = audienceOrder.flatMap(({ key, label }) =>
+  testimonials
+    .filter((testimonial) => testimonial.audience === key)
+    .map((testimonial) => ({ ...testimonial, audienceLabel: label })),
+);
 ---
 
-<section id="testimonials" class="py-20">
-  <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-    <SectionHeader
-      title="受講者・ご利用者の声"
-      subtitle="AI活用の伴走・研修を通じて、実際に業務が変わった方々からの評価です。"
-    />
-
-    <div class="grid grid-cols-1 gap-6 md:grid-cols-3">
-      {ordered.map((group, index) => (
-        <div class={`flex flex-col gap-3`}>
-          <p class="text-sm font-semibold text-teal-600">{group.label}</p>
-          {group.items.map((testimonial) => (
-            <TestimonialCard testimonial={testimonial} class="grow" />
-          ))}
-        </div>
-      ))}
-    </div>
-
-    <div class="mt-10 text-center">
-      <Button href={siteConfig.mentaUrl} variant="outline" external>
-        MENTAで評価一覧を見る
-        <svg class="ml-1.5 h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <path d="M7 7h10v10" />
-          <path d="M7 17 17 7" />
-        </svg>
-      </Button>
-      <p class="mt-3 text-xs text-muted-foreground">
-        第三者プラットフォーム上の評価をそのままご確認いただけます。
-      </p>
-    </div>
+<SplitSection
+  id="testimonials"
+  eyebrow="Voices"
+  title="受講者・ご利用者の声"
+  lead="AI活用の伴走・指導を通じて、実際に業務が変わった方々からの評価です。"
+>
+  <div slot="actions">
+    <Button href={siteConfig.mentaUrl} variant="outline" size="md" external>
+      MENTAで評価一覧を見る
+      <svg
+        class="ml-1.5 h-4 w-4"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M7 7h10v10" />
+        <path d="M7 17 17 7" />
+      </svg>
+    </Button>
+    <p class="mt-3 text-xs text-muted-foreground">
+      第三者プラットフォーム上の評価をそのままご確認いただけます。
+    </p>
   </div>
-</section>
+
+  {/* カードを並べず、引用を連続させて読ませる */}
+  <div class="flex flex-col divide-y divide-border border-y border-border">
+    {
+      ordered.map((testimonial) => (
+        <figure class="py-6">
+          <div class="flex items-center gap-3">
+            <p class="text-sm font-medium text-primary">
+              {testimonial.audienceLabel}
+            </p>
+            <p class="text-xs text-muted-foreground" aria-label={`評価 ${testimonial.rating} / 5`}>
+              {"★".repeat(testimonial.rating)}
+            </p>
+          </div>
+          <blockquote class="mt-3 text-foreground leading-relaxed">
+            {testimonial.quote}
+          </blockquote>
+          <figcaption class="mt-3 flex flex-wrap gap-x-3 text-xs text-muted-foreground">
+            <span>{testimonial.authorAttribute}</span>
+            {testimonial.source && <span>{testimonial.source}</span>}
+          </figcaption>
+        </figure>
+      ))
+    }
+  </div>
+</SplitSection>

--- a/src/components/ui/Badge.astro
+++ b/src/components/ui/Badge.astro
@@ -9,7 +9,7 @@ interface Props {
 const { variant = "teal", class: className } = Astro.props;
 
 const variants = {
-  teal: "bg-teal-500/10 text-teal-600 border-teal-500/20",
+  teal: "bg-primary/10 text-primary border-primary/20",
   emerald: "bg-emerald-500/10 text-emerald-600 border-emerald-500/20",
   blue: "bg-blue-500/10 text-blue-600 border-blue-500/20",
   red: "bg-red-500/10 text-red-400 border-red-500/20",

--- a/src/components/ui/SplitSection.astro
+++ b/src/components/ui/SplitSection.astro
@@ -1,0 +1,30 @@
+---
+import Section from "@/components/ui/Section.astro";
+import SectionHeader from "@/components/ui/SectionHeader.astro";
+
+interface Props {
+  id?: string;
+  eyebrow?: string;
+  title: string;
+  lead?: string;
+}
+
+const { id, eyebrow, title, lead } = Astro.props;
+---
+
+{/*
+  左に訴求コピー（スクロール追従）、右に本体を置く2カラム。
+  カードグリッドの反復を避け、階層を配置と余白で作るための土台。
+*/}
+<Section id={id}>
+  <div class="grid grid-cols-1 lg:grid-cols-[1fr_1.4fr] gap-10 lg:gap-16">
+    <div class="lg:sticky lg:top-24 self-start">
+      <SectionHeader eyebrow={eyebrow} title={title} subtitle={lead} class="mb-6" />
+      <slot name="actions" />
+    </div>
+
+    <div class="min-w-0">
+      <slot />
+    </div>
+  </div>
+</Section>

--- a/src/layouts/KnowledgeLayout.astro
+++ b/src/layouts/KnowledgeLayout.astro
@@ -184,12 +184,12 @@ const jsonLd = JSON.stringify({
               previous ? (
                 <a
                   href={`${articleBasePath}/${previous.slug}`}
-                  class="group block p-4 border border-border hover:border-teal-500/60 hover:bg-teal-50/30 transition-colors"
+                  class="group block p-4 border border-border hover:border-primary/60 hover:bg-secondary/30 transition-colors"
                 >
                   <span class="block text-xs text-muted-foreground mb-1">
                     ← 前の記事
                   </span>
-                  <span class="block font-semibold text-foreground group-hover:text-teal-600 transition-colors line-clamp-2">
+                  <span class="block font-semibold text-foreground group-hover:text-primary transition-colors line-clamp-2">
                     {previous.title}
                   </span>
                 </a>
@@ -201,12 +201,12 @@ const jsonLd = JSON.stringify({
               next ? (
                 <a
                   href={`${articleBasePath}/${next.slug}`}
-                  class="group block p-4 border border-border hover:border-teal-500/60 hover:bg-teal-50/30 transition-colors text-right sm:text-right"
+                  class="group block p-4 border border-border hover:border-primary/60 hover:bg-secondary/30 transition-colors text-right sm:text-right"
                 >
                   <span class="block text-xs text-muted-foreground mb-1">
                     次の記事 →
                   </span>
-                  <span class="block font-semibold text-foreground group-hover:text-teal-600 transition-colors line-clamp-2">
+                  <span class="block font-semibold text-foreground group-hover:text-primary transition-colors line-clamp-2">
                     {next.title}
                   </span>
                 </a>
@@ -219,7 +219,7 @@ const jsonLd = JSON.stringify({
           <footer class="mt-8">
             <a
               href={articleBasePath}
-              class="text-teal-600 hover:text-teal-700 transition-colors inline-flex items-center gap-1"
+              class="text-primary hover:text-primary transition-colors inline-flex items-center gap-1"
             >
               ← {backLinkLabel} の記事一覧に戻る
             </a>

--- a/src/pages/ai-news/[tool]/[slug].astro
+++ b/src/pages/ai-news/[tool]/[slug].astro
@@ -39,7 +39,7 @@ const formattedDate = entry.data.date.toLocaleDateString("ja-JP", {
       <div class="mb-8">
         <a
           href={`/ai-news/${entry.data.tool}`}
-          class="text-sm text-teal-600 hover:text-teal-700 transition-colors"
+          class="text-sm text-primary hover:text-primary transition-colors"
         >
           ← {entry.data.toolLabel} のニュースへ戻る
         </a>
@@ -66,7 +66,7 @@ const formattedDate = entry.data.date.toLocaleDateString("ja-JP", {
           href={entry.data.sourceUrl}
           target="_blank"
           rel="noopener noreferrer"
-          class="mt-6 inline-flex items-center gap-2 px-4 py-2 rounded-md border border-teal-600 text-teal-700 hover:bg-teal-50 transition-colors text-sm font-medium"
+          class="mt-6 inline-flex items-center gap-2 px-4 py-2 rounded-md border border-primary text-primary hover:bg-secondary transition-colors text-sm font-medium"
         >
           ニュース原文を読む ↗
         </a>
@@ -92,7 +92,7 @@ const formattedDate = entry.data.date.toLocaleDateString("ja-JP", {
                   <li>
                     <a
                       href={href}
-                      class="text-teal-600 hover:text-teal-700 transition-colors"
+                      class="text-primary hover:text-primary transition-colors"
                     >
                       {href}
                     </a>

--- a/src/pages/ai-news/[tool]/index.astro
+++ b/src/pages/ai-news/[tool]/index.astro
@@ -42,7 +42,7 @@ const months = getAiNewsArchive(entries);
       <div class="mb-8">
         <a
           href="/ai-news"
-          class="text-sm text-teal-600 hover:text-teal-700 transition-colors"
+          class="text-sm text-primary hover:text-primary transition-colors"
         >
           ← AI News に戻る
         </a>

--- a/src/pages/ai-news/archive/[month].astro
+++ b/src/pages/ai-news/archive/[month].astro
@@ -41,7 +41,7 @@ const months = getAiNewsArchive(entries);
       <div class="mb-8">
         <a
           href="/ai-news"
-          class="text-sm text-teal-600 hover:text-teal-700 transition-colors"
+          class="text-sm text-primary hover:text-primary transition-colors"
         >
           ← AI News に戻る
         </a>

--- a/src/pages/ai-news/index.astro
+++ b/src/pages/ai-news/index.astro
@@ -65,7 +65,7 @@ const months = getAiNewsArchive(entries);
                 過去のニュースは
                 <a
                   href={`/ai-news/archive/${months[0].key}`}
-                  class="text-teal-600 hover:text-teal-700 transition-colors"
+                  class="text-primary hover:text-primary transition-colors"
                 >
                   月別アーカイブ
                 </a>

--- a/src/pages/cases/[slug].astro
+++ b/src/pages/cases/[slug].astro
@@ -83,7 +83,7 @@ const { caseStudy } = Astro.props;
           {
             caseStudy.support.map((item) => (
               <li class="flex items-start gap-3 text-sm text-foreground leading-relaxed">
-                <span class="w-1.5 h-1.5 rounded-full bg-teal-500 shrink-0 mt-2" />
+                <span class="w-1.5 h-1.5 rounded-full bg-primary shrink-0 mt-2" />
                 {item}
               </li>
             ))
@@ -98,7 +98,7 @@ const { caseStudy } = Astro.props;
             caseStudy.outcomes.map((item) => (
               <li class="flex items-start gap-3 text-sm text-foreground leading-relaxed">
                 <svg
-                  class="w-5 h-5 text-teal-600 shrink-0 mt-0.5"
+                  class="w-5 h-5 text-primary shrink-0 mt-0.5"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -123,7 +123,7 @@ const { caseStudy } = Astro.props;
           <div class="mb-10">
             <a
               href={caseStudy.serviceHref}
-              class="inline-flex items-center gap-1 text-sm font-medium text-teal-600 hover:text-teal-700 transition-colors"
+              class="inline-flex items-center gap-1 text-sm font-medium text-primary hover:text-primary transition-colors"
             >
               この事例に関連するサービスを見る →
             </a>

--- a/src/pages/cases/index.astro
+++ b/src/pages/cases/index.astro
@@ -49,7 +49,7 @@ import { caseStudies } from "@/data";
                   ))}
                 </div>
               )}
-              <span class="inline-flex items-center gap-1 text-sm font-medium text-teal-600 group-hover:text-teal-700 transition-colors">
+              <span class="inline-flex items-center gap-1 text-sm font-medium text-primary group-hover:text-primary transition-colors">
                 詳しく見る →
               </span>
             </a>

--- a/src/pages/knowledge/[category]/index.astro
+++ b/src/pages/knowledge/[category]/index.astro
@@ -74,7 +74,7 @@ const dateFormatter = new Intl.DateTimeFormat("ja-JP", {
               {subcategoryMetrics.map(({ meta, metrics }) => (
                 <a
                   href={`/knowledge/${category.slug}/${meta.slug}`}
-                  class="flex flex-col p-5 border border-border hover:border-teal-500/60 hover:bg-teal-50/30 transition-colors"
+                  class="flex flex-col p-5 border border-border hover:border-primary/60 hover:bg-secondary/30 transition-colors"
                 >
                   <h3 class="font-semibold text-foreground mb-1">
                     {meta.label}
@@ -83,7 +83,7 @@ const dateFormatter = new Intl.DateTimeFormat("ja-JP", {
                     {meta.description}
                   </p>
                   <div class="mt-auto flex items-center gap-2 flex-wrap text-[11px] text-muted-foreground">
-                    <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-teal-500/10 text-teal-700 font-medium tabular-nums">
+                    <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-primary/10 text-primary font-medium tabular-nums">
                       {metrics.articleCount}
                       <span class="font-normal">記事</span>
                     </span>
@@ -123,7 +123,7 @@ const dateFormatter = new Intl.DateTimeFormat("ja-JP", {
             </p>
             <a
               href="/knowledge"
-              class="inline-block mt-4 text-teal-600 hover:text-teal-700 transition-colors"
+              class="inline-block mt-4 text-primary hover:text-primary transition-colors"
             >
               ← Knowledge Base に戻る
             </a>

--- a/src/pages/knowledge/index.astro
+++ b/src/pages/knowledge/index.astro
@@ -54,12 +54,12 @@ function getCategoryLabel(slug: string): string {
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2 mb-1">
                 <h3
-                  class="text-lg font-semibold text-foreground group-hover:text-teal-700 transition-colors"
+                  class="text-lg font-semibold text-foreground group-hover:text-primary transition-colors"
                 >
                   ロードマップから始める
                 </h3>
                 <span
-                  class="text-xs text-teal-700 bg-white/70 px-2 py-0.5 rounded-full"
+                  class="text-xs text-primary bg-white/70 px-2 py-0.5 rounded-full"
                   >推奨</span
                 >
               </div>
@@ -70,7 +70,7 @@ function getCategoryLabel(slug: string): string {
             </div>
             <span
               aria-hidden="true"
-              class="shrink-0 text-teal-600 group-hover:translate-x-1 transition-transform mt-1"
+              class="shrink-0 text-primary group-hover:translate-x-1 transition-transform mt-1"
               >→</span
             >
           </div>
@@ -93,7 +93,7 @@ function getCategoryLabel(slug: string): string {
       <div class="mb-16 flex justify-end">
         <a
           href="/knowledge/tags"
-          class="inline-flex items-center gap-1 text-sm text-teal-600 hover:text-teal-700 transition-colors"
+          class="inline-flex items-center gap-1 text-sm text-primary hover:text-primary transition-colors"
         >
           タグから記事を探す →
         </a>

--- a/src/pages/knowledge/roadmap.astro
+++ b/src/pages/knowledge/roadmap.astro
@@ -30,7 +30,7 @@ const resolvedPaths = resolveAllRoadmaps(roadmapPaths, allEntries);
           resolvedPaths.map((path) => (
             <a
               href={`#${path.id}`}
-              class="inline-flex items-center px-4 py-2 rounded-full border border-border bg-secondary/40 text-sm text-foreground hover:border-teal-500 hover:text-teal-700 transition-colors"
+              class="inline-flex items-center px-4 py-2 rounded-full border border-border bg-secondary/40 text-sm text-foreground hover:border-primary hover:text-primary transition-colors"
             >
               {path.title}
             </a>
@@ -64,13 +64,13 @@ const resolvedPaths = resolveAllRoadmaps(roadmapPaths, allEntries);
                       >
                         <span
                           aria-hidden="true"
-                          class="shrink-0 w-9 h-9 rounded-full bg-teal-50 text-teal-700 border border-teal-200 flex items-center justify-center text-sm font-semibold"
+                          class="shrink-0 w-9 h-9 rounded-full bg-secondary text-primary border border-primary flex items-center justify-center text-sm font-semibold"
                         >
                           {idx + 1}
                         </span>
                         <div class="flex-1 min-w-0">
                           <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1 mb-1">
-                            <h3 class="text-base font-semibold text-foreground group-hover:text-teal-700 transition-colors">
+                            <h3 class="text-base font-semibold text-foreground group-hover:text-primary transition-colors">
                               {step.title}
                             </h3>
                             <span class="text-xs text-muted-foreground">
@@ -83,7 +83,7 @@ const resolvedPaths = resolveAllRoadmaps(roadmapPaths, allEntries);
                         </div>
                         <span
                           aria-hidden="true"
-                          class="shrink-0 text-muted-foreground group-hover:text-teal-700 transition-colors mt-1"
+                          class="shrink-0 text-muted-foreground group-hover:text-primary transition-colors mt-1"
                         >
                           →
                         </span>
@@ -100,7 +100,7 @@ const resolvedPaths = resolveAllRoadmaps(roadmapPaths, allEntries);
       <div class="mt-16 text-center">
         <a
           href="/knowledge"
-          class="inline-flex items-center gap-1 text-sm text-teal-600 hover:text-teal-700 transition-colors"
+          class="inline-flex items-center gap-1 text-sm text-primary hover:text-primary transition-colors"
         >
           ← Knowledge Base トップへ戻る
         </a>

--- a/src/pages/knowledge/tags/index.astro
+++ b/src/pages/knowledge/tags/index.astro
@@ -33,7 +33,7 @@ const tags = getAllTags(allEntries);
             {tags.map(({ tag, slug, count }) => (
               <a
                 href={`/knowledge/tags/${slug}`}
-                class="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-border bg-white hover:border-teal-500/60 hover:bg-teal-50/40 hover:text-teal-700 transition-colors text-sm"
+                class="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-border bg-white hover:border-primary/60 hover:bg-secondary/40 hover:text-primary transition-colors text-sm"
               >
                 <span class="font-medium text-foreground">#{tag}</span>
                 <span class="text-xs text-muted-foreground">{count}</span>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -31,6 +31,6 @@ import LegalLayout from "@/layouts/LegalLayout.astro";
   <h2 class="text-xl font-semibold text-foreground mt-8 mb-4">5. お問い合わせ</h2>
   <p>
     プライバシーポリシーに関するお問い合わせは、
-    <a href="/contact" class="text-teal-600 hover:underline">お問い合わせフォーム</a>よりご連絡ください。
+    <a href="/contact" class="text-primary hover:underline">お問い合わせフォーム</a>よりご連絡ください。
   </p>
 </LegalLayout>

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -18,7 +18,7 @@ import { services } from "@/data";
         {services.map((service) => (
           <a
             href={service.href}
-            class="px-4 py-2 text-sm font-medium text-muted-foreground bg-white/80 border border-border rounded-full hover:text-teal-600 hover:border-primary/40 transition-all"
+            class="px-4 py-2 text-sm font-medium text-muted-foreground bg-white/80 border border-border rounded-full hover:text-primary hover:border-primary/40 transition-all"
           >
             {service.title} の詳細
           </a>
@@ -40,7 +40,7 @@ import { services } from "@/data";
       </p>
       <a
         href="/contact"
-        class="inline-flex items-center gap-2 px-6 py-3 bg-teal-500 text-white font-medium rounded-[4px] hover:bg-teal-600 transition-colors"
+        class="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white font-medium rounded-[4px] hover:bg-primary transition-colors"
       >
         お問い合わせ
         <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">

--- a/src/pages/tech/[slug].astro
+++ b/src/pages/tech/[slug].astro
@@ -47,7 +47,7 @@ const { tool } = Astro.props;
         </h1>
       </div>
 
-      <p class="text-lg text-teal-700 font-medium mb-8">{tool.tagline}</p>
+      <p class="text-lg text-primary font-medium mb-8">{tool.tagline}</p>
 
       <div class="mb-10">
         <h2 class="text-xl font-bold text-foreground mb-3">概要</h2>
@@ -63,7 +63,7 @@ const { tool } = Astro.props;
             tool.strengths.map((strength) => (
               <li class="flex items-start gap-3 text-sm text-foreground leading-relaxed">
                 <svg
-                  class="w-5 h-5 text-teal-600 shrink-0 mt-0.5"
+                  class="w-5 h-5 text-primary shrink-0 mt-0.5"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -109,7 +109,7 @@ const { tool } = Astro.props;
               {tool.relatedServiceHref && (
                 <a
                   href={tool.relatedServiceHref}
-                  class="inline-flex items-center gap-1 text-sm font-medium text-teal-600 hover:text-teal-700 transition-colors"
+                  class="inline-flex items-center gap-1 text-sm font-medium text-primary hover:text-primary transition-colors"
                 >
                   関連サービスを見る →
                 </a>
@@ -117,7 +117,7 @@ const { tool } = Astro.props;
               {tool.relatedKnowledgeHref && (
                 <a
                   href={tool.relatedKnowledgeHref}
-                  class="inline-flex items-center gap-1 text-sm font-medium text-teal-600 hover:text-teal-700 transition-colors"
+                  class="inline-flex items-center gap-1 text-sm font-medium text-primary hover:text-primary transition-colors"
                 >
                   Knowledge Base の関連記事 →
                 </a>

--- a/src/pages/terms-of-service.astro
+++ b/src/pages/terms-of-service.astro
@@ -35,6 +35,6 @@ import LegalLayout from "@/layouts/LegalLayout.astro";
   <h2 class="text-xl font-semibold text-foreground mt-8 mb-4">5. お問い合わせ</h2>
   <p>
     本規約に関するお問い合わせは、
-    <a href="/contact" class="text-teal-600 hover:underline">お問い合わせフォーム</a>よりご連絡ください。
+    <a href="/contact" class="text-primary hover:underline">お問い合わせフォーム</a>よりご連絡ください。
   </p>
 </LegalLayout>

--- a/tests/components/ArticleSidebar.test.ts
+++ b/tests/components/ArticleSidebar.test.ts
@@ -164,7 +164,7 @@ describe("ArticleSidebar.astro - tier description", () => {
 });
 
 describe("ArticleSidebar.astro - Phase 1 挙動の回帰", () => {
-  it("正常系: 現在記事の <a> に aria-current=page と teal クラスが付くこと", async () => {
+  it("正常系: 現在記事の <a> に aria-current=page とアクセント色が付くこと", async () => {
     const html = await container.renderToString(ArticleSidebar, {
       props: {
         ...baseProps,
@@ -183,7 +183,7 @@ describe("ArticleSidebar.astro - Phase 1 挙動の回帰", () => {
     expect(html).toMatch(
       /<a[^>]+href="\/knowledge\/ai-tools\/claude-code\/intro"[^>]*aria-current="page"/,
     );
-    expect(html).toMatch(/border-teal-500[\s\S]*intro/);
+    expect(html).toMatch(/border-primary[\s\S]*intro/);
   });
 
   it("正常系: hasTiers=false（全グループ tier=null）でフラットリストにフォールバックすること", async () => {

--- a/tests/styles/designRules.test.ts
+++ b/tests/styles/designRules.test.ts
@@ -65,6 +65,22 @@ describe("影", () => {
     );
     expect(violations, violations.join("\n")).toEqual([]);
   });
+
+  it("色指定のない ring を残さないこと", () => {
+    // ring は box-shadow で描かれる。色を伴わない ring-N は
+    // 枠線置き換えの取りこぼしで、意図しない影として残る
+    const violations: string[] = [];
+
+    for (const file of files) {
+      for (const [index, line] of file.content.split("\n").entries()) {
+        if (/\bring-(1|2|4|8)\b/.test(line) && !/\bring-[a-z]/.test(line)) {
+          violations.push(`${file.path}:${index + 1}: ${line.trim()}`);
+        }
+      }
+    }
+
+    expect(violations, violations.join("\n")).toEqual([]);
+  });
 });
 
 describe("グラデーションと質感表現", () => {
@@ -81,6 +97,25 @@ describe("グラデーションと質感表現", () => {
   it("teal から emerald への2色グラデーションを使わないこと", () => {
     const violations = findViolations(/\b(from|via|to)-(teal|emerald)-\d{2,3}\b/);
     expect(violations, violations.join("\n")).toEqual([]);
+  });
+});
+
+describe("カラートークン", () => {
+  it("アクセント色（teal）を生の Tailwind 色で指定しないこと", () => {
+    // アクセントは global.css の @theme トークン（primary / accent）を参照する。
+    // emerald / red などの状態色は docs/DESIGN.md が例外として許可している
+    const violations = findViolations(/\bteal-\d{2,3}\b/);
+    expect(violations, violations.join("\n")).toEqual([]);
+  });
+});
+
+describe("見出し", () => {
+  it("SectionHeader が中央寄せを持たないこと", () => {
+    const header = files.find(
+      (file) => file.path === "src/components/ui/SectionHeader.astro",
+    );
+    expect(header).toBeDefined();
+    expect(header!.content).not.toMatch(/text-center|mx-auto/);
   });
 });
 


### PR DESCRIPTION
## 背景

トップページで「中央寄せ見出し＋3カラム均一カードグリッド」が**6セクション連続**しており（Stats / Testimonials / Cases / FeaturedKnowledge / Media / NoteArticles）、同じリズムの反復がテンプレート感の最大要因になっていた。

`docs/DESIGN.md` の「階層は余白 → 文字 → 配置 → 区切り線の順で表現する」に沿って作り直す。

## 変更内容

### 1. `SplitSection.astro` を新設

`Services.astro` が既に到達していた「左に訴求コピー（sticky）＋右に行リスト」の形を共通化した。

### 2. セクションのリズムを作り分ける

同じ形の反復を避けるため、意図的に4種類を配置している。

| セクション | Before | After |
|---|---|---|
| Services | 2カラム＋行リスト | `SplitSection` へ移行（形は維持） |
| Testimonials | `TestimonialCard` 3カラム | `SplitSection` ＋ 引用の連続 |
| Cases | 3カラムカード | 全幅の `divide-y` 行リスト |
| FeaturedKnowledge | 3カラムカード（Casesとほぼ同一） | 全幅の `divide-y` 行リスト |
| Stats | 枠付きカード5枚 | 見出しを持たない実績バンド |
| Media / NoteArticles | 3カラムカード | 補足情報としての小さな行リスト |
| Cta | 塗りのバナー | 罫線で区切っただけの締め |
| TechStack / Difference | `bg-secondary/30` の区画 | `Section` ＋ eyebrow へ統一 |

### 3. 色をトークンへ統一

`text-teal-600` などの生の Tailwind 色 **36ファイル分**を `@theme` トークン（`primary` / `accent` / `border` / `secondary`）へ置換。`emerald` / `red` の状態色は `docs/DESIGN.md` が例外として許可しているため残している。

### 4. 前PRの取りこぼし修正（回帰）

規約テストを増やす過程で、前PRの一括置換による不具合を2件発見して修正した。

- **色を失った `ring-1` が3箇所**残り、意図しない `box-shadow` として描画されていた
- **フォーカスリングの色指定が失われていた**（`focus:ring-2 focus:border-primary/40` になっており、リングが既定のグレーに）。`ContactForm` の入力欄と `ArticleSidebar` のセレクトで発生。アクセシビリティの後退だったため復旧

### 5. 規約テストの追加ルール

- アクセント色（`teal-*`）を生の Tailwind 色で指定しないこと
- `SectionHeader` が中央寄せを持たないこと
- 色指定のない `ring-N` を残さないこと（上記の取りこぼしを機械的に検出）

## 検証

- `npm run check` — 0 errors
- `npm test` — 195 tests / 21 files すべてパス
- `npm run build` — エラー0件。ビルド出力に `bg-gradient-to-*` / `rounded-2xl` / `rounded-3xl` / `gradient-text` が0件であることを確認
- **7ページ × 4幅（1440 / 1024 / 768 / 390px）= 28通りで横スクロールなし**

### 目視確認のお願い

作業中に Chrome ウィンドウが幅0の状態になり（`innerWidth=0`）、スクリーンショットが取得できませんでした。**トップページの見た目はご確認をお願いします。** 気になる点があれば後続PRで調整します。

## 残作業（PR 4）

- `Navbar` のスクロール時 `backdrop-blur` を不透明背景＋1px下線へ
- `ServiceLandingPage`（205行）のグリッド整理
- `KnowledgeLayout` の aside 背景
- アイコンSVGの一元化（最大3重複）

🤖 Generated with [Claude Code](https://claude.com/claude-code)